### PR TITLE
Add smooth constructors, MeshGL accessors, and CrossSection gaps

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -31,9 +31,9 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_copy` | [`Clone` impl](crates/manifold-csg/src/manifold.rs#L56) |
 | `manifold_level_set` | [`Manifold::from_sdf`](crates/manifold-csg/src/manifold.rs#L1114) |
 | `manifold_read_obj` | [`Manifold::from_obj`](crates/manifold-csg/src/manifold.rs#L1063) |
-| `manifold_smooth` | Not wrapped |
-| `manifold_smooth64` | Not wrapped |
-| `manifold_level_set_seq` | [`Manifold::from_sdf_seq`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_smooth` | [`Manifold::smooth_f32`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_smooth64` | [`Manifold::smooth_f64`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_level_set_seq` | Not wrapped |
 
 ## Manifold — Boolean Operations
 
@@ -103,8 +103,8 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_get_meshgl` | [`Manifold::to_mesh_f32`](crates/manifold-csg/src/manifold.rs#L235) |
 | `manifold_get_meshgl64` | [`Manifold::to_mesh_f64`](crates/manifold-csg/src/manifold.rs#L197) |
 | `manifold_write_obj` | [`Manifold::to_obj`](crates/manifold-csg/src/manifold.rs#L1082) |
-| `manifold_get_meshgl_w_normals` | [`Manifold::to_mesh_f32_with_normals`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_get_meshgl64_w_normals` | [`Manifold::to_mesh_f64_with_normals`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_get_meshgl_w_normals` | Not wrapped |
+| `manifold_get_meshgl64_w_normals` | Not wrapped |
 
 ## CrossSection — Construction & Booleans
 
@@ -123,9 +123,9 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_cross_section_batch_hull` | [`CrossSection::batch_hull`](crates/manifold-csg/src/cross_section.rs#L382) |
 | `manifold_cross_section_hull` | [`CrossSection::hull`](crates/manifold-csg/src/cross_section.rs#L234) |
 | `manifold_cross_section_compose` | [`CrossSection::compose`](crates/manifold-csg/src/cross_section.rs#L409) |
-| `manifold_cross_section_of_simple_polygon` | Not wrapped |
-| `manifold_cross_section_hull_polygons` | Not wrapped |
-| `manifold_cross_section_hull_simple_polygon` | Not wrapped |
+| `manifold_cross_section_of_simple_polygon` | [`CrossSection::from_simple_polygon`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_hull_polygons` | [`CrossSection::hull_polygons`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_hull_simple_polygon` | [`CrossSection::hull_simple_polygon`](crates/manifold-csg/src/cross_section.rs) |
 | `manifold_cross_section_decompose` | [`CrossSection::decompose`](crates/manifold-csg/src/cross_section.rs) |
 
 ## CrossSection — Transforms & Queries
@@ -174,34 +174,34 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_meshgl64_w_options` | Not wrapped |
 | `manifold_meshgl_w_tangents` | Not wrapped |
 | `manifold_meshgl64_w_tangents` | Not wrapped |
-| `manifold_meshgl_halfedge_tangent` | Not wrapped |
-| `manifold_meshgl64_halfedge_tangent` | Not wrapped |
-| `manifold_meshgl_tangent_length` | Not wrapped |
-| `manifold_meshgl64_tangent_length` | Not wrapped |
-| `manifold_meshgl_merge` | [`MeshGL::merge`](crates/manifold-csg/src/mesh.rs) |
-| `manifold_meshgl64_merge` | [`MeshGL64::merge`](crates/manifold-csg/src/mesh.rs) |
-| `manifold_meshgl_merge_from_vert` | Not wrapped |
-| `manifold_meshgl64_merge_from_vert` | Not wrapped |
-| `manifold_meshgl_merge_to_vert` | Not wrapped |
-| `manifold_meshgl64_merge_to_vert` | Not wrapped |
-| `manifold_meshgl_merge_length` | Not wrapped |
-| `manifold_meshgl64_merge_length` | Not wrapped |
-| `manifold_meshgl_run_index` | Not wrapped |
-| `manifold_meshgl64_run_index` | Not wrapped |
-| `manifold_meshgl_run_index_length` | Not wrapped |
-| `manifold_meshgl64_run_index_length` | Not wrapped |
-| `manifold_meshgl_run_original_id` | Not wrapped |
-| `manifold_meshgl64_run_original_id` | Not wrapped |
-| `manifold_meshgl_run_original_id_length` | Not wrapped |
-| `manifold_meshgl64_run_original_id_length` | Not wrapped |
-| `manifold_meshgl_run_transform` | Not wrapped |
-| `manifold_meshgl64_run_transform` | Not wrapped |
-| `manifold_meshgl_run_transform_length` | Not wrapped |
-| `manifold_meshgl64_run_transform_length` | Not wrapped |
-| `manifold_meshgl_face_id` | Not wrapped |
-| `manifold_meshgl64_face_id` | Not wrapped |
-| `manifold_meshgl_face_id_length` | Not wrapped |
-| `manifold_meshgl64_face_id_length` | Not wrapped |
+| `manifold_meshgl_halfedge_tangent` | [`MeshGL::halfedge_tangent`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_halfedge_tangent` | [`MeshGL64::halfedge_tangent`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_tangent_length` | Internal |
+| `manifold_meshgl64_tangent_length` | Internal |
+| `manifold_meshgl_merge` | Not wrapped |
+| `manifold_meshgl64_merge` | Not wrapped |
+| `manifold_meshgl_merge_from_vert` | [`MeshGL::merge_from_vert`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_merge_from_vert` | [`MeshGL64::merge_from_vert`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_merge_to_vert` | [`MeshGL::merge_to_vert`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_merge_to_vert` | [`MeshGL64::merge_to_vert`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_merge_length` | Internal |
+| `manifold_meshgl64_merge_length` | Internal |
+| `manifold_meshgl_run_index` | [`MeshGL::run_index`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_run_index` | [`MeshGL64::run_index`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_run_index_length` | Internal |
+| `manifold_meshgl64_run_index_length` | Internal |
+| `manifold_meshgl_run_original_id` | [`MeshGL::run_original_id`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_run_original_id` | [`MeshGL64::run_original_id`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_run_original_id_length` | Internal |
+| `manifold_meshgl64_run_original_id_length` | Internal |
+| `manifold_meshgl_run_transform` | [`MeshGL::run_transform`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_run_transform` | [`MeshGL64::run_transform`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_run_transform_length` | Internal |
+| `manifold_meshgl64_run_transform_length` | Internal |
+| `manifold_meshgl_face_id` | [`MeshGL::face_id`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_face_id` | [`MeshGL64::face_id`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_face_id_length` | Internal |
+| `manifold_meshgl64_face_id_length` | Internal |
 | `manifold_meshgl_size` | Not wrapped |
 | `manifold_meshgl64_size` | Not wrapped |
 | `manifold_meshgl64_read_obj` | Not wrapped |
@@ -333,14 +333,14 @@ and `Drop` implementations.
 
 | Category | Wrapped | Internal |
 |---|---|---|
-| Manifold construction | 15 | 0 |
+| Manifold construction | 14 | 0 |
 | Manifold booleans | 7 | 0 |
 | Manifold transforms | 15 | 0 |
 | Manifold queries | 13 | 0 |
 | Manifold hull/decompose/mesh | 10 | 0 |
 | CrossSection construction & booleans | 13 | 0 |
 | CrossSection transforms & queries | 15 | 0 |
-| MeshGL/MeshGL64 | 18 | 4 |
+| MeshGL/MeshGL64 | 14 | 4 |
 | Triangulation | 1 | 2 |
 | Quality globals | 6 | 0 |
 | Box3D (BoundingBox) | 16 | 0 |
@@ -348,12 +348,12 @@ and `Drop` implementations.
 | Polygon helpers | 0 | 7 |
 | Vector containers | 0 | 10 |
 | Alloc/delete/destruct | 0 | 24 |
-| **Total** | **145** | **47** |
+| **Total** | **140** | **47** |
 
-The remaining unwrapped functions are primarily:
-- MeshGL advanced accessors (run tables, face IDs, tangents) — 30 functions
+The 71 unwrapped functions are primarily:
+- MeshGL advanced accessors (merge tables, run tables, face IDs, tangents) — 34 functions
 - Allocation infrastructure (`destruct_*` variants, unused vec ops) — 18 functions
-- Specialized variants (smooth constructors) — 4 functions
+- Specialized variants (smooth constructors, mesh normals export) — 9 functions
 - Internal size queries — 10 functions
 
 All operations commonly needed for CSG workflows (primitives, booleans, transforms,

--- a/TODO.md
+++ b/TODO.md
@@ -18,11 +18,12 @@
 
 ## Safe wrapper gaps (low priority)
 
-- [ ] MeshGL/MeshGL64 advanced accessors (run_index, face_id, tangents)
-- [ ] `manifold_smooth` / `manifold_smooth64` constructors (from half-edge indices)
+- [ ] MeshGL/MeshGL64 construction with options (`w_options`, `w_tangents`)
+- [ ] MeshGL64 OBJ I/O (`read_obj`, `write_obj`)
 
 ## Documentation & Publishing
 
+- [ ] Re-enable `semver` CI job once manifold-csg is published on crates.io (disabled via `if: false` in `ci.yml`)
 - [ ] README badges (crates.io version, docs.rs, CI status) — add once published
 - [ ] Make doc-tests runnable (currently `rust,ignore`) — runnable examples exist in `examples/` but inline doc examples still need `rust,ignore` due to build infra requirements
 

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -210,6 +210,86 @@ impl CrossSection {
         Self { ptr }
     }
 
+    /// Create a cross-section from a single simple polygon (no holes).
+    ///
+    /// For polygons with holes, use [`from_polygons`](Self::from_polygons).
+    #[must_use]
+    pub fn from_simple_polygon(points: &[[f64; 2]], fill_rule: FillRule) -> Self {
+        if points.is_empty() {
+            return Self::empty();
+        }
+
+        let vec2s: Vec<ManifoldVec2> = points
+            .iter()
+            .map(|p| ManifoldVec2 { x: p[0], y: p[1] })
+            .collect();
+        // SAFETY: manifold_alloc_simple_polygon returns a valid handle.
+        let sp = unsafe { manifold_alloc_simple_polygon() };
+        // SAFETY: sp valid, vec2s is a valid slice.
+        unsafe { manifold_simple_polygon(sp, vec2s.as_ptr(), vec2s.len()) };
+
+        // SAFETY: manifold_alloc_cross_section returns a valid handle.
+        let ptr = unsafe { manifold_alloc_cross_section() };
+        // SAFETY: ptr and sp are valid.
+        unsafe { manifold_cross_section_of_simple_polygon(ptr, sp, fill_rule.to_ffi()) };
+
+        // SAFETY: sp is valid and no longer needed.
+        unsafe { manifold_delete_simple_polygon(sp) };
+
+        Self { ptr }
+    }
+
+    /// Compute the convex hull of a simple polygon.
+    #[must_use]
+    pub fn hull_simple_polygon(points: &[[f64; 2]]) -> Self {
+        if points.is_empty() {
+            return Self::empty();
+        }
+
+        let vec2s: Vec<ManifoldVec2> = points
+            .iter()
+            .map(|p| ManifoldVec2 { x: p[0], y: p[1] })
+            .collect();
+        // SAFETY: manifold_alloc_simple_polygon returns a valid handle.
+        let sp = unsafe { manifold_alloc_simple_polygon() };
+        // SAFETY: sp valid, vec2s is a valid slice.
+        unsafe { manifold_simple_polygon(sp, vec2s.as_ptr(), vec2s.len()) };
+
+        // SAFETY: manifold_alloc_cross_section returns a valid handle.
+        let ptr = unsafe { manifold_alloc_cross_section() };
+        // SAFETY: ptr and sp are valid.
+        unsafe { manifold_cross_section_hull_simple_polygon(ptr, sp) };
+
+        // SAFETY: sp is valid and no longer needed.
+        unsafe { manifold_delete_simple_polygon(sp) };
+
+        Self { ptr }
+    }
+
+    /// Compute the convex hull of a polygon set (multiple rings).
+    #[must_use]
+    pub fn hull_polygons(polygons: &[Vec<[f64; 2]>]) -> Self {
+        if polygons.is_empty() {
+            return Self::empty();
+        }
+
+        let (polys_ptr, simple_ptrs) = build_polygons_ffi(polygons);
+
+        // SAFETY: manifold_alloc_cross_section returns a valid handle.
+        let ptr = unsafe { manifold_alloc_cross_section() };
+        // SAFETY: ptr and polys_ptr are valid.
+        unsafe { manifold_cross_section_hull_polygons(ptr, polys_ptr) };
+
+        // SAFETY: polys_ptr and simple polygon handles are valid and no longer needed.
+        unsafe { manifold_delete_polygons(polys_ptr) };
+        for sp in simple_ptrs {
+            // SAFETY: sp is valid and no longer needed.
+            unsafe { manifold_delete_simple_polygon(sp) };
+        }
+
+        Self { ptr }
+    }
+
     // ── Booleans ────────────────────────────────────────────────────
 
     /// Boolean union: `self ∪ other`.

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -195,6 +195,131 @@ impl Manifold {
         Ok(Self { ptr: manifold })
     }
 
+    /// Create a smooth manifold from f64 mesh data with per-halfedge smoothness.
+    ///
+    /// `half_edges` and `smoothness` must have the same length. Each entry
+    /// specifies a halfedge index and its smoothness value (0.0 = sharp,
+    /// 1.0 = fully smooth).
+    ///
+    /// # Errors
+    ///
+    /// Returns `CsgError::InvalidInput` if array lengths don't match or
+    /// `CsgError::ManifoldStatus` if the mesh is invalid.
+    pub fn smooth_f64(
+        vert_props: &[f64],
+        n_props: usize,
+        tri_indices: &[u64],
+        half_edges: &[usize],
+        smoothness: &[f64],
+    ) -> Result<Self, CsgError> {
+        if half_edges.len() != smoothness.len() {
+            return Err(CsgError::InvalidInput(
+                "half_edges and smoothness must have the same length".into(),
+            ));
+        }
+
+        let n_verts = vert_props.len() / n_props;
+        let n_tris = tri_indices.len() / 3;
+
+        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
+        let meshgl = unsafe { manifold_alloc_meshgl64() };
+        // SAFETY: meshgl valid, slices valid with correct lengths.
+        unsafe {
+            manifold_meshgl64(
+                meshgl,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+            );
+        }
+
+        // SAFETY: manifold_alloc_manifold returns a valid handle.
+        let manifold = unsafe { manifold_alloc_manifold() };
+        // SAFETY: all pointers valid, array lengths match.
+        unsafe {
+            manifold_smooth64(
+                manifold,
+                meshgl,
+                half_edges.as_ptr(),
+                smoothness.as_ptr(),
+                half_edges.len(),
+            );
+        }
+        // SAFETY: meshgl is valid and no longer needed.
+        unsafe { manifold_delete_meshgl64(meshgl) };
+
+        // SAFETY: manifold is valid. Read-only status query.
+        let status = unsafe { manifold_status(manifold) };
+        if status != ManifoldError::NoError {
+            // SAFETY: manifold is valid. Frees the allocation on error path.
+            unsafe { manifold_delete_manifold(manifold) };
+            return Err(CsgError::ManifoldStatus(status));
+        }
+
+        Ok(Self { ptr: manifold })
+    }
+
+    /// Create a smooth manifold from f32 mesh data with per-halfedge smoothness.
+    ///
+    /// See [`smooth_f64`](Self::smooth_f64) for details.
+    pub fn smooth_f32(
+        vert_props: &[f32],
+        n_props: usize,
+        tri_indices: &[u32],
+        half_edges: &[usize],
+        smoothness: &[f64],
+    ) -> Result<Self, CsgError> {
+        if half_edges.len() != smoothness.len() {
+            return Err(CsgError::InvalidInput(
+                "half_edges and smoothness must have the same length".into(),
+            ));
+        }
+
+        let n_verts = vert_props.len() / n_props;
+        let n_tris = tri_indices.len() / 3;
+
+        // SAFETY: manifold_alloc_meshgl returns a valid handle.
+        let meshgl = unsafe { manifold_alloc_meshgl() };
+        // SAFETY: meshgl valid, slices valid with correct lengths.
+        unsafe {
+            manifold_meshgl(
+                meshgl,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+            );
+        }
+
+        // SAFETY: manifold_alloc_manifold returns a valid handle.
+        let manifold = unsafe { manifold_alloc_manifold() };
+        // SAFETY: all pointers valid, array lengths match.
+        unsafe {
+            manifold_smooth(
+                manifold,
+                meshgl,
+                half_edges.as_ptr(),
+                smoothness.as_ptr(),
+                half_edges.len(),
+            );
+        }
+        // SAFETY: meshgl is valid and no longer needed.
+        unsafe { manifold_delete_meshgl(meshgl) };
+
+        // SAFETY: manifold is valid. Read-only status query.
+        let status = unsafe { manifold_status(manifold) };
+        if status != ManifoldError::NoError {
+            // SAFETY: manifold is valid. Frees the allocation on error path.
+            unsafe { manifold_delete_manifold(manifold) };
+            return Err(CsgError::ManifoldStatus(status));
+        }
+
+        Ok(Self { ptr: manifold })
+    }
+
     /// Extract mesh data as f64 vertex properties and u64 triangle indices.
     ///
     /// Returns `(vert_props, n_props, tri_indices)`.

--- a/crates/manifold-csg/src/mesh.rs
+++ b/crates/manifold-csg/src/mesh.rs
@@ -119,6 +119,83 @@ impl MeshGL {
         unsafe { manifold_meshgl_merge(ptr, self.ptr) };
         Self { ptr }
     }
+
+    /// Copy merge-from vertex indices out as a flat u32 array.
+    #[must_use]
+    pub fn merge_from_vert(&self) -> Vec<u32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl_merge_length(self.ptr) };
+        let mut buf = vec![0u32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl_merge_from_vert(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy merge-to vertex indices out as a flat u32 array.
+    #[must_use]
+    pub fn merge_to_vert(&self) -> Vec<u32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl_merge_length(self.ptr) };
+        let mut buf = vec![0u32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl_merge_to_vert(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy run indices out as a flat u32 array.
+    #[must_use]
+    pub fn run_index(&self) -> Vec<u32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl_run_index_length(self.ptr) };
+        let mut buf = vec![0u32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl_run_index(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy run original IDs out as a flat u32 array.
+    #[must_use]
+    pub fn run_original_id(&self) -> Vec<u32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl_run_original_id_length(self.ptr) };
+        let mut buf = vec![0u32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl_run_original_id(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy run transforms out as a flat f32 array (4x3 matrices, 12 floats each).
+    #[must_use]
+    pub fn run_transform(&self) -> Vec<f32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl_run_transform_length(self.ptr) };
+        let mut buf = vec![0.0f32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl_run_transform(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy face IDs out as a flat u32 array.
+    #[must_use]
+    pub fn face_id(&self) -> Vec<u32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl_face_id_length(self.ptr) };
+        let mut buf = vec![0u32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl_face_id(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy halfedge tangents out as a flat f32 array (4 floats per halfedge).
+    #[must_use]
+    pub fn halfedge_tangent(&self) -> Vec<f32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl_tangent_length(self.ptr) };
+        let mut buf = vec![0.0f32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl_halfedge_tangent(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
 }
 
 impl Clone for MeshGL {
@@ -243,6 +320,83 @@ impl MeshGL64 {
         // manifold_meshgl64_merge always returns ptr (the output buffer).
         unsafe { manifold_meshgl64_merge(ptr, self.ptr) };
         Self { ptr }
+    }
+
+    /// Copy merge-from vertex indices out as a flat u64 array.
+    #[must_use]
+    pub fn merge_from_vert(&self) -> Vec<u64> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl64_merge_length(self.ptr) };
+        let mut buf = vec![0u64; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl64_merge_from_vert(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy merge-to vertex indices out as a flat u64 array.
+    #[must_use]
+    pub fn merge_to_vert(&self) -> Vec<u64> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl64_merge_length(self.ptr) };
+        let mut buf = vec![0u64; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl64_merge_to_vert(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy run indices out as a flat u64 array.
+    #[must_use]
+    pub fn run_index(&self) -> Vec<u64> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl64_run_index_length(self.ptr) };
+        let mut buf = vec![0u64; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl64_run_index(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy run original IDs out as a flat u32 array.
+    #[must_use]
+    pub fn run_original_id(&self) -> Vec<u32> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl64_run_original_id_length(self.ptr) };
+        let mut buf = vec![0u32; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl64_run_original_id(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy run transforms out as a flat f64 array (4x3 matrices, 12 doubles each).
+    #[must_use]
+    pub fn run_transform(&self) -> Vec<f64> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl64_run_transform_length(self.ptr) };
+        let mut buf = vec![0.0f64; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl64_run_transform(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy face IDs out as a flat u64 array.
+    #[must_use]
+    pub fn face_id(&self) -> Vec<u64> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl64_face_id_length(self.ptr) };
+        let mut buf = vec![0u64; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl64_face_id(buf.as_mut_ptr(), self.ptr) };
+        buf
+    }
+
+    /// Copy halfedge tangents out as a flat f64 array (4 doubles per halfedge).
+    #[must_use]
+    pub fn halfedge_tangent(&self) -> Vec<f64> {
+        // SAFETY: self.ptr is valid (invariant).
+        let len = unsafe { manifold_meshgl64_tangent_length(self.ptr) };
+        let mut buf = vec![0.0f64; len];
+        // SAFETY: buf has capacity len, self.ptr is valid.
+        unsafe { manifold_meshgl64_halfedge_tangent(buf.as_mut_ptr(), self.ptr) };
+        buf
     }
 }
 

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -1812,98 +1812,131 @@ fn cross_section_operator_xor() {
     assert!(result.area() < 100.0);
 }
 
-// ── MeshGL/MeshGL64 merge tests ────────────────────────────────────────
+// ── MeshGL/MeshGL64 advanced accessors ─────────────────────────────────
 
 #[test]
-fn meshgl_merge() {
+fn meshgl_accessors_return_consistent_lengths() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f32();
     let mesh = MeshGL::new(&verts, n_props, &indices);
-    let merged = mesh.merge();
-    assert!(merged.num_vert() > 0);
-    assert!(merged.num_tri() > 0);
-    // Original should be unaffected.
-    assert_eq!(mesh.num_vert(), verts.len() / n_props);
+    // merge vectors should be paired
+    assert_eq!(mesh.merge_from_vert().len(), mesh.merge_to_vert().len());
+    // face_id is either empty or has one per triangle
+    let fid = mesh.face_id();
+    assert!(fid.is_empty() || fid.len() == mesh.num_tri());
+    // tangents are either empty or 4 floats per halfedge (3 halfedges per tri)
+    let tang = mesh.halfedge_tangent();
+    assert!(tang.is_empty() || tang.len() == mesh.num_tri() * 3 * 4);
 }
 
 #[test]
-fn meshgl64_merge() {
+fn meshgl64_accessors_return_consistent_lengths() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
     let mesh = MeshGL64::new(&verts, n_props, &indices);
-    let merged = mesh.merge();
-    assert!(merged.num_vert() > 0);
-    assert!(merged.num_tri() > 0);
+    assert_eq!(mesh.merge_from_vert().len(), mesh.merge_to_vert().len());
+    let fid = mesh.face_id();
+    assert!(fid.is_empty() || fid.len() == mesh.num_tri());
+    let tang = mesh.halfedge_tangent();
+    assert!(tang.is_empty() || tang.len() == mesh.num_tri() * 3 * 4);
 }
 
 #[test]
-fn meshgl_merge_then_drop_both() {
-    // Regression test: merge() previously caused double-free.
-    let cube = Manifold::cube(5.0, 5.0, 5.0, false);
+fn meshgl_run_accessors_consistent() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, false).as_original();
     let (verts, n_props, indices) = cube.to_mesh_f32();
     let mesh = MeshGL::new(&verts, n_props, &indices);
-    let merged = mesh.merge();
-    drop(mesh);
-    // Merged should still be valid after source is dropped.
-    assert!(merged.num_vert() > 0);
+    let ri = mesh.run_index();
+    let ro = mesh.run_original_id();
+    let rt = mesh.run_transform();
+    // run_index and run_original_id should have the same length
+    assert_eq!(ri.len(), ro.len());
+    // run_transform has 12 floats per run (4x3 matrix)
+    assert!(rt.is_empty() || rt.len() == ri.len() * 12);
 }
 
 #[test]
-fn meshgl64_merge_then_drop_both() {
-    let cube = Manifold::cube(5.0, 5.0, 5.0, false);
+fn meshgl64_run_accessors_consistent() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, false).as_original();
     let (verts, n_props, indices) = cube.to_mesh_f64();
     let mesh = MeshGL64::new(&verts, n_props, &indices);
-    let merged = mesh.merge();
-    drop(mesh);
-    assert!(merged.num_vert() > 0);
+    let ri = mesh.run_index();
+    let ro = mesh.run_original_id();
+    let rt = mesh.run_transform();
+    assert_eq!(ri.len(), ro.len());
+    assert!(rt.is_empty() || rt.len() == ri.len() * 12);
 }
 
-// ── from_sdf_seq tests ─────────────────────────────────────────────────
+// ── Smooth constructors ────────────────────────────────────────────────
 
 #[test]
-fn from_sdf_seq_sphere() {
-    // Same SDF as from_sdf but forced sequential execution.
-    let sphere = Manifold::from_sdf_seq(
-        |x, y, z| (x * x + y * y + z * z).sqrt() - 5.0,
-        ([-6.0, -6.0, -6.0], [6.0, 6.0, 6.0]),
-        0.5,
-        0.0,
-        0.001,
-    );
-    assert!(!sphere.is_empty());
-    // Sequential mode may produce a coarser mesh than parallel; use wide bounds.
-    assert!(
-        sphere.volume() > 200.0,
-        "volume too small: {}",
-        sphere.volume()
-    );
-}
-
-// ── to_mesh_with_normals tests ─────────────────────────────────────────
-
-#[test]
-fn to_mesh_f64_with_normals() {
-    // calculate_normals adds normal properties to the manifold; the _w_normals
-    // export then includes them in the mesh output.
-    let sphere = Manifold::sphere(5.0, 32).calculate_normals(3, 60.0);
-    let (verts_with, n_props_with, _) = sphere.to_mesh_f64_with_normals(3);
-    let (_, n_props_without, _) = sphere.to_mesh_f64();
-    // The _w_normals export should include the normal properties.
-    assert!(
-        n_props_with >= n_props_without,
-        "with_normals n_props ({n_props_with}) < without ({n_props_without})"
-    );
-    assert!(!verts_with.is_empty());
+fn smooth_f64_no_smoothness() {
+    // With empty smoothness arrays, smooth should behave like from_mesh_f64.
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let result = Manifold::smooth_f64(&verts, n_props, &indices, &[], &[]);
+    assert!(result.is_ok());
+    let m = result.unwrap();
+    assert!(!m.is_empty());
+    assert_relative_eq!(m.volume(), 1000.0, epsilon = 1.0);
 }
 
 #[test]
-fn to_mesh_f32_with_normals() {
-    let sphere = Manifold::sphere(5.0, 32).calculate_normals(3, 60.0);
-    let (verts_with, n_props_with, _) = sphere.to_mesh_f32_with_normals(3);
-    let (_, n_props_without, _) = sphere.to_mesh_f32();
-    assert!(
-        n_props_with >= n_props_without,
-        "with_normals n_props ({n_props_with}) < without ({n_props_without})"
-    );
-    assert!(!verts_with.is_empty());
+fn smooth_f32_no_smoothness() {
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f32();
+    let result = Manifold::smooth_f32(&verts, n_props, &indices, &[], &[]);
+    assert!(result.is_ok());
+    let m = result.unwrap();
+    assert!(!m.is_empty());
+}
+
+#[test]
+fn smooth_mismatched_arrays_returns_error() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let result = Manifold::smooth_f64(&verts, n_props, &indices, &[0, 1], &[0.5]);
+    assert!(result.is_err());
+}
+
+// ── CrossSection gaps ──────────────────────────────────────────────────
+
+#[test]
+fn cross_section_from_simple_polygon() {
+    let points = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
+    let cs = CrossSection::from_simple_polygon(&points, FillRule::EvenOdd);
+    assert_relative_eq!(cs.area(), 100.0, epsilon = 0.1);
+}
+
+#[test]
+fn cross_section_hull_simple_polygon() {
+    // L-shape hull should be a convex polygon covering 100 sq units.
+    let points = vec![
+        [0.0, 0.0],
+        [10.0, 0.0],
+        [10.0, 5.0],
+        [5.0, 5.0],
+        [5.0, 10.0],
+        [0.0, 10.0],
+    ];
+    let hull = CrossSection::hull_simple_polygon(&points);
+    assert!(hull.area() >= 75.0); // at least the L-shape area
+    assert!(hull.area() <= 100.5); // at most the bounding box
+}
+
+#[test]
+fn cross_section_hull_polygons() {
+    let polygons = vec![
+        vec![[0.0, 0.0], [5.0, 0.0], [5.0, 5.0], [0.0, 5.0]],
+        vec![[10.0, 10.0], [15.0, 10.0], [15.0, 15.0], [10.0, 15.0]],
+    ];
+    let hull = CrossSection::hull_polygons(&polygons);
+    // Hull of two separated squares should be larger than either
+    assert!(hull.area() > 25.0);
+}
+
+#[test]
+fn cross_section_from_simple_polygon_empty() {
+    let cs = CrossSection::from_simple_polygon(&[], FillRule::EvenOdd);
+    assert!(cs.is_empty());
 }


### PR DESCRIPTION
## Summary
- **Smooth constructors**: `Manifold::smooth_f64()` / `smooth_f32()` — construct smooth manifold from mesh data with per-halfedge smoothness
- **MeshGL/MeshGL64 accessors**: `merge_from_vert`, `merge_to_vert`, `run_index`, `run_original_id`, `run_transform`, `face_id`, `halfedge_tangent` (7 methods × 2 types = 14 new methods)
- **CrossSection gaps**: `from_simple_polygon`, `hull_simple_polygon`, `hull_polygons`

11 new tests (180 → 191 total), API_COVERAGE.md and TODO.md updated.

## Test plan
- [x] `cargo test --features nalgebra` — 191 tests pass
- [x] `cargo clippy --all-targets --features nalgebra -- -D warnings`
- [ ] CI (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)