### PR TITLE
Add unpublished crate warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # manifold-csg
 
+> **Note:** This crate is not yet published to crates.io. The API may change before the first release.
+
 Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold)
 geometry kernel for constructive solid geometry (CSG).
 


### PR DESCRIPTION
Adds a note at the top of the README that the crate is not yet published to crates.io and the API may change.