### PR TITLE
ci: add cargo-semver-checks and cargo-deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,34 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  semver:
+    name: Semver
+    runs-on: ubuntu-latest
+    # Only meaningful once published to crates.io
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-semver-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-semver-
+      - name: Install cargo-semver-checks
+        run: cargo install cargo-semver-checks --locked
+      - name: Check semver
+        run: cargo semver-checks -p manifold-csg
+
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
   test:
     strategy:
       fail-fast: false

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,26 @@
+[graph]
+all-features = true
+
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

- **semver**: Runs `cargo-semver-checks` against the last published crates.io version to catch accidental API breakage. Uses `continue-on-error: true` since we haven't published yet — becomes a hard gate after first publish.
- **deny**: Runs `cargo-deny` via `EmbarkStudios/cargo-deny-action@v2` for license compatibility, vulnerability advisories, and source auditing. Adds `deny.toml` allowing Apache-2.0, MIT, Unicode-3.0, and Zlib.

## Test plan

- [ ] Deny job passes (licenses, bans, sources, advisories)
- [ ] Semver job completes (expected soft-fail since crate isn't published yet)
- [ ] Existing jobs unaffected