### PR TITLE
Fix soundness bugs in FFI callbacks, batch operations, and global setters

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -33,7 +33,7 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_read_obj` | [`Manifold::from_obj`](crates/manifold-csg/src/manifold.rs#L1063) |
 | `manifold_smooth` | [`Manifold::smooth_f32`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_smooth64` | [`Manifold::smooth_f64`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_level_set_seq` | In PR #7 |
+| `manifold_level_set_seq` | [`Manifold::from_sdf_seq`](crates/manifold-csg/src/manifold.rs) |
 
 ## Manifold — Boolean Operations
 
@@ -103,8 +103,8 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_get_meshgl` | [`Manifold::to_mesh_f32`](crates/manifold-csg/src/manifold.rs#L235) |
 | `manifold_get_meshgl64` | [`Manifold::to_mesh_f64`](crates/manifold-csg/src/manifold.rs#L197) |
 | `manifold_write_obj` | [`Manifold::to_obj`](crates/manifold-csg/src/manifold.rs#L1082) |
-| `manifold_get_meshgl_w_normals` | In PR #7 |
-| `manifold_get_meshgl64_w_normals` | In PR #7 |
+| `manifold_get_meshgl_w_normals` | [`Manifold::to_mesh_f32_with_normals`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_get_meshgl64_w_normals` | [`Manifold::to_mesh_f64_with_normals`](crates/manifold-csg/src/manifold.rs) |
 
 ## CrossSection — Construction & Booleans
 
@@ -178,8 +178,8 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_meshgl64_halfedge_tangent` | [`MeshGL64::halfedge_tangent`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_tangent_length` | Internal |
 | `manifold_meshgl64_tangent_length` | Internal |
-| `manifold_meshgl_merge` | In PR #7 |
-| `manifold_meshgl64_merge` | In PR #7 |
+| `manifold_meshgl_merge` | [`MeshGL::merge`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_merge` | [`MeshGL64::merge`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_merge_from_vert` | [`MeshGL::merge_from_vert`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl64_merge_from_vert` | [`MeshGL64::merge_from_vert`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_merge_to_vert` | [`MeshGL::merge_to_vert`](crates/manifold-csg/src/mesh.rs) |

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ cargo test --features nalgebra   # runs the test suite
 
 ## Testing
 
-107+ integration tests covering primitives, booleans, transforms, mesh
+196 integration tests covering primitives, booleans, transforms, mesh
 round-trips, plane operations, slicing, 2D cross-sections, extrusion,
 triangulation, callback APIs (warp, SDF, OBJ I/O, set_properties), `Send`
 safety, and f64 precision. The test suite runs on Linux, macOS, and Windows

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -553,6 +553,8 @@ impl CrossSection {
             unsafe { manifold_cross_section_copy(copy_ptr, cs.ptr) };
             // SAFETY: vec_ptr is valid, copy_ptr is a valid cross-section.
             unsafe { manifold_cross_section_vec_push_back(vec_ptr, copy_ptr) };
+            // SAFETY: push_back copies the value; free the temporary allocation.
+            unsafe { manifold_delete_cross_section(copy_ptr) };
         }
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };
@@ -586,6 +588,8 @@ impl CrossSection {
             unsafe { manifold_cross_section_copy(copy_ptr, cs.ptr) };
             // SAFETY: vec_ptr is valid, copy_ptr is a valid cross-section.
             unsafe { manifold_cross_section_vec_push_back(vec_ptr, copy_ptr) };
+            // SAFETY: push_back copies the value; free the temporary allocation.
+            unsafe { manifold_delete_cross_section(copy_ptr) };
         }
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };
@@ -610,6 +614,8 @@ impl CrossSection {
             unsafe { manifold_cross_section_copy(copy_ptr, cs.ptr) };
             // SAFETY: vec_ptr is valid, copy_ptr is a valid cross-section.
             unsafe { manifold_cross_section_vec_push_back(vec_ptr, copy_ptr) };
+            // SAFETY: push_back copies the value; free the temporary allocation.
+            unsafe { manifold_delete_cross_section(copy_ptr) };
         }
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -710,6 +710,8 @@ impl Manifold {
             unsafe { manifold_copy(copy_ptr, m.ptr) };
             // SAFETY: vec_ptr is valid, copy_ptr is a valid manifold.
             unsafe { manifold_manifold_vec_push_back(vec_ptr, copy_ptr) };
+            // SAFETY: push_back copies the value; free the temporary allocation.
+            unsafe { manifold_delete_manifold(copy_ptr) };
         }
 
         // SAFETY: manifold_alloc_manifold returns a valid handle.
@@ -891,6 +893,8 @@ impl Manifold {
             unsafe { manifold_copy(copy_ptr, m.ptr) };
             // SAFETY: vec_ptr is valid, copy_ptr is a valid manifold.
             unsafe { manifold_manifold_vec_push_back(vec_ptr, copy_ptr) };
+            // SAFETY: push_back copies the value; free the temporary allocation.
+            unsafe { manifold_delete_manifold(copy_ptr) };
         }
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
@@ -1068,6 +1072,8 @@ impl Manifold {
             unsafe { manifold_copy(copy_ptr, m.ptr) };
             // SAFETY: vec_ptr is valid, copy_ptr is a valid manifold.
             unsafe { manifold_manifold_vec_push_back(vec_ptr, copy_ptr) };
+            // SAFETY: push_back copies the value; free the temporary allocation.
+            unsafe { manifold_delete_manifold(copy_ptr) };
         }
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
@@ -1258,12 +1264,16 @@ impl Manifold {
     /// - `position`: the vertex position `[x, y, z]`
     /// - `old_props`: the existing properties (length = current `self.num_prop()`)
     #[must_use]
-    pub fn set_properties<F>(&self, num_prop: i32, mut f: F) -> Self
+    pub fn set_properties<F>(&self, num_prop: usize, mut f: F) -> Self
     where
         F: FnMut(&mut [f64], [f64; 3], &[f64]),
     {
+        assert!(
+            num_prop <= i32::MAX as usize,
+            "num_prop must fit in i32 for the C API"
+        );
         let old_num_prop = self.num_prop();
-        let new_num_prop = num_prop as usize;
+        let new_num_prop = num_prop;
 
         struct Context<'a, F> {
             f: &'a mut F,
@@ -1288,6 +1298,9 @@ impl Manifold {
                 // SAFETY: new_prop has ctx.new_num_prop elements (guaranteed by C API).
                 let new_slice =
                     unsafe { std::slice::from_raw_parts_mut(new_prop, ctx.new_num_prop) };
+                // Zero the output buffer so panics in the closure don't leave
+                // uninitialized memory in the manifold's property data.
+                new_slice.fill(0.0);
                 // SAFETY: old_prop may be null if the manifold has no custom properties.
                 // When non-null, it has ctx.old_num_prop elements (guaranteed by C API).
                 let old_slice = if old_prop.is_null() {
@@ -1309,7 +1322,16 @@ impl Manifold {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: ptr valid, self.ptr valid (invariant), trampoline+ctx valid for call duration.
-        unsafe { manifold_set_properties(ptr, self.ptr, num_prop, Some(trampoline::<F>), ctx_ptr) };
+        // SAFETY: num_prop fits in c_int (checked by assert above).
+        unsafe {
+            manifold_set_properties(
+                ptr,
+                self.ptr,
+                num_prop as std::ffi::c_int,
+                Some(trampoline::<F>),
+                ctx_ptr,
+            )
+        };
         Self { ptr }
     }
 
@@ -1370,14 +1392,14 @@ impl Manifold {
     /// * `tolerance` - tolerance for surface accuracy
     #[must_use]
     pub fn from_sdf<F>(
-        mut f: F,
+        f: F,
         bounds: ([f64; 3], [f64; 3]),
         edge_length: f64,
         level: f64,
         tolerance: f64,
     ) -> Self
     where
-        F: FnMut(f64, f64, f64) -> f64,
+        F: Fn(f64, f64, f64) -> f64 + Sync,
     {
         unsafe extern "C" fn trampoline<F>(
             x: f64,
@@ -1386,19 +1408,20 @@ impl Manifold {
             ctx: *mut std::ffi::c_void,
         ) -> f64
         where
-            F: FnMut(f64, f64, f64) -> f64,
+            F: Fn(f64, f64, f64) -> f64 + Sync,
         {
             // Catch panics to prevent UB from unwinding through C stack frames.
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                // SAFETY: ctx was created from a &mut F and is valid for the call duration.
-                let f = unsafe { &mut *(ctx as *mut F) };
+                // SAFETY: ctx points to an F that is Sync, so shared access
+                // from multiple C threads is sound.
+                let f = unsafe { &*(ctx as *const F) };
                 f(x, y, z)
             }));
             // Return large positive distance on panic (outside surface).
             result.unwrap_or(f64::MAX)
         }
 
-        let ctx = &mut f as *mut F as *mut std::ffi::c_void;
+        let ctx = &f as *const F as *mut std::ffi::c_void;
         // SAFETY: manifold_alloc_box returns a valid handle.
         let box_ptr = unsafe { manifold_alloc_box() };
         // SAFETY: box_ptr is valid from alloc.
@@ -1635,36 +1658,47 @@ impl Manifold {
 
 // ── Quality globals ─────────────────────────────────────────────────────
 
+/// Guard for global quality setters. The C API's global state is not
+/// thread-safe, so we serialize access from the Rust side.
+static QUALITY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Set the minimum circular angle (degrees) for tessellation.
 ///
-/// **Warning:** This modifies global state shared by all manifold operations
-/// in the current process. Not thread-safe.
+/// This modifies global state shared by all manifold operations in the
+/// current process.
 pub fn set_min_circular_angle(degrees: f64) {
-    // SAFETY: This is a global state setter with no pointer invariants.
+    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
     unsafe { manifold_set_min_circular_angle(degrees) };
 }
 
 /// Set the minimum circular edge length for tessellation.
 ///
-/// **Warning:** This modifies global state.
+/// This modifies global state shared by all manifold operations in the
+/// current process.
 pub fn set_min_circular_edge_length(length: f64) {
-    // SAFETY: This is a global state setter with no pointer invariants.
+    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
     unsafe { manifold_set_min_circular_edge_length(length) };
 }
 
 /// Set the number of circular segments for tessellation.
 ///
-/// **Warning:** This modifies global state.
+/// This modifies global state shared by all manifold operations in the
+/// current process.
 pub fn set_circular_segments(number: i32) {
-    // SAFETY: This is a global state setter with no pointer invariants.
+    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
     unsafe { manifold_set_circular_segments(number) };
 }
 
 /// Reset circular tessellation parameters to defaults.
 ///
-/// **Warning:** This modifies global state.
+/// This modifies global state shared by all manifold operations in the
+/// current process.
 pub fn reset_to_circular_defaults() {
-    // SAFETY: This is a global state setter with no pointer invariants.
+    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
     unsafe { manifold_reset_to_circular_defaults() };
 }
 

--- a/crates/manifold-csg/src/triangulation.rs
+++ b/crates/manifold-csg/src/triangulation.rs
@@ -44,7 +44,7 @@ pub fn triangulate_polygons(polygons: &[Vec<[f64; 2]>], epsilon: f64) -> Option<
             .map(|c| {
                 // The C API returns non-negative indices into the vertex array.
                 // Validate to catch any upstream bugs rather than silently wrapping.
-                debug_assert!(
+                assert!(
                     c[0] >= 0 && c[1] >= 0 && c[2] >= 0,
                     "negative triangle index from C API"
                 );


### PR DESCRIPTION
## Summary

**Soundness fixes (UB from safe code):**
- `from_sdf` data race — the parallel C callback was invoked from multiple threads but the closure was `FnMut` (exclusive access). Changed to `Fn + Sync` for safe shared access.
- Memory leak in all 6 batch/compose/hull operations — `push_back` copies the value into the C++ vector but the temporary allocation was never freed.
- `set_properties` accepted `i32` for `num_prop` — negative values wrapped to `usize::MAX` in `slice::from_raw_parts_mut`. Changed to `usize` with bounds check.

**Safety hardening:**
- Triangulation `debug_assert` for negative indices → `assert` (was no-op in release builds)
- Global quality setters serialized with `Mutex` (C-side globals are not thread-safe)
- `set_properties` callback zeros output buffer before calling user closure (panic safety)

**Docs:**
- API_COVERAGE.md — fix stale entries with proper wrapper links
- README test count updated (107 → 196)

## Test plan
- [x] `cargo test --features nalgebra` — 196 tests pass
- [x] `cargo clippy --all-targets --features nalgebra -- -D warnings`
- [ ] CI (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)