### PR TITLE
Add generic boolean, MeshGL tangent constructors, and MeshGL64 OBJ I/O

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -33,7 +33,7 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_read_obj` | [`Manifold::from_obj`](crates/manifold-csg/src/manifold.rs#L1063) |
 | `manifold_smooth` | [`Manifold::smooth_f32`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_smooth64` | [`Manifold::smooth_f64`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_level_set_seq` | Not wrapped |
+| `manifold_level_set_seq` | In PR #7 |
 
 ## Manifold — Boolean Operations
 
@@ -42,7 +42,7 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_union` | [`Manifold::union`](crates/manifold-csg/src/manifold.rs#L607), `&a + &b` |
 | `manifold_difference` | [`Manifold::difference`](crates/manifold-csg/src/manifold.rs#L592), `&a - &b` |
 | `manifold_intersection` | [`Manifold::intersection`](crates/manifold-csg/src/manifold.rs#L622), `&a ^ &b` |
-| `manifold_boolean` | Not wrapped |
+| `manifold_boolean` | [`Manifold::boolean`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_batch_boolean` | [`Manifold::batch_union`](crates/manifold-csg/src/manifold.rs#L489), [`batch_difference`](crates/manifold-csg/src/manifold.rs#L495) |
 | `manifold_batch_hull` | [`Manifold::batch_hull`](crates/manifold-csg/src/manifold.rs#L673) |
 | `manifold_split` | [`Manifold::split`](crates/manifold-csg/src/manifold.rs#L859) |
@@ -86,8 +86,8 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_min_gap` | [`Manifold::min_gap`](crates/manifold-csg/src/manifold.rs#L941) |
 | `manifold_status` | Internal |
 | `manifold_as_original` | [`Manifold::as_original`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_manifold_size` | Not wrapped |
-| `manifold_manifold_pair_size` | Not wrapped |
+| `manifold_manifold_size` | Not needed (alloc size) |
+| `manifold_manifold_pair_size` | Not needed (alloc size) |
 
 ## Manifold — Hull, Decomposition & Mesh Extraction
 
@@ -103,8 +103,8 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_get_meshgl` | [`Manifold::to_mesh_f32`](crates/manifold-csg/src/manifold.rs#L235) |
 | `manifold_get_meshgl64` | [`Manifold::to_mesh_f64`](crates/manifold-csg/src/manifold.rs#L197) |
 | `manifold_write_obj` | [`Manifold::to_obj`](crates/manifold-csg/src/manifold.rs#L1082) |
-| `manifold_get_meshgl_w_normals` | Not wrapped |
-| `manifold_get_meshgl64_w_normals` | Not wrapped |
+| `manifold_get_meshgl_w_normals` | In PR #7 |
+| `manifold_get_meshgl64_w_normals` | In PR #7 |
 
 ## CrossSection — Construction & Booleans
 
@@ -118,7 +118,7 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_cross_section_union` | [`CrossSection::union`](crates/manifold-csg/src/cross_section.rs#L166), `&a + &b` |
 | `manifold_cross_section_difference` | [`CrossSection::difference`](crates/manifold-csg/src/cross_section.rs#L176), `&a - &b` |
 | `manifold_cross_section_intersection` | [`CrossSection::intersection`](crates/manifold-csg/src/cross_section.rs#L186), `&a ^ &b` |
-| `manifold_cross_section_boolean` | Not wrapped |
+| `manifold_cross_section_boolean` | [`CrossSection::boolean`](crates/manifold-csg/src/cross_section.rs) |
 | `manifold_cross_section_batch_boolean` | [`CrossSection::batch_boolean`](crates/manifold-csg/src/cross_section.rs#L349), [`batch_union`](crates/manifold-csg/src/cross_section.rs#L376) |
 | `manifold_cross_section_batch_hull` | [`CrossSection::batch_hull`](crates/manifold-csg/src/cross_section.rs#L382) |
 | `manifold_cross_section_hull` | [`CrossSection::hull`](crates/manifold-csg/src/cross_section.rs#L234) |
@@ -146,7 +146,7 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_cross_section_bounds` | [`CrossSection::bounds`](crates/manifold-csg/src/cross_section.rs#L316) |
 | `manifold_cross_section_to_polygons` | [`CrossSection::to_polygons`](crates/manifold-csg/src/cross_section.rs#L479) |
 | `manifold_cross_section_transform` | [`CrossSection::transform`](crates/manifold-csg/src/cross_section.rs) |
-| `manifold_cross_section_size` | Not wrapped |
+| `manifold_cross_section_size` | Not needed (alloc size) |
 
 ## MeshGL (f32) & MeshGL64 (f64)
 
@@ -168,18 +168,18 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_meshgl_tri_length` | Internal |
 | `manifold_meshgl64_vert_properties_length` | Internal |
 | `manifold_meshgl64_tri_length` | Internal |
-| `manifold_meshgl_copy` | Not wrapped |
-| `manifold_meshgl64_copy` | Not wrapped |
+| `manifold_meshgl_copy` | Internal (Clone impl) |
+| `manifold_meshgl64_copy` | Internal (Clone impl) |
 | `manifold_meshgl_w_options` | Not wrapped |
 | `manifold_meshgl64_w_options` | Not wrapped |
-| `manifold_meshgl_w_tangents` | Not wrapped |
-| `manifold_meshgl64_w_tangents` | Not wrapped |
+| `manifold_meshgl_w_tangents` | [`MeshGL::new_with_tangents`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_w_tangents` | [`MeshGL64::new_with_tangents`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_halfedge_tangent` | [`MeshGL::halfedge_tangent`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl64_halfedge_tangent` | [`MeshGL64::halfedge_tangent`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_tangent_length` | Internal |
 | `manifold_meshgl64_tangent_length` | Internal |
-| `manifold_meshgl_merge` | Not wrapped |
-| `manifold_meshgl64_merge` | Not wrapped |
+| `manifold_meshgl_merge` | In PR #7 |
+| `manifold_meshgl64_merge` | In PR #7 |
 | `manifold_meshgl_merge_from_vert` | [`MeshGL::merge_from_vert`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl64_merge_from_vert` | [`MeshGL64::merge_from_vert`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_merge_to_vert` | [`MeshGL::merge_to_vert`](crates/manifold-csg/src/mesh.rs) |
@@ -202,10 +202,10 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_meshgl64_face_id` | [`MeshGL64::face_id`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_face_id_length` | Internal |
 | `manifold_meshgl64_face_id_length` | Internal |
-| `manifold_meshgl_size` | Not wrapped |
-| `manifold_meshgl64_size` | Not wrapped |
-| `manifold_meshgl64_read_obj` | Not wrapped |
-| `manifold_meshgl64_write_obj` | Not wrapped |
+| `manifold_meshgl_size` | Not needed (alloc size) |
+| `manifold_meshgl64_size` | Not needed (alloc size) |
+| `manifold_meshgl64_read_obj` | [`MeshGL64::from_obj`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_write_obj` | [`MeshGL64::to_obj`](crates/manifold-csg/src/mesh.rs) |
 
 ## Triangulation
 
@@ -249,7 +249,7 @@ Fully wrapped via the `BoundingBox` type in `crates/manifold-csg/src/bounding_bo
 | `manifold_box_transform` | [`BoundingBox::transform`](crates/manifold-csg/src/bounding_box.rs) |
 | `manifold_box_translate` | [`BoundingBox::translate`](crates/manifold-csg/src/bounding_box.rs) |
 | `manifold_box_mul` | [`BoundingBox::mul`](crates/manifold-csg/src/bounding_box.rs) |
-| `manifold_box_size` | Not wrapped |
+| `manifold_box_size` | Not needed (alloc size) |
 
 ## Rect2D Operations (`Rect`)
 
@@ -273,7 +273,7 @@ Fully wrapped via the `Rect` type in `crates/manifold-csg/src/rect.rs`.
 | `manifold_rect_transform` | [`Rect::transform`](crates/manifold-csg/src/rect.rs) |
 | `manifold_rect_translate` | [`Rect::translate`](crates/manifold-csg/src/rect.rs) |
 | `manifold_rect_mul` | [`Rect::mul`](crates/manifold-csg/src/rect.rs) |
-| `manifold_rect_size` | Not wrapped |
+| `manifold_rect_size` | Not needed (alloc size) |
 
 ## Polygon Helpers (Internal)
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,8 +18,7 @@
 
 ## Safe wrapper gaps (low priority)
 
-- [ ] MeshGL/MeshGL64 construction with options (`w_options`, `w_tangents`)
-- [ ] MeshGL64 OBJ I/O (`read_obj`, `write_obj`)
+- [ ] MeshGL/MeshGL64 construction with full options (`w_options` — merge vectors + run data)
 
 ## Documentation & Publishing
 

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -322,6 +322,20 @@ impl CrossSection {
         Self { ptr }
     }
 
+    /// Generic boolean operation with an explicit operation type.
+    ///
+    /// Prefer the specific methods ([`union`](Self::union),
+    /// [`difference`](Self::difference), [`intersection`](Self::intersection))
+    /// or operator overloads for readability.
+    #[must_use]
+    pub fn boolean(&self, other: &Self, op: ManifoldOpType) -> Self {
+        // SAFETY: manifold_alloc_cross_section returns a valid handle.
+        let ptr = unsafe { manifold_alloc_cross_section() };
+        // SAFETY: all three pointers are valid.
+        unsafe { manifold_cross_section_boolean(ptr, self.ptr, other.ptr, op) };
+        Self { ptr }
+    }
+
     // ── Offset ──────────────────────────────────────────────────────
 
     /// Inflate (positive delta) or deflate (negative delta) the cross-section.

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -823,6 +823,21 @@ impl Manifold {
         Self { ptr }
     }
 
+    /// Generic boolean operation with an explicit operation type.
+    ///
+    /// Prefer the specific methods ([`union`](Self::union),
+    /// [`difference`](Self::difference), [`intersection`](Self::intersection))
+    /// or operator overloads (`+`, `-`, `^`) for readability. This method
+    /// is useful when the operation type is determined at runtime.
+    #[must_use]
+    pub fn boolean(&self, other: &Self, op: ManifoldOpType) -> Self {
+        // SAFETY: manifold_alloc_manifold returns a valid handle.
+        let ptr = unsafe { manifold_alloc_manifold() };
+        // SAFETY: all three pointers are valid.
+        unsafe { manifold_boolean(ptr, self.ptr, other.ptr, op) };
+        Self { ptr }
+    }
+
     /// Decompose into connected components.
     #[must_use]
     pub fn decompose(&self) -> Vec<Self> {

--- a/crates/manifold-csg/src/mesh.rs
+++ b/crates/manifold-csg/src/mesh.rs
@@ -63,6 +63,44 @@ impl MeshGL {
         Self { ptr }
     }
 
+    /// Create a MeshGL with halfedge tangent data.
+    ///
+    /// `halfedge_tangent` must have `num_tri * 3 * 4` elements (4 floats per
+    /// halfedge, 3 halfedges per triangle).
+    ///
+    /// # Panics
+    ///
+    /// Same as [`new`](Self::new).
+    #[must_use]
+    pub fn new_with_tangents(
+        vert_props: &[f32],
+        n_props: usize,
+        tri_indices: &[u32],
+        halfedge_tangent: &[f32],
+    ) -> Self {
+        assert!(n_props >= 3, "n_props must be >= 3");
+        assert!(vert_props.len() % n_props == 0);
+        assert!(tri_indices.len() % 3 == 0);
+        let n_verts = vert_props.len() / n_props;
+        let n_tris = tri_indices.len() / 3;
+
+        // SAFETY: manifold_alloc_meshgl returns a valid handle.
+        let ptr = unsafe { manifold_alloc_meshgl() };
+        // SAFETY: ptr valid, all slices valid with correct lengths.
+        unsafe {
+            manifold_meshgl_w_tangents(
+                ptr,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+                halfedge_tangent.as_ptr(),
+            );
+        }
+        Self { ptr }
+    }
+
     /// Number of vertices.
     #[must_use]
     pub fn num_vert(&self) -> usize {
@@ -265,6 +303,39 @@ impl MeshGL64 {
         Self { ptr }
     }
 
+    /// Create a MeshGL64 with halfedge tangent data.
+    ///
+    /// See [`MeshGL::new_with_tangents`] for details.
+    #[must_use]
+    pub fn new_with_tangents(
+        vert_props: &[f64],
+        n_props: usize,
+        tri_indices: &[u64],
+        halfedge_tangent: &[f64],
+    ) -> Self {
+        assert!(n_props >= 3, "n_props must be >= 3");
+        assert!(vert_props.len() % n_props == 0);
+        assert!(tri_indices.len() % 3 == 0);
+        let n_verts = vert_props.len() / n_props;
+        let n_tris = tri_indices.len() / 3;
+
+        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
+        let ptr = unsafe { manifold_alloc_meshgl64() };
+        // SAFETY: ptr valid, all slices valid with correct lengths.
+        unsafe {
+            manifold_meshgl64_w_tangents(
+                ptr,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+                halfedge_tangent.as_ptr(),
+            );
+        }
+        Self { ptr }
+    }
+
     /// Number of vertices.
     #[must_use]
     pub fn num_vert(&self) -> usize {
@@ -397,6 +468,40 @@ impl MeshGL64 {
         // SAFETY: buf has capacity len, self.ptr is valid.
         unsafe { manifold_meshgl64_halfedge_tangent(buf.as_mut_ptr(), self.ptr) };
         buf
+    }
+
+    /// Read a MeshGL64 from a Wavefront OBJ string.
+    pub fn from_obj(obj_content: &str) -> Result<Self, crate::types::CsgError> {
+        let c_str = std::ffi::CString::new(obj_content).map_err(|_| {
+            crate::types::CsgError::InvalidInput("OBJ content contains null byte".into())
+        })?;
+        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
+        let ptr = unsafe { manifold_alloc_meshgl64() };
+        // SAFETY: ptr valid from alloc, c_str.as_ptr() is a valid null-terminated string.
+        unsafe { manifold_meshgl64_read_obj(ptr, c_str.as_ptr()) };
+        Ok(Self { ptr })
+    }
+
+    /// Export this mesh as a Wavefront OBJ string.
+    #[must_use]
+    pub fn to_obj(&self) -> String {
+        let mut result = String::new();
+
+        unsafe extern "C" fn callback(data: *mut std::ffi::c_char, ctx: *mut std::ffi::c_void) {
+            // Catch panics to prevent UB from unwinding through C stack frames.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                // SAFETY: ctx was created from a &mut String and is valid for the call.
+                let result = unsafe { &mut *(ctx as *mut String) };
+                // SAFETY: data is a null-terminated C string provided by manifold3d.
+                let c_str = unsafe { std::ffi::CStr::from_ptr(data) };
+                *result = c_str.to_string_lossy().into_owned();
+            }));
+        }
+
+        let ctx = &mut result as *mut String as *mut std::ffi::c_void;
+        // SAFETY: self.ptr is valid (invariant), callback and ctx are valid for the call.
+        unsafe { manifold_meshgl64_write_obj(self.ptr, Some(callback), ctx) };
+        result
     }
 }
 

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -1,6 +1,6 @@
 use approx::assert_relative_eq;
 use manifold_csg::{
-    BoundingBox, CrossSection, FillRule, JoinType, Manifold, MeshGL, MeshGL64, Rect,
+    BoundingBox, CrossSection, FillRule, JoinType, Manifold, MeshGL, MeshGL64, OpType, Rect,
     get_circular_segments, reserve_ids, reset_to_circular_defaults, set_circular_segments,
     set_min_circular_angle, set_min_circular_edge_length, triangulate_polygons,
 };
@@ -1939,4 +1939,67 @@ fn cross_section_hull_polygons() {
 fn cross_section_from_simple_polygon_empty() {
     let cs = CrossSection::from_simple_polygon(&[], FillRule::EvenOdd);
     assert!(cs.is_empty());
+}
+
+// ── Generic boolean ────────────────────────────────────────────────────
+
+#[test]
+fn manifold_boolean_union() {
+    let a = Manifold::cube(10.0, 10.0, 10.0, true);
+    let b = Manifold::cube(10.0, 10.0, 10.0, true).translate(5.0, 0.0, 0.0);
+    let result = a.boolean(&b, OpType::Add);
+    assert!(result.volume() > 1000.0);
+    assert!(result.volume() < 2000.0);
+}
+
+#[test]
+fn cross_section_boolean_subtract() {
+    let a = CrossSection::square(10.0, 10.0, true);
+    let b = CrossSection::square(5.0, 5.0, true);
+    let result = a.boolean(&b, OpType::Subtract);
+    assert_relative_eq!(result.area(), 75.0, epsilon = 0.1);
+}
+
+// ── MeshGL64 OBJ I/O ──────────────────────────────────────────────────
+
+#[test]
+fn meshgl64_obj_round_trip() {
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let mesh = MeshGL64::new(&verts, n_props, &indices);
+    let obj = mesh.to_obj();
+    assert!(!obj.is_empty());
+    assert!(obj.contains("v "));
+    assert!(obj.contains("f "));
+
+    let mesh2 = MeshGL64::from_obj(&obj).unwrap();
+    assert!(mesh2.num_vert() > 0);
+    assert!(mesh2.num_tri() > 0);
+}
+
+// ── MeshGL with tangents ───────────────────────────────────────────────
+
+#[test]
+fn meshgl_new_with_tangents() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f32();
+    let n_tris = indices.len() / 3;
+    // 4 floats per halfedge, 3 halfedges per triangle
+    let tangents = vec![0.0f32; n_tris * 3 * 4];
+    let mesh = MeshGL::new_with_tangents(&verts, n_props, &indices, &tangents);
+    assert_eq!(mesh.num_vert(), verts.len() / n_props);
+    assert_eq!(mesh.num_tri(), n_tris);
+    assert_eq!(mesh.halfedge_tangent().len(), tangents.len());
+}
+
+#[test]
+fn meshgl64_new_with_tangents() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let n_tris = indices.len() / 3;
+    let tangents = vec![0.0f64; n_tris * 3 * 4];
+    let mesh = MeshGL64::new_with_tangents(&verts, n_props, &indices, &tangents);
+    assert_eq!(mesh.num_vert(), verts.len() / n_props);
+    assert_eq!(mesh.num_tri(), n_tris);
+    assert_eq!(mesh.halfedge_tangent().len(), tangents.len());
 }


### PR DESCRIPTION
## Summary
Stacked on #10.

- **Generic boolean**: `Manifold::boolean()` / `CrossSection::boolean()` with runtime `OpType`
- **MeshGL tangent constructors**: `new_with_tangents()` for both MeshGL and MeshGL64
- **MeshGL64 OBJ I/O**: `from_obj()` / `to_obj()` for mesh-level Wavefront import/export
- Marks allocation size queries and Clone internals in API_COVERAGE.md

After this + PR #7 + #10 merge, only `manifold_meshgl_w_options` (advanced construction with merge vectors + run data) remains unwrapped.

5 new tests (191 → 196 total).

## Test plan
- [x] `cargo test --features nalgebra` — 196 tests pass
- [x] `cargo clippy --all-targets --features nalgebra -- -D warnings`
- [ ] CI (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)