### PR TITLE
Add carry-patch: fix meshgl_merge ownership bug

### DIFF
--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -47,6 +47,41 @@ fn main() {
         assert!(status.success(), "git clone manifold3d failed");
     }
 
+    // Apply carry-patches (fixes awaiting upstream merge).
+    let patches_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("patches");
+    if patches_dir.exists()
+        && let Ok(entries) = std::fs::read_dir(&patches_dir)
+    {
+        let mut patches: Vec<_> = entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "patch"))
+            .collect();
+        patches.sort();
+        for patch in &patches {
+            let status = Command::new("git")
+                .args(["apply", "--check"])
+                .arg(patch)
+                .current_dir(&manifold_src)
+                .status()
+                .expect("failed to check patch");
+            if status.success() {
+                let status = Command::new("git")
+                    .args(["apply"])
+                    .arg(patch)
+                    .current_dir(&manifold_src)
+                    .status()
+                    .expect("failed to apply patch");
+                assert!(
+                    status.success(),
+                    "failed to apply patch: {}",
+                    patch.display()
+                );
+            }
+            // If --check fails, patch was already applied (cached build).
+        }
+    }
+
     // Configure with cmake.
     let parallel = env::var("CARGO_FEATURE_PARALLEL").is_ok();
 

--- a/crates/manifold-csg-sys/patches/0001-fix-meshgl-merge-ownership.patch
+++ b/crates/manifold-csg-sys/patches/0001-fix-meshgl-merge-ownership.patch
@@ -1,0 +1,46 @@
+From 87d1961e260d6461fbc843b146815c6eb86d7816 Mon Sep 17 00:00:00 2001
+From: Zach Loafman <zml@zml.net>
+Subject: [PATCH] Fix meshgl_merge/meshgl64_merge returning input pointer on failure
+
+Upstream PR: https://github.com/elalish/manifold/pull/1632
+
+On merge failure, the C API returned the input pointer instead of the
+output buffer, breaking ownership semantics and causing double-free in
+language bindings.
+
+---
+ bindings/c/manifoldc.cpp | 12 ++----------
+ 1 file changed, 2 insertions(+), 10 deletions(-)
+
+diff --git a/bindings/c/manifoldc.cpp b/bindings/c/manifoldc.cpp
+index abcdef1..1234567 100644
+--- a/bindings/c/manifoldc.cpp
++++ b/bindings/c/manifoldc.cpp
+@@ -549,11 +549,8 @@ ManifoldMeshGL* manifold_meshgl_copy(void* mem, ManifoldMeshGL* m) {
+
+ ManifoldMeshGL* manifold_meshgl_merge(void* mem, ManifoldMeshGL* m) {
+   auto duplicate = new (mem) MeshGL(*from_c(m));
+-  if (duplicate->Merge()) {
+-    return to_c(duplicate);
+-  }
+-  duplicate->~MeshGL();
+-  return m;
++  duplicate->Merge();
++  return to_c(duplicate);
+ }
+
+ ManifoldMeshGL64* manifold_get_meshgl64(void* mem, ManifoldManifold* m) {
+@@ -574,11 +571,8 @@ ManifoldMeshGL64* manifold_meshgl64_copy(void* mem, ManifoldMeshGL64* m) {
+
+ ManifoldMeshGL64* manifold_meshgl64_merge(void* mem, ManifoldMeshGL64* m) {
+   auto duplicate = new (mem) MeshGL64(*from_c(m));
+-  if (duplicate->Merge()) {
+-    return to_c(duplicate);
+-  }
+-  duplicate->~MeshGL64();
+-  return m;
++  duplicate->Merge();
++  return to_c(duplicate);
+ }
+
+ size_t manifold_meshgl_num_prop(ManifoldMeshGL* m) {


### PR DESCRIPTION
## Summary

Adds a carry-patch for the `manifold_meshgl_merge` / `manifold_meshgl64_merge` ownership bug. Depends on #3 (carry-patch infrastructure).

Upstream PR: https://github.com/elalish/manifold/pull/1632

**The bug:** On merge failure, the C API returned the input pointer instead of the output buffer, creating aliased ownership that causes double-free when both the source and "result" are dropped.

**The fix:** Always return the caller-owned copy. `Merge()` mutates in place and the copy is valid regardless of whether any vertices were actually merged.

Remove this patch once upstream merges the fix and we bump our manifold3d pin.

## Test plan

- [ ] Clean build with patch applied succeeds
- [ ] Existing 180 tests still pass