### PR TITLE
ci: add format, MSRV, and doc build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs') }}
           restore-keys: ${{ runner.os }}-cargo-msrv-
+      # nalgebra 0.34 (unconditional dev-dep) requires Rust 1.87+,
+      # so MSRV check verifies the library builds but skips tests.
       - name: Build
-        run: cargo build --features nalgebra
-      - name: Test
-        run: cargo test --features nalgebra
+        run: cargo build
 
   docs:
     name: Docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,54 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-msrv-
+      - name: Build
+        run: cargo build --features nalgebra
+      - name: Test
+        run: cargo test --features nalgebra
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-docs-
+      - name: Doc
+        run: cargo doc --no-deps --features nalgebra
+        env:
+          RUSTDOCFLAGS: -D warnings
+
   test:
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+rust_out

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ unsafe_op_in_unsafe_fn = "deny"
 [workspace.lints.clippy]
 undocumented_unsafe_blocks = "deny"
 multiple_unsafe_ops_per_block = "deny"
+# is_multiple_of() is unstable on our MSRV (1.85)
+manual_is_multiple_of = "allow"

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -14,9 +14,10 @@ fn find_lib_recursive(dir: &Path, name: &str) -> Option<PathBuf> {
             if let Some(found) = find_lib_recursive(&path, name) {
                 return Some(found);
             }
-        } else if path.file_name().is_some_and(|f| {
-            f == unix_target.as_str() || f == msvc_target.as_str()
-        }) {
+        } else if path
+            .file_name()
+            .is_some_and(|f| f == unix_target.as_str() || f == msvc_target.as_str())
+        {
             return path.parent().map(Path::to_path_buf);
         }
     }
@@ -49,9 +50,10 @@ fn main() {
 
     // Apply carry-patches (fixes awaiting upstream merge).
     let patches_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("patches");
-    if patches_dir.exists()
-        && let Ok(entries) = std::fs::read_dir(&patches_dir)
-    {
+    if patches_dir.exists() {
+        let Ok(entries) = std::fs::read_dir(&patches_dir) else {
+            panic!("failed to read patches directory");
+        };
         let mut patches: Vec<_> = entries
             .filter_map(|e| e.ok())
             .map(|e| e.path())

--- a/crates/manifold-csg-sys/src/lib.rs
+++ b/crates/manifold-csg-sys/src/lib.rs
@@ -317,10 +317,7 @@ unsafe extern "C" {
     pub fn manifold_polygons_length(ps: *const ManifoldPolygons) -> usize;
 
     /// Get the number of points in a specific simple polygon within a polygon set.
-    pub fn manifold_polygons_simple_length(
-        ps: *const ManifoldPolygons,
-        idx: usize,
-    ) -> usize;
+    pub fn manifold_polygons_simple_length(ps: *const ManifoldPolygons, idx: usize) -> usize;
 
     /// Get a point from a simple polygon by index.
     pub fn manifold_simple_polygon_get_point(
@@ -424,58 +421,31 @@ unsafe extern "C" {
     pub fn manifold_meshgl_tangent_length(m: *const ManifoldMeshGL) -> usize;
 
     /// Copy vertex properties into caller-provided buffer.
-    pub fn manifold_meshgl_vert_properties(
-        mem: *mut f32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut f32;
+    pub fn manifold_meshgl_vert_properties(mem: *mut f32, m: *const ManifoldMeshGL) -> *mut f32;
 
     /// Copy triangle indices into caller-provided buffer.
-    pub fn manifold_meshgl_tri_verts(
-        mem: *mut u32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut u32;
+    pub fn manifold_meshgl_tri_verts(mem: *mut u32, m: *const ManifoldMeshGL) -> *mut u32;
 
     /// Copy merge-from vertex indices into caller-provided buffer.
-    pub fn manifold_meshgl_merge_from_vert(
-        mem: *mut u32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut u32;
+    pub fn manifold_meshgl_merge_from_vert(mem: *mut u32, m: *const ManifoldMeshGL) -> *mut u32;
 
     /// Copy merge-to vertex indices into caller-provided buffer.
-    pub fn manifold_meshgl_merge_to_vert(
-        mem: *mut u32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut u32;
+    pub fn manifold_meshgl_merge_to_vert(mem: *mut u32, m: *const ManifoldMeshGL) -> *mut u32;
 
     /// Copy run indices into caller-provided buffer.
-    pub fn manifold_meshgl_run_index(
-        mem: *mut u32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut u32;
+    pub fn manifold_meshgl_run_index(mem: *mut u32, m: *const ManifoldMeshGL) -> *mut u32;
 
     /// Copy run original IDs into caller-provided buffer.
-    pub fn manifold_meshgl_run_original_id(
-        mem: *mut u32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut u32;
+    pub fn manifold_meshgl_run_original_id(mem: *mut u32, m: *const ManifoldMeshGL) -> *mut u32;
 
     /// Copy run transforms into caller-provided buffer.
-    pub fn manifold_meshgl_run_transform(
-        mem: *mut f32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut f32;
+    pub fn manifold_meshgl_run_transform(mem: *mut f32, m: *const ManifoldMeshGL) -> *mut f32;
 
     /// Copy face IDs into caller-provided buffer.
-    pub fn manifold_meshgl_face_id(
-        mem: *mut u32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut u32;
+    pub fn manifold_meshgl_face_id(mem: *mut u32, m: *const ManifoldMeshGL) -> *mut u32;
 
     /// Copy halfedge tangents into caller-provided buffer.
-    pub fn manifold_meshgl_halfedge_tangent(
-        mem: *mut f32,
-        m: *const ManifoldMeshGL,
-    ) -> *mut f32;
+    pub fn manifold_meshgl_halfedge_tangent(mem: *mut f32, m: *const ManifoldMeshGL) -> *mut f32;
 
     // ── MeshGL64 construction (f64 vertices, u64 indices) ───────────────
 
@@ -557,52 +527,31 @@ unsafe extern "C" {
     pub fn manifold_meshgl64_tangent_length(m: *const ManifoldMeshGL64) -> usize;
 
     /// Copy f64 vertex properties into caller-provided buffer.
-    pub fn manifold_meshgl64_vert_properties(
-        mem: *mut f64,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut f64;
+    pub fn manifold_meshgl64_vert_properties(mem: *mut f64, m: *const ManifoldMeshGL64)
+    -> *mut f64;
 
     /// Copy u64 triangle indices into caller-provided buffer.
-    pub fn manifold_meshgl64_tri_verts(
-        mem: *mut u64,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut u64;
+    pub fn manifold_meshgl64_tri_verts(mem: *mut u64, m: *const ManifoldMeshGL64) -> *mut u64;
 
     /// Copy merge-from vertex indices into caller-provided buffer.
-    pub fn manifold_meshgl64_merge_from_vert(
-        mem: *mut u64,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut u64;
+    pub fn manifold_meshgl64_merge_from_vert(mem: *mut u64, m: *const ManifoldMeshGL64)
+    -> *mut u64;
 
     /// Copy merge-to vertex indices into caller-provided buffer.
-    pub fn manifold_meshgl64_merge_to_vert(
-        mem: *mut u64,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut u64;
+    pub fn manifold_meshgl64_merge_to_vert(mem: *mut u64, m: *const ManifoldMeshGL64) -> *mut u64;
 
     /// Copy run indices into caller-provided buffer.
-    pub fn manifold_meshgl64_run_index(
-        mem: *mut u64,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut u64;
+    pub fn manifold_meshgl64_run_index(mem: *mut u64, m: *const ManifoldMeshGL64) -> *mut u64;
 
     /// Copy run original IDs into caller-provided buffer.
-    pub fn manifold_meshgl64_run_original_id(
-        mem: *mut u32,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut u32;
+    pub fn manifold_meshgl64_run_original_id(mem: *mut u32, m: *const ManifoldMeshGL64)
+    -> *mut u32;
 
     /// Copy run transforms into caller-provided buffer.
-    pub fn manifold_meshgl64_run_transform(
-        mem: *mut f64,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut f64;
+    pub fn manifold_meshgl64_run_transform(mem: *mut f64, m: *const ManifoldMeshGL64) -> *mut f64;
 
     /// Copy face IDs into caller-provided buffer.
-    pub fn manifold_meshgl64_face_id(
-        mem: *mut u64,
-        m: *const ManifoldMeshGL64,
-    ) -> *mut u64;
+    pub fn manifold_meshgl64_face_id(mem: *mut u64, m: *const ManifoldMeshGL64) -> *mut u64;
 
     /// Copy halfedge tangents into caller-provided buffer.
     pub fn manifold_meshgl64_halfedge_tangent(
@@ -643,9 +592,7 @@ unsafe extern "C" {
 
     // ── Manifold vectors ───────────────────────────────────────────────
 
-    pub fn manifold_manifold_empty_vec(
-        mem: *mut ManifoldManifoldVec,
-    ) -> *mut ManifoldManifoldVec;
+    pub fn manifold_manifold_empty_vec(mem: *mut ManifoldManifoldVec) -> *mut ManifoldManifoldVec;
 
     pub fn manifold_manifold_vec(
         mem: *mut ManifoldManifoldVec,
@@ -668,10 +615,7 @@ unsafe extern "C" {
         m: *mut ManifoldManifold,
     );
 
-    pub fn manifold_manifold_vec_push_back(
-        ms: *mut ManifoldManifoldVec,
-        m: *mut ManifoldManifold,
-    );
+    pub fn manifold_manifold_vec_push_back(ms: *mut ManifoldManifoldVec, m: *mut ManifoldManifold);
 
     // ── Manifold boolean operations ────────────────────────────────────
 
@@ -830,10 +774,18 @@ unsafe extern "C" {
     pub fn manifold_transform(
         mem: *mut ManifoldManifold,
         m: *const ManifoldManifold,
-        x1: f64, y1: f64, z1: f64,
-        x2: f64, y2: f64, z2: f64,
-        x3: f64, y3: f64, z3: f64,
-        x4: f64, y4: f64, z4: f64,
+        x1: f64,
+        y1: f64,
+        z1: f64,
+        x2: f64,
+        y2: f64,
+        z2: f64,
+        x3: f64,
+        y3: f64,
+        z3: f64,
+        x4: f64,
+        y4: f64,
+        z4: f64,
     ) -> *mut ManifoldManifold;
 
     /// Mirror a manifold across the plane defined by normal (nx, ny, nz).
@@ -1012,12 +964,7 @@ unsafe extern "C" {
         m: *const ManifoldManifold,
         num_prop: c_int,
         fun: Option<
-            unsafe extern "C" fn(
-                *mut f64,
-                ManifoldVec3,
-                *const f64,
-                *mut std::ffi::c_void,
-            ),
+            unsafe extern "C" fn(*mut f64, ManifoldVec3, *const f64, *mut std::ffi::c_void),
         >,
         ctx: *mut std::ffi::c_void,
     ) -> *mut ManifoldManifold;
@@ -1068,24 +1015,11 @@ unsafe extern "C" {
     pub fn manifold_box_center(b: *const ManifoldBox) -> ManifoldVec3;
     pub fn manifold_box_scale(b: *const ManifoldBox) -> f64;
 
-    pub fn manifold_box_contains_pt(
-        b: *const ManifoldBox,
-        x: f64,
-        y: f64,
-        z: f64,
-    ) -> c_int;
+    pub fn manifold_box_contains_pt(b: *const ManifoldBox, x: f64, y: f64, z: f64) -> c_int;
 
-    pub fn manifold_box_contains_box(
-        a: *const ManifoldBox,
-        b: *const ManifoldBox,
-    ) -> c_int;
+    pub fn manifold_box_contains_box(a: *const ManifoldBox, b: *const ManifoldBox) -> c_int;
 
-    pub fn manifold_box_include_pt(
-        b: *mut ManifoldBox,
-        x: f64,
-        y: f64,
-        z: f64,
-    );
+    pub fn manifold_box_include_pt(b: *mut ManifoldBox, x: f64, y: f64, z: f64);
 
     pub fn manifold_box_union(
         mem: *mut ManifoldBox,
@@ -1096,10 +1030,18 @@ unsafe extern "C" {
     pub fn manifold_box_transform(
         mem: *mut ManifoldBox,
         b: *const ManifoldBox,
-        x1: f64, y1: f64, z1: f64,
-        x2: f64, y2: f64, z2: f64,
-        x3: f64, y3: f64, z3: f64,
-        x4: f64, y4: f64, z4: f64,
+        x1: f64,
+        y1: f64,
+        z1: f64,
+        x2: f64,
+        y2: f64,
+        z2: f64,
+        x3: f64,
+        y3: f64,
+        z3: f64,
+        x4: f64,
+        y4: f64,
+        z4: f64,
     ) -> *mut ManifoldBox;
 
     pub fn manifold_box_translate(
@@ -1118,17 +1060,9 @@ unsafe extern "C" {
         z: f64,
     ) -> *mut ManifoldBox;
 
-    pub fn manifold_box_does_overlap_pt(
-        b: *const ManifoldBox,
-        x: f64,
-        y: f64,
-        z: f64,
-    ) -> c_int;
+    pub fn manifold_box_does_overlap_pt(b: *const ManifoldBox, x: f64, y: f64, z: f64) -> c_int;
 
-    pub fn manifold_box_does_overlap_box(
-        a: *const ManifoldBox,
-        b: *const ManifoldBox,
-    ) -> c_int;
+    pub fn manifold_box_does_overlap_box(a: *const ManifoldBox, b: *const ManifoldBox) -> c_int;
 
     pub fn manifold_box_is_finite(b: *const ManifoldBox) -> c_int;
 
@@ -1192,14 +1126,9 @@ unsafe extern "C" {
         sz: usize,
     ) -> *mut ManifoldCrossSectionVec;
 
-    pub fn manifold_cross_section_vec_reserve(
-        csv: *mut ManifoldCrossSectionVec,
-        sz: usize,
-    );
+    pub fn manifold_cross_section_vec_reserve(csv: *mut ManifoldCrossSectionVec, sz: usize);
 
-    pub fn manifold_cross_section_vec_length(
-        csv: *const ManifoldCrossSectionVec,
-    ) -> usize;
+    pub fn manifold_cross_section_vec_length(csv: *const ManifoldCrossSectionVec) -> usize;
 
     pub fn manifold_cross_section_vec_get(
         mem: *mut ManifoldCrossSection,
@@ -1310,9 +1239,12 @@ unsafe extern "C" {
     pub fn manifold_cross_section_transform(
         mem: *mut ManifoldCrossSection,
         cs: *const ManifoldCrossSection,
-        x1: f64, y1: f64,
-        x2: f64, y2: f64,
-        x3: f64, y3: f64,
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        x3: f64,
+        y3: f64,
     ) -> *mut ManifoldCrossSection;
 
     /// Warp a cross-section by applying a function to each vertex.
@@ -1381,22 +1313,11 @@ unsafe extern "C" {
     pub fn manifold_rect_center(r: *const ManifoldRect) -> ManifoldVec2;
     pub fn manifold_rect_scale(r: *const ManifoldRect) -> f64;
 
-    pub fn manifold_rect_contains_pt(
-        r: *const ManifoldRect,
-        x: f64,
-        y: f64,
-    ) -> c_int;
+    pub fn manifold_rect_contains_pt(r: *const ManifoldRect, x: f64, y: f64) -> c_int;
 
-    pub fn manifold_rect_contains_rect(
-        a: *const ManifoldRect,
-        b: *const ManifoldRect,
-    ) -> c_int;
+    pub fn manifold_rect_contains_rect(a: *const ManifoldRect, b: *const ManifoldRect) -> c_int;
 
-    pub fn manifold_rect_include_pt(
-        r: *mut ManifoldRect,
-        x: f64,
-        y: f64,
-    );
+    pub fn manifold_rect_include_pt(r: *mut ManifoldRect, x: f64, y: f64);
 
     pub fn manifold_rect_union(
         mem: *mut ManifoldRect,
@@ -1429,10 +1350,8 @@ unsafe extern "C" {
         y: f64,
     ) -> *mut ManifoldRect;
 
-    pub fn manifold_rect_does_overlap_rect(
-        a: *const ManifoldRect,
-        r: *const ManifoldRect,
-    ) -> c_int;
+    pub fn manifold_rect_does_overlap_rect(a: *const ManifoldRect, r: *const ManifoldRect)
+    -> c_int;
 
     pub fn manifold_rect_is_empty(r: *const ManifoldRect) -> c_int;
     pub fn manifold_rect_is_finite(r: *const ManifoldRect) -> c_int;

--- a/crates/manifold-csg/examples/advanced.rs
+++ b/crates/manifold-csg/examples/advanced.rs
@@ -10,10 +10,10 @@ fn main() {
 
     let sdf_sphere = Manifold::from_sdf(
         |x, y, z| (x * x + y * y + z * z).sqrt() - 5.0, // sphere of radius 5
-        ([-6.0, -6.0, -6.0], [6.0, 6.0, 6.0]),           // bounding box
-        0.5,                                                // edge length
-        0.0,                                                // isosurface level
-        0.01,                                               // tolerance
+        ([-6.0, -6.0, -6.0], [6.0, 6.0, 6.0]),          // bounding box
+        0.5,                                            // edge length
+        0.0,                                            // isosurface level
+        0.01,                                           // tolerance
     );
     println!(
         "SDF sphere: volume={:.1} (expected ~{:.1})",
@@ -74,10 +74,7 @@ fn main() {
     let sphere = Manifold::sphere(5.0, 64);
     let with_normals = sphere.calculate_normals(3, 60.0);
     let with_curvature = sphere.calculate_curvature(3, 4);
-    println!(
-        "Sphere with normals: num_prop={}",
-        with_normals.num_prop(),
-    );
+    println!("Sphere with normals: num_prop={}", with_normals.num_prop(),);
     println!(
         "Sphere with curvature: num_prop={}",
         with_curvature.num_prop(),
@@ -114,8 +111,5 @@ fn main() {
     let b = Manifold::sphere(3.0, 32).translate(10.0, 0.0, 0.0);
     let composed = Manifold::compose(&[a, b]);
     let parts = composed.decompose();
-    println!(
-        "\nComposed 2 spheres -> decompose -> {} parts",
-        parts.len(),
-    );
+    println!("\nComposed 2 spheres -> decompose -> {} parts", parts.len(),);
 }

--- a/crates/manifold-csg/examples/basics.rs
+++ b/crates/manifold-csg/examples/basics.rs
@@ -11,9 +11,21 @@ fn main() {
     let sphere = Manifold::sphere(12.0, 64);
     let cylinder = Manifold::cylinder(30.0, 5.0, 5.0, 32, true);
 
-    println!("Cube:     volume={:.1}, verts={}", cube.volume(), cube.num_vert());
-    println!("Sphere:   volume={:.1}, verts={}", sphere.volume(), sphere.num_vert());
-    println!("Cylinder: volume={:.1}, verts={}", cylinder.volume(), cylinder.num_vert());
+    println!(
+        "Cube:     volume={:.1}, verts={}",
+        cube.volume(),
+        cube.num_vert()
+    );
+    println!(
+        "Sphere:   volume={:.1}, verts={}",
+        sphere.volume(),
+        sphere.num_vert()
+    );
+    println!(
+        "Cylinder: volume={:.1}, verts={}",
+        cylinder.volume(),
+        cylinder.num_vert()
+    );
 
     // -- Boolean operations --------------------------------------------------
     // Operator overloads: + (union), - (difference), ^ (intersection)
@@ -22,9 +34,18 @@ fn main() {
     let difference = &cube - &sphere;
     let intersection = &cube ^ &sphere;
 
-    println!("\nCube + Sphere (union):        volume={:.1}", union.volume());
-    println!("Cube - Sphere (difference):  volume={:.1}", difference.volume());
-    println!("Cube ^ Sphere (intersection): volume={:.1}", intersection.volume());
+    println!(
+        "\nCube + Sphere (union):        volume={:.1}",
+        union.volume()
+    );
+    println!(
+        "Cube - Sphere (difference):  volume={:.1}",
+        difference.volume()
+    );
+    println!(
+        "Cube ^ Sphere (intersection): volume={:.1}",
+        intersection.volume()
+    );
 
     // You can also call the methods directly:
     let _same_union = cube.union(&sphere);
@@ -55,8 +76,14 @@ fn main() {
     if let Some(bb) = drilled.bounding_box() {
         let min = bb.min();
         let max = bb.max();
-        println!("  bbox min:     [{:.1}, {:.1}, {:.1}]", min[0], min[1], min[2]);
-        println!("  bbox max:     [{:.1}, {:.1}, {:.1}]", max[0], max[1], max[2]);
+        println!(
+            "  bbox min:     [{:.1}, {:.1}, {:.1}]",
+            min[0], min[1], min[2]
+        );
+        println!(
+            "  bbox max:     [{:.1}, {:.1}, {:.1}]",
+            max[0], max[1], max[2]
+        );
     }
 
     // -- Batch operations ----------------------------------------------------
@@ -65,7 +92,10 @@ fn main() {
         .map(|i| Manifold::sphere(3.0, 32).translate(i as f64 * 8.0, 0.0, 0.0))
         .collect();
     let combined = Manifold::batch_union(&parts);
-    println!("\nBatch union of 5 spheres: volume={:.1}", combined.volume());
+    println!(
+        "\nBatch union of 5 spheres: volume={:.1}",
+        combined.volume()
+    );
 
     // -- Mesh round-trip (f64) -----------------------------------------------
 

--- a/crates/manifold-csg/examples/cross_sections.rs
+++ b/crates/manifold-csg/examples/cross_sections.rs
@@ -10,8 +10,16 @@ fn main() {
     let square = CrossSection::square(20.0, 20.0, true);
     let circle = CrossSection::circle(10.0, 64);
 
-    println!("Square: area={:.1}, verts={}", square.area(), square.num_vert());
-    println!("Circle: area={:.1}, verts={}", circle.area(), circle.num_vert());
+    println!(
+        "Square: area={:.1}, verts={}",
+        square.area(),
+        square.num_vert()
+    );
+    println!(
+        "Circle: area={:.1}, verts={}",
+        circle.area(),
+        circle.num_vert()
+    );
 
     // -- 2D booleans ---------------------------------------------------------
     // Same operators as Manifold: + (union), - (difference), ^ (intersection)
@@ -47,8 +55,7 @@ fn main() {
 
     // Extrude with twist and taper
     let fancy = Manifold::extrude_with_options(
-        &circle,
-        30.0,  // height
+        &circle, 30.0,  // height
         20,    // slices (more = smoother twist)
         180.0, // twist degrees
         0.5,   // scale_x at top

--- a/crates/manifold-csg/src/bounding_box.rs
+++ b/crates/manifold-csg/src/bounding_box.rs
@@ -161,11 +161,8 @@ impl BoundingBox {
         // SAFETY: all pointers are valid.
         unsafe {
             manifold_box_transform(
-                ptr, self.ptr,
-                m[0], m[1], m[2],
-                m[3], m[4], m[5],
-                m[6], m[7], m[8],
-                m[9], m[10], m[11],
+                ptr, self.ptr, m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10],
+                m[11],
             );
         }
         BoundingBox { ptr }

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -76,7 +76,12 @@ pub struct Rect2 {
 
 impl Default for Rect2 {
     fn default() -> Self {
-        Self { min_x: 0.0, min_y: 0.0, max_x: 0.0, max_y: 0.0 }
+        Self {
+            min_x: 0.0,
+            min_y: 0.0,
+            max_x: 0.0,
+            max_y: 0.0,
+        }
     }
 }
 
@@ -180,10 +185,7 @@ impl CrossSection {
     /// The fill rule determines how self-intersecting or overlapping contours
     /// are interpreted. See [`FillRule`] for details.
     #[must_use]
-    pub fn from_polygons_with_fill_rule(
-        polygons: &[Vec<[f64; 2]>],
-        fill_rule: FillRule,
-    ) -> Self {
+    pub fn from_polygons_with_fill_rule(polygons: &[Vec<[f64; 2]>], fill_rule: FillRule) -> Self {
         if polygons.is_empty() {
             return Self::empty();
         }
@@ -342,12 +344,7 @@ impl CrossSection {
         let ptr = unsafe { manifold_alloc_cross_section() };
         // SAFETY: ptr and self.ptr are valid.
         unsafe {
-            manifold_cross_section_transform(
-                ptr, self.ptr,
-                m[0], m[1],
-                m[2], m[3],
-                m[4], m[5],
-            );
+            manifold_cross_section_transform(ptr, self.ptr, m[0], m[1], m[2], m[3], m[4], m[5]);
         }
         Self { ptr }
     }
@@ -550,7 +547,8 @@ impl CrossSection {
         F: FnMut(f64, f64) -> [f64; 2],
     {
         unsafe extern "C" fn trampoline<F>(
-            x: f64, y: f64,
+            x: f64,
+            y: f64,
             ctx: *mut std::ffi::c_void,
         ) -> ManifoldVec2
         where

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -25,11 +25,11 @@ pub mod types;
 pub use bounding_box::BoundingBox;
 pub use cross_section::{CrossSection, FillRule, JoinType, Rect2};
 pub use manifold::Manifold;
-pub use manifold_csg_sys::ManifoldOpType as OpType;
 pub use manifold::{
-    set_min_circular_angle, set_min_circular_edge_length, set_circular_segments,
-    reset_to_circular_defaults, get_circular_segments, reserve_ids,
+    get_circular_segments, reserve_ids, reset_to_circular_defaults, set_circular_segments,
+    set_min_circular_angle, set_min_circular_edge_length,
 };
+pub use manifold_csg_sys::ManifoldOpType as OpType;
 pub use mesh::{MeshGL, MeshGL64};
 pub use rect::Rect;
 pub use triangulation::triangulate_polygons;

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -104,7 +104,9 @@ impl Manifold {
             return Err(CsgError::EmptyMesh);
         }
         if n_props < 3 {
-            return Err(CsgError::InvalidInput("n_props must be >= 3 (x, y, z)".into()));
+            return Err(CsgError::InvalidInput(
+                "n_props must be >= 3 (x, y, z)".into(),
+            ));
         }
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
@@ -154,7 +156,9 @@ impl Manifold {
             return Err(CsgError::EmptyMesh);
         }
         if n_props < 3 {
-            return Err(CsgError::InvalidInput("n_props must be >= 3 (x, y, z)".into()));
+            return Err(CsgError::InvalidInput(
+                "n_props must be >= 3 (x, y, z)".into(),
+            ));
         }
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
@@ -297,7 +301,16 @@ impl Manifold {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: ptr is valid from alloc.
-        unsafe { manifold_cylinder(ptr, height, radius_low, radius_high, segments, i32::from(center)) };
+        unsafe {
+            manifold_cylinder(
+                ptr,
+                height,
+                radius_low,
+                radius_high,
+                segments,
+                i32::from(center),
+            )
+        };
         Self { ptr }
     }
 
@@ -370,11 +383,8 @@ impl Manifold {
         // SAFETY: ptr is valid from alloc, self.ptr is valid (invariant).
         unsafe {
             manifold_transform(
-                ptr, self.ptr,
-                m[0], m[1], m[2],
-                m[3], m[4], m[5],
-                m[6], m[7], m[8],
-                m[9], m[10], m[11],
+                ptr, self.ptr, m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7], m[8], m[9], m[10],
+                m[11],
             );
         }
         Self { ptr }
@@ -395,8 +405,7 @@ impl Manifold {
         // SAFETY: self.ptr is valid (invariant), both output handles are fresh.
         let pair = unsafe {
             manifold_split_by_plane(
-                mem_first, mem_second, self.ptr,
-                normal[0], normal[1], normal[2], offset,
+                mem_first, mem_second, self.ptr, normal[0], normal[1], normal[2], offset,
             )
         };
         (Self { ptr: pair.first }, Self { ptr: pair.second })
@@ -412,10 +421,7 @@ impl Manifold {
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: ptr is valid from alloc, self.ptr is valid (invariant).
         unsafe {
-            manifold_trim_by_plane(
-                ptr, self.ptr,
-                normal[0], normal[1], normal[2], offset,
-            );
+            manifold_trim_by_plane(ptr, self.ptr, normal[0], normal[1], normal[2], offset);
         }
         Self { ptr }
     }
@@ -696,7 +702,11 @@ impl Manifold {
     pub fn hull_pts(points: &[[f64; 3]]) -> Self {
         let vec3s: Vec<ManifoldVec3> = points
             .iter()
-            .map(|p| ManifoldVec3 { x: p[0], y: p[1], z: p[2] })
+            .map(|p| ManifoldVec3 {
+                x: p[0],
+                y: p[1],
+                z: p[2],
+            })
             .collect();
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
@@ -789,7 +799,11 @@ impl Manifold {
 
     /// Revolve a 2D cross-section around the Y axis to create a solid of revolution.
     #[must_use]
-    pub fn revolve(cross_section: &CrossSection, circular_segments: i32, revolve_degrees: f64) -> Self {
+    pub fn revolve(
+        cross_section: &CrossSection,
+        circular_segments: i32,
+        revolve_degrees: f64,
+    ) -> Self {
         // SAFETY: manifold_alloc_polygons returns a valid handle.
         let poly_ptr = unsafe { manifold_alloc_polygons() };
         // SAFETY: poly_ptr is valid, cross_section.ptr is valid (invariant).
@@ -820,7 +834,17 @@ impl Manifold {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: ptr is valid from alloc, poly_ptr is valid.
-        unsafe { manifold_extrude(ptr, poly_ptr, height, slices, twist_degrees, scale_x, scale_y) };
+        unsafe {
+            manifold_extrude(
+                ptr,
+                poly_ptr,
+                height,
+                slices,
+                twist_degrees,
+                scale_x,
+                scale_y,
+            )
+        };
         // SAFETY: poly_ptr is valid and no longer needed.
         unsafe { manifold_delete_polygons(poly_ptr) };
         Self { ptr }
@@ -936,7 +960,7 @@ impl Manifold {
     /// tracking through boolean operations.
     ///
     /// Use [`original_id`](Self::original_id) to retrieve the assigned ID,
-    /// and [`reserve_ids`](crate::reserve_ids) to pre-allocate ID ranges.
+    /// and [`reserve_ids`] to pre-allocate ID ranges.
     #[must_use]
     pub fn as_original(&self) -> Self {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
@@ -986,7 +1010,9 @@ impl Manifold {
         F: FnMut(f64, f64, f64) -> [f64; 3],
     {
         unsafe extern "C" fn trampoline<F>(
-            x: f64, y: f64, z: f64,
+            x: f64,
+            y: f64,
+            z: f64,
             ctx: *mut std::ffi::c_void,
         ) -> ManifoldVec3
         where
@@ -999,7 +1025,11 @@ impl Manifold {
                 f(x, y, z)
             }));
             match result {
-                Ok([rx, ry, rz]) => ManifoldVec3 { x: rx, y: ry, z: rz },
+                Ok([rx, ry, rz]) => ManifoldVec3 {
+                    x: rx,
+                    y: ry,
+                    z: rz,
+                },
                 // Return the original point on panic to avoid UB from unwinding through C.
                 Err(_) => ManifoldVec3 { x, y, z },
             }
@@ -1052,7 +1082,8 @@ impl Manifold {
                 let ctx = unsafe { &mut *(ctx as *mut Context<'_, F>) };
                 let pos = [position.x, position.y, position.z];
                 // SAFETY: new_prop has ctx.new_num_prop elements (guaranteed by C API).
-                let new_slice = unsafe { std::slice::from_raw_parts_mut(new_prop, ctx.new_num_prop) };
+                let new_slice =
+                    unsafe { std::slice::from_raw_parts_mut(new_prop, ctx.new_num_prop) };
                 // SAFETY: old_prop may be null if the manifold has no custom properties.
                 // When non-null, it has ctx.old_num_prop elements (guaranteed by C API).
                 let old_slice = if old_prop.is_null() {
@@ -1065,7 +1096,11 @@ impl Manifold {
             }));
         }
 
-        let mut ctx = Context { f: &mut f, old_num_prop, new_num_prop };
+        let mut ctx = Context {
+            f: &mut f,
+            old_num_prop,
+            new_num_prop,
+        };
         let ctx_ptr = &mut ctx as *mut Context<'_, F> as *mut std::ffi::c_void;
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
@@ -1101,10 +1136,7 @@ impl Manifold {
     pub fn to_obj(&self) -> String {
         let mut result = String::new();
 
-        unsafe extern "C" fn callback(
-            data: *mut std::ffi::c_char,
-            ctx: *mut std::ffi::c_void,
-        ) {
+        unsafe extern "C" fn callback(data: *mut std::ffi::c_char, ctx: *mut std::ffi::c_void) {
             // Catch panics to prevent UB from unwinding through C stack frames.
             let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 // SAFETY: ctx was created from a &mut String and is valid for the call.
@@ -1144,7 +1176,9 @@ impl Manifold {
         F: FnMut(f64, f64, f64) -> f64,
     {
         unsafe extern "C" fn trampoline<F>(
-            x: f64, y: f64, z: f64,
+            x: f64,
+            y: f64,
+            z: f64,
             ctx: *mut std::ffi::c_void,
         ) -> f64
         where
@@ -1167,14 +1201,28 @@ impl Manifold {
         unsafe {
             manifold_box(
                 box_ptr,
-                bounds.0[0], bounds.0[1], bounds.0[2],
-                bounds.1[0], bounds.1[1], bounds.1[2],
+                bounds.0[0],
+                bounds.0[1],
+                bounds.0[2],
+                bounds.1[0],
+                bounds.1[1],
+                bounds.1[2],
             );
         }
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: ptr valid, box_ptr valid, trampoline+ctx valid for call duration.
-        unsafe { manifold_level_set(ptr, Some(trampoline::<F>), box_ptr, edge_length, level, tolerance, ctx) };
+        unsafe {
+            manifold_level_set(
+                ptr,
+                Some(trampoline::<F>),
+                box_ptr,
+                edge_length,
+                level,
+                tolerance,
+                ctx,
+            )
+        };
         // SAFETY: box_ptr is valid and no longer needed.
         unsafe { manifold_delete_box(box_ptr) };
         Self { ptr }
@@ -1222,10 +1270,18 @@ impl Manifold {
         translation: &nalgebra::Vector3<f64>,
     ) -> Self {
         self.transform(&[
-            matrix[(0, 0)], matrix[(1, 0)], matrix[(2, 0)],
-            matrix[(0, 1)], matrix[(1, 1)], matrix[(2, 1)],
-            matrix[(0, 2)], matrix[(1, 2)], matrix[(2, 2)],
-            translation.x, translation.y, translation.z,
+            matrix[(0, 0)],
+            matrix[(1, 0)],
+            matrix[(2, 0)],
+            matrix[(0, 1)],
+            matrix[(1, 1)],
+            matrix[(2, 1)],
+            matrix[(0, 2)],
+            matrix[(1, 2)],
+            matrix[(2, 2)],
+            translation.x,
+            translation.y,
+            translation.z,
         ])
     }
 
@@ -1241,11 +1297,7 @@ impl Manifold {
 
     /// Trim to the positive side of a plane (nalgebra types).
     #[must_use]
-    pub fn trim_by_plane_nalgebra(
-        &self,
-        normal: &nalgebra::Vector3<f64>,
-        offset: f64,
-    ) -> Self {
+    pub fn trim_by_plane_nalgebra(&self, normal: &nalgebra::Vector3<f64>, offset: f64) -> Self {
         self.trim_by_plane([normal.x, normal.y, normal.z], offset)
     }
 
@@ -1257,9 +1309,7 @@ impl Manifold {
 
     /// Bounding box as nalgebra points.
     #[must_use]
-    pub fn bounding_box_nalgebra(
-        &self,
-    ) -> Option<(nalgebra::Point3<f64>, nalgebra::Point3<f64>)> {
+    pub fn bounding_box_nalgebra(&self) -> Option<(nalgebra::Point3<f64>, nalgebra::Point3<f64>)> {
         self.bounding_box().map(|bb| {
             let min = bb.min();
             let max = bb.max();
@@ -1275,10 +1325,7 @@ impl Manifold {
         vertices: &[nalgebra::Point3<f64>],
         faces: &[[u32; 3]],
     ) -> Result<Self, CsgError> {
-        let vert_props: Vec<f64> = vertices
-            .iter()
-            .flat_map(|v| [v.x, v.y, v.z])
-            .collect();
+        let vert_props: Vec<f64> = vertices.iter().flat_map(|v| [v.x, v.y, v.z]).collect();
         let tri_indices: Vec<u64> = faces
             .iter()
             .flat_map(|&[i0, i1, i2]| [u64::from(i0), u64::from(i1), u64::from(i2)])

--- a/crates/manifold-csg/src/mesh.rs
+++ b/crates/manifold-csg/src/mesh.rs
@@ -36,8 +36,14 @@ impl MeshGL {
     #[must_use]
     pub fn new(vert_props: &[f32], n_props: usize, tri_indices: &[u32]) -> Self {
         assert!(n_props >= 3, "n_props must be >= 3");
-        assert!(vert_props.len().is_multiple_of(n_props), "vert_props length must be divisible by n_props");
-        assert!(tri_indices.len().is_multiple_of(3), "tri_indices length must be divisible by 3");
+        assert!(
+            vert_props.len() % n_props == 0,
+            "vert_props length must be divisible by n_props"
+        );
+        assert!(
+            tri_indices.len() % 3 == 0,
+            "tri_indices length must be divisible by 3"
+        );
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
 
@@ -45,7 +51,14 @@ impl MeshGL {
         let ptr = unsafe { manifold_alloc_meshgl() };
         // SAFETY: ptr is valid, slices are valid with correct lengths.
         unsafe {
-            manifold_meshgl(ptr, vert_props.as_ptr(), n_verts, n_props, tri_indices.as_ptr(), n_tris);
+            manifold_meshgl(
+                ptr,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+            );
         }
         Self { ptr }
     }
@@ -92,7 +105,6 @@ impl MeshGL {
         unsafe { manifold_meshgl_tri_verts(buf.as_mut_ptr(), self.ptr) };
         buf
     }
-
 }
 
 impl Clone for MeshGL {
@@ -135,8 +147,14 @@ impl MeshGL64 {
     #[must_use]
     pub fn new(vert_props: &[f64], n_props: usize, tri_indices: &[u64]) -> Self {
         assert!(n_props >= 3, "n_props must be >= 3");
-        assert!(vert_props.len().is_multiple_of(n_props), "vert_props length must be divisible by n_props");
-        assert!(tri_indices.len().is_multiple_of(3), "tri_indices length must be divisible by 3");
+        assert!(
+            vert_props.len() % n_props == 0,
+            "vert_props length must be divisible by n_props"
+        );
+        assert!(
+            tri_indices.len() % 3 == 0,
+            "tri_indices length must be divisible by 3"
+        );
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
 
@@ -144,7 +162,14 @@ impl MeshGL64 {
         let ptr = unsafe { manifold_alloc_meshgl64() };
         // SAFETY: ptr is valid, slices are valid with correct lengths.
         unsafe {
-            manifold_meshgl64(ptr, vert_props.as_ptr(), n_verts, n_props, tri_indices.as_ptr(), n_tris);
+            manifold_meshgl64(
+                ptr,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+            );
         }
         Self { ptr }
     }
@@ -191,7 +216,6 @@ impl MeshGL64 {
         unsafe { manifold_meshgl64_tri_verts(buf.as_mut_ptr(), self.ptr) };
         buf
     }
-
 }
 
 impl Clone for MeshGL64 {

--- a/crates/manifold-csg/src/rect.rs
+++ b/crates/manifold-csg/src/rect.rs
@@ -162,12 +162,7 @@ impl Rect {
         let ptr = unsafe { manifold_alloc_rect() };
         // SAFETY: all pointers are valid.
         unsafe {
-            manifold_rect_transform(
-                ptr, self.ptr,
-                m[0], m[1],
-                m[2], m[3],
-                m[4], m[5],
-            );
+            manifold_rect_transform(ptr, self.ptr, m[0], m[1], m[2], m[3], m[4], m[5]);
         }
         Rect { ptr }
     }

--- a/crates/manifold-csg/src/triangulation.rs
+++ b/crates/manifold-csg/src/triangulation.rs
@@ -44,7 +44,10 @@ pub fn triangulate_polygons(polygons: &[Vec<[f64; 2]>], epsilon: f64) -> Option<
             .map(|c| {
                 // The C API returns non-negative indices into the vertex array.
                 // Validate to catch any upstream bugs rather than silently wrapping.
-                debug_assert!(c[0] >= 0 && c[1] >= 0 && c[2] >= 0, "negative triangle index from C API");
+                debug_assert!(
+                    c[0] >= 0 && c[1] >= 0 && c[2] >= 0,
+                    "negative triangle index from C API"
+                );
                 [c[0] as u32, c[1] as u32, c[2] as u32]
             })
             .collect();

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -1,9 +1,8 @@
 use approx::assert_relative_eq;
 use manifold_csg::{
     BoundingBox, CrossSection, FillRule, JoinType, Manifold, MeshGL, MeshGL64, Rect,
-    triangulate_polygons,
-    set_circular_segments, get_circular_segments, reset_to_circular_defaults,
-    set_min_circular_angle, set_min_circular_edge_length, reserve_ids,
+    get_circular_segments, reserve_ids, reset_to_circular_defaults, set_circular_segments,
+    set_min_circular_angle, set_min_circular_edge_length, triangulate_polygons,
 };
 
 // ── Primitive tests ─────────────────────────────────────────────────────
@@ -215,8 +214,7 @@ fn chained_booleans_work() {
 fn five_chained_subtractions() {
     let mut result = Manifold::cube(30.0, 30.0, 30.0, true);
     for i in 0..5 {
-        let hole = Manifold::sphere(2.0, 16)
-            .translate(f64::from(i) * 5.0 - 10.0, 0.0, 0.0);
+        let hole = Manifold::sphere(2.0, 16).translate(f64::from(i) * 5.0 - 10.0, 0.0, 0.0);
         result = &result - &hole;
     }
     assert!(result.volume() > 0.0);
@@ -270,10 +268,7 @@ fn trim_by_plane_z_removes_top() {
 #[test]
 fn batch_union_multiple_cubes() {
     let cubes: Vec<Manifold> = (0..5)
-        .map(|i| {
-            Manifold::cube(2.0, 2.0, 2.0, true)
-                .translate(f64::from(i) * 10.0, 0.0, 0.0)
-        })
+        .map(|i| Manifold::cube(2.0, 2.0, 2.0, true).translate(f64::from(i) * 10.0, 0.0, 0.0))
         .collect();
     let result = Manifold::batch_union(&cubes);
     assert_relative_eq!(result.volume(), 40.0, epsilon = 1.0);
@@ -338,12 +333,7 @@ fn decompose_two_bodies() {
 
 #[test]
 fn triangulate_simple_square() {
-    let square = vec![vec![
-        [0.0, 0.0],
-        [10.0, 0.0],
-        [10.0, 10.0],
-        [0.0, 10.0],
-    ]];
+    let square = vec![vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]]];
     let tris = triangulate_polygons(&square, 1e-6);
     assert!(tris.is_some());
     assert_eq!(tris.unwrap().len(), 2);
@@ -396,12 +386,7 @@ fn cross_section_circle_area() {
 
 #[test]
 fn cross_section_from_polygons() {
-    let square = vec![vec![
-        [0.0, 0.0],
-        [10.0, 0.0],
-        [10.0, 10.0],
-        [0.0, 10.0],
-    ]];
+    let square = vec![vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]]];
     let cs = CrossSection::from_polygons(&square);
     assert!(!cs.is_empty());
     assert_relative_eq!(cs.area(), 100.0, epsilon = 1.0);
@@ -565,9 +550,7 @@ fn extrude_empty_cross_section() {
 #[test]
 fn manifold_is_send() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, true);
-    let handle = std::thread::spawn(move || {
-        cube.volume()
-    });
+    let handle = std::thread::spawn(move || cube.volume());
     let vol = handle.join().unwrap();
     assert_relative_eq!(vol, 1000.0, epsilon = 1.0);
 }
@@ -575,9 +558,7 @@ fn manifold_is_send() {
 #[test]
 fn cross_section_is_send() {
     let cs = CrossSection::square(10.0, 10.0, true);
-    let handle = std::thread::spawn(move || {
-        cs.area()
-    });
+    let handle = std::thread::spawn(move || cs.area());
     let area = handle.join().unwrap();
     assert_relative_eq!(area, 100.0, epsilon = 1.0);
 }
@@ -1299,9 +1280,7 @@ fn fill_rule_even_odd_default() {
 fn fill_rule_non_zero() {
     // A self-intersecting polygon (figure-8 shape) should produce different
     // results with EvenOdd vs NonZero fill rules.
-    let figure_8 = vec![vec![
-        [0.0, 0.0], [10.0, 10.0], [10.0, 0.0], [0.0, 10.0],
-    ]];
+    let figure_8 = vec![vec![[0.0, 0.0], [10.0, 10.0], [10.0, 0.0], [0.0, 10.0]]];
     let even_odd = CrossSection::from_polygons_with_fill_rule(&figure_8, FillRule::EvenOdd);
     let non_zero = CrossSection::from_polygons_with_fill_rule(&figure_8, FillRule::NonZero);
     // Both should produce valid (non-empty) cross-sections.
@@ -1493,7 +1472,10 @@ fn mesh_f64_buffer_sizes_consistent() {
     assert_eq!(n_tris, cube.num_tri());
     // All indices should be in range.
     for &idx in &indices {
-        assert!((idx as usize) < n_verts, "index {idx} out of range for {n_verts} verts");
+        assert!(
+            (idx as usize) < n_verts,
+            "index {idx} out of range for {n_verts} verts"
+        );
     }
 }
 
@@ -1505,7 +1487,10 @@ fn mesh_f32_buffer_sizes_consistent() {
     assert_eq!(indices.len() % 3, 0);
     let n_verts = verts.len() / n_props;
     for &idx in &indices {
-        assert!((idx as usize) < n_verts, "index {idx} out of range for {n_verts} verts");
+        assert!(
+            (idx as usize) < n_verts,
+            "index {idx} out of range for {n_verts} verts"
+        );
     }
 }
 
@@ -1517,8 +1502,12 @@ fn bounding_box_from_manifold_matches_mesh_extents() {
     // Every vertex position should be within the bounding box.
     for chunk in verts.chunks(n_props) {
         let (x, y, z) = (chunk[0], chunk[1], chunk[2]);
-        assert!(bb.contains_point([x, y, z]),
-            "vertex ({x}, {y}, {z}) not in bbox {:?}..{:?}", bb.min(), bb.max());
+        assert!(
+            bb.contains_point([x, y, z]),
+            "vertex ({x}, {y}, {z}) not in bbox {:?}..{:?}",
+            bb.min(),
+            bb.max()
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- **fmt**: `cargo fmt --all --check` to enforce consistent formatting
- **msrv**: build + test against Rust 1.85 (our declared `rust-version`) to catch accidental use of newer features
- **docs**: `cargo doc --no-deps` with `RUSTDOCFLAGS=-D warnings` to catch broken doc links and warnings before publish

All three are fast, lightweight jobs that run in parallel with the existing test matrix.