### PR TITLE
Pre-publish cleanup: Sync for all types, docs, and review skill

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: review
+description: Run a deep code review across the manifold-csg crates
+user-invocable: true
+---
+
+# Review
+
+Run a thorough code review of the manifold-csg workspace. Check all `crates/` source files.
+
+## Arguments
+
+- No arguments: review the entire codebase
+- A file path or glob: review only matching files (e.g., `crates/manifold-csg/src/manifold.rs`)
+- `since release`: review only files changed since the last release tag (use `git diff --name-only $(git describe --tags --abbrev=0)..HEAD -- '*.rs'` to get the list)
+- `staged`: review only staged files (`git diff --cached --name-only -- '*.rs'`)
+- `branch`: review only files changed on the current branch vs `main` (`git diff --name-only main...HEAD -- '*.rs'`)
+
+## Review Categories
+
+Work through each category in order. For each finding, cite the file and line number.
+
+### 1. Idiomatic Rust
+
+Review as the pickiest expert Rust reviewer. Look for:
+- Anti-patterns and non-idiomatic code
+- Misuse of language features (lifetimes, traits, enums, error handling)
+- Places where `Result` should replace `bool`/`Option`, enums should replace strings, named structs should replace tuples
+- Missing standard trait implementations (Display, From, Default, etc.)
+- Unnecessary clones, allocations, or copies
+- Iterator chains that could replace manual loops
+
+### 2. Code Smells
+
+- Dead code (unused functions, imports, fields, variants)
+- Duplicate code — check across crates, not just within files
+- Functions that are too long or do too many things
+- Refactoring opportunities (extract function, simplify conditionals)
+- Magic numbers that should be named constants
+- Stale comments — references to upstream PR/issue numbers or transient implementation details that will go stale. These belong in CLAUDE.md or API_COVERAGE.md, not code comments.
+- Stale docs — hardcoded counts (test count, function count, version numbers) in README or API_COVERAGE.md that will go stale on the next change. Prefer prose over numbers, or make them easy to regenerate.
+
+### 3. FFI Safety & Resource Management
+
+This is the highest-risk area for a bindings crate. Verify:
+- Every C allocation (`manifold_alloc_*`) is paired with deallocation (`manifold_delete_*`) on ALL paths including error returns and panics
+- `Drop` implementations null-check before freeing
+- No double-free paths — verify ownership transfer semantics in batch operations, decompose, etc.
+- `unsafe impl Send` — justification still valid? Check upstream C++ for any new thread-local state or shared mutable state
+- `unsafe impl Sync` — verify the justification holds. Check that whatever synchronization mechanism upstream uses (carry-patch or merged) is actually present in the pinned commit or applied via patch.
+- No panic-across-FFI risk — if a Rust panic unwinds through C frames, it's UB. Check that all FFI callback trampolines use `catch_unwind`
+- Integer casts at the FFI boundary (u32↔u64, usize→c_int) — check for truncation/overflow
+- Pointer validity — every raw pointer dereference must have a preceding validity argument (allocation or invariant)
+- Buffer size correctness — when copying data out via length+copy accessor pairs, verify buffer sizes match what the C API expects
+- `ManifoldManifoldPair` — verify both returned pointers are always consumed (no leak if caller ignores one half of a split)
+- Mutable FFI methods (those taking `*mut`) — verify the safe wrapper requires `&mut self` to prevent aliasing
+
+### 4. Numerical Precision
+
+Precision is our key differentiator (f64/MeshGL64). Verify:
+- f64 precision is used by default everywhere — no accidental f32 narrowing
+- f32 code paths are clearly documented as lossy
+- No unnecessary f64→f32→f64 round-trips in internal code paths
+- Operations that bridge CrossSection↔Manifold don't silently lose precision through intermediate representations
+- Tolerance/epsilon values are documented and appropriate
+
+### 5. API Completeness
+
+We bind the manifold3d C API (pinned to a specific upstream commit in `build.rs`). The review focus is on **maintaining** completeness.
+
+**Sys crate vs upstream header:**
+- Find the built C header (`manifoldc.h`) under `target/*/build/manifold-csg-sys-*/out/` and diff against `manifold-csg-sys/src/lib.rs`
+- Check for newly added C API functions that need binding
+- Verify all function signatures still match the header — ABI drift from upstream changes
+
+**Safe wrapper coverage:**
+- For every function group bound in the sys crate, verify there is a corresponding safe method. Flag sys-level functions that have no safe wrapper yet. Prioritize by usefulness.
+- Are all callback-based APIs wrapped safely with `catch_unwind`?
+- Are all MeshGL/MeshGL64 accessors exposed through the safe types?
+- Are the quality globals exposed and documented as affecting global state?
+
+**Feature flag coverage:**
+- Does the `nalgebra` feature cover all methods that take/return geometric types?
+- Are there other popular geometry crates that should have optional integration?
+
+### 6. API Ergonomics
+
+Review the safe API from a user's perspective:
+- Are method signatures intuitive? Would a first-time user understand the parameter order?
+- Are there missing convenience methods?
+- Should any methods accept `impl Into<T>` for flexibility?
+- Are builder patterns appropriate anywhere?
+- Error types — are they specific enough to be actionable?
+- Does the re-export structure in `lib.rs` give users a clean import experience?
+- Are operator overloads discoverable and documented?
+
+**C/C++ API parity (many users will transition from the C/C++ library):**
+- Compare parameter order and types against the C header. Flag reordering, renamed parameters, or hidden defaults that would surprise a C/C++ user.
+- Check that optional/defaulted parameters match C API defaults. If a wrapper omits a C parameter, verify there's a sensible default or `_with_options` variant.
+- Check consistency: do similar functions handle the same parameter the same way?
+- Where Rust packs multiple C params into an array (e.g., `normal: [f64; 3]` instead of `nx, ny, nz`), verify this is documented
+
+### 7. Test Coverage & Quality
+
+Assess the test suite:
+- Untested public functions — every public method should have at least one test
+- Edge cases — empty inputs, zero-size primitives, very large/small values, degenerate geometry
+- Negative testing — do error paths get exercised?
+- Thread safety — is Send tested with actual thread spawning? Is Sync tested with concurrent reads?
+- Round-trip fidelity — are mesh export→import round-trips tested for volume/vertex preservation?
+- Test isolation — do tests depend on execution order or shared mutable state?
+- Assertion quality — are tests checking meaningful properties or just "doesn't panic"?
+
+### 8. Examples & Documentation Artifacts
+
+**Examples:**
+- Do all examples compile and run? (`cargo run -p manifold-csg --example <name>`)
+- Do examples cover the main entry points?
+- Are examples free of unexplained `unwrap()`?
+
+**API_COVERAGE.md:**
+- Does it account for every function in the sys crate?
+- Are safe wrapper links accurate?
+- Does the summary count match the detailed tables?
+
+**README:**
+- Are feature descriptions accurate? (e.g., Send/Sync, f64 default, test count, upstream version)
+- Do quick-start examples compile?
+- Are links valid?
+- MSRV, platform support, and build requirements documented?
+- Badges present and pointing to the right crate/repo?
+
+**Docstrings:**
+- Do all main types (`Manifold`, `CrossSection`, `MeshGL`, `MeshGL64`) link to the upstream manifold3d API docs so users can understand parameter semantics?
+- Does the crate-level doc (`lib.rs`) link to upstream?
+- Run `cargo doc --no-deps` — any warnings?
+- Are methods with non-obvious parameters (e.g., `normal_idx`, `min_sharp_angle`, column-major matrices) documented well enough that a user doesn't have to read C++ headers?
+
+### 9. Packaging & Publishing Correctness
+
+**Versioning (see CLAUDE.md for the scheme):**
+- Verify sys crate version matches the upstream pin
+- Verify safe crate dependency pins the correct sys version
+- Sys patch bumps must be semver-compatible (additions only). Flag any violations.
+
+**Cargo.toml correctness:**
+- `description`, `readme`, `keywords`, `categories` — present and accurate
+- `package.exclude` / `package.include` — no test fixtures or build artifacts in published crate
+- `links` key in sys crate — correctly set
+
+**Publishing readiness:**
+- `cargo publish --dry-run` for both crates — does it succeed?
+- Crate size — reasonably small? (no vendored C++ source)
+- License files present and referenced
+
+**API stability audit (pre-publish):**
+- Flag any public API that feels provisional or likely to change — hard to undo after publishing
+- Are there methods that should be `pub(crate)` instead of `pub`?
+- Are return types locked in appropriately?
+
+**Dependency hygiene:**
+- `cargo update --dry-run` — anything to bump?
+- Dev-dependencies correctly scoped?
+- Feature flags complete?
+
+**Documentation:**
+- Crate-level `//!` docs present with examples
+- Doc-tests — can any `rust,ignore` tests be made runnable?
+
+### 10. Upstream Compatibility & Carry-Patches
+
+This crate tracks manifold3d upstream, pinning to a specific commit SHA.
+
+**Pinned commit:**
+- Is the pinned SHA still on upstream's master branch (not reverted)?
+- What's the latest upstream release tag? How far ahead/behind are we?
+- Have any upstream changes since our pin affected the C API?
+
+**Carry-patches (`crates/manifold-csg-sys/patches/`):**
+- List all current patches. For each:
+  - Has the upstream PR been merged? If so, is it included in our pinned commit? (Can be removed if yes.)
+  - Does the patch still apply cleanly?
+  - Is any safety justification in our code (e.g., `unsafe impl Sync`) dependent on this patch?
+- Are there upstream fixes we need that aren't in our pin or patches?
+
+**Known upstream bugs:**
+- Check manifold3d issues for bugs affecting functions we bind
+- Note any upstream error status propagation issues that affect our safe wrappers
+
+### 11. Dependency Audit
+
+- Cargo dependencies at latest? (`cargo update --dry-run`)
+- C++ dependencies — check upstream releases for newer versions. Manifold pulls Clipper2 and TBB via CMake FetchContent.
+- License concerns — warn on any copyleft/viral license
+- Unnecessary or redundant dependencies
+
+### 12. Cross-Platform & CI
+
+- Does the build work on all platforms? Check CI results.
+- Are there platform-specific code paths in `build.rs`?
+- Does CI test with and without the `parallel` feature?
+- Does CI test the declared MSRV?
+- Are there CI jobs that should exist but don't?
+
+## Output Format
+
+Group findings by category. For each finding:
+
+```
+**[Category] file.rs:123** — Short description of the issue.
+Suggested fix or explanation.
+```
+
+Assign each finding a severity:
+- **error**: Correctness bug, unsoundness, undefined behavior, memory safety violation
+- **warning**: Likely bug, missing safety check, precision loss, incomplete API
+- **note**: Style, ergonomics, documentation, nice-to-have improvement
+
+At the end, provide a summary: total findings per category, severity breakdown (error/warning/note), and recommended priority order for fixes.
+
+If a category has zero findings, say so explicitly — don't skip it silently.

--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -365,11 +365,6 @@ and `Drop` implementations.
 | Alloc/delete/destruct | 0 | 24 |
 | **Total** | **152** | **49** |
 
-The 71 unwrapped functions are primarily:
-- MeshGL advanced accessors (merge tables, run tables, face IDs, tangents) — 34 functions
-- Allocation infrastructure (`destruct_*` variants, unused vec ops) — 18 functions
-- Specialized variants (smooth constructors, mesh normals export) — 9 functions
-- Internal size queries — 10 functions
-
-All operations commonly needed for CSG workflows (primitives, booleans, transforms,
-mesh I/O, extrusion, hull, slicing, SDF, spatial queries) have safe wrappers.
+Unwrapped functions are primarily allocation infrastructure (`destruct_*` variants,
+unused vector ops), internal size queries, and specialized construction variants.
+All operations commonly needed for CSG workflows have safe wrappers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,10 @@ The sys crate clones manifold3d (pinned to a specific commit on master, post-v3.
 
 ## Versioning
 
-- **`manifold-csg-sys`** uses version `{major}.{minor}.{patch}` where major.minor tracks the upstream manifold3d version and patch >= 100 is our release number. For example, `3.4.100` tracks manifold3d v3.4.1, and `3.4.101` would be our next release against the same upstream.
+- **`manifold-csg-sys`** uses version `{major}.{minor}.{patch}` where major.minor tracks the upstream manifold3d version and patch >= 100 is our release number. For example, `3.4.100` tracks manifold3d v3.4.1, and `3.4.101` would be our next release against the same upstream. Patch bumps (e.g., `3.4.101` → `3.4.102`) must be semver-compatible: no removed or changed function signatures, only additions.
 - **`manifold-csg`** uses standard semver (`0.1.0`, etc.) independent of the upstream version. Its `Cargo.toml` pins the sys crate version it depends on.
 - When bumping the manifold3d pin in `build.rs`, the sys crate version must be updated to match (e.g., manifold3d v3.5.0 -> sys crate `3.5.100`).
+- The sys crate pins upstream to a specific commit SHA rather than a tag. This is necessary because upstream doesn't follow strict semver — minor releases can include breaking changes. Pinning to a commit gives us the same reproducibility as a tag, while allowing us to pick up post-release fixes and carry-patches between releases.
 
 ## Key design decisions
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # manifold-csg
 
-> **Note:** This crate is not yet published to crates.io. The API may change before the first release.
+[![crates.io](https://img.shields.io/crates/v/manifold-csg.svg)](https://crates.io/crates/manifold-csg)
+[![docs.rs](https://docs.rs/manifold-csg/badge.svg)](https://docs.rs/manifold-csg)
+[![CI](https://github.com/zmerlynn/manifold-csg/actions/workflows/ci.yml/badge.svg)](https://github.com/zmerlynn/manifold-csg/actions/workflows/ci.yml)
 
 Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold)
 geometry kernel for constructive solid geometry (CSG).
 
 manifold3d is a fast, robust C++ library for boolean operations on 3D triangle
-meshes. These bindings aim to make its capabilities accessible from Rust with
-minimal overhead and without requiring users to manage C pointers or memory.
+meshes. These bindings make its capabilities accessible from Rust with minimal
+overhead and without requiring users to manage C pointers or memory. See the
+[upstream documentation](https://elalish.github.io/manifold/docs/html/) for
+details on the underlying algorithms and behavior.
 
 ## What's included
 
-**`manifold-csg-sys`** provides raw FFI bindings to the complete manifold3d
-v3.4.1 C API — all 256 functions, types, and enums. If you need direct C-level
-control, it's there.
+**`manifold-csg-sys`** provides raw FFI bindings to the manifold3d C API. If
+you need direct C-level control, it's there.
 
 **`manifold-csg`** wraps the most commonly needed operations in safe Rust:
 
@@ -40,15 +43,15 @@ to its safe wrapper (or noting where one doesn't exist yet).
 - **f64 by default.** Mesh I/O uses `MeshGL64` so you don't lose precision
   through f32 round-trips. f32 paths (`from_mesh_f32`, `to_mesh_f32`, `MeshGL`)
   are available when you need them.
-- **`Send` but not `Sync`.** Manifold and CrossSection objects can move between
-  threads but shouldn't be shared — the C++ internals have mutable lazy state
-  that isn't safe for concurrent reads.
+- **`Send` + `Sync`.** All types can be moved across threads and shared for
+  concurrent reads.
 - **Automatic memory management.** All C handles are freed via `Drop`. No manual
   cleanup needed.
 - **Operator overloads.** `&a + &b` (union), `&a - &b` (difference), `&a ^ &b`
   (intersection) work on both `Manifold` and `CrossSection`.
 - **Callback-based APIs wrapped safely.** `warp`, `set_properties`, `from_sdf`,
-  and OBJ I/O all accept closures.
+  and OBJ I/O all accept closures with `catch_unwind` to prevent panics from
+  unwinding through C stack frames.
 - **C API parity.** Parameter order and names follow the C API so users
   transitioning from C/C++ find things where they expect.
 
@@ -81,14 +84,17 @@ complete, runnable examples.
 
 ## Build requirements
 
+- Rust 1.85+
 - git, cmake, a C++ compiler
-- First build clones manifold3d v3.4.1 and compiles it; subsequent builds use
-  the cached copy
+- First build clones manifold3d and compiles it from source; subsequent builds
+  use the cached copy. Internet access is required for the initial clone.
 
 ```sh
 cargo build           # builds both crates
 cargo test --features nalgebra   # runs the test suite
 ```
+
+Tested on Linux, macOS, and Windows.
 
 ## Feature flags
 
@@ -97,20 +103,14 @@ cargo test --features nalgebra   # runs the test suite
 | `parallel` | yes | Enables TBB-based parallelism for boolean operations |
 | `nalgebra` | no | Adds convenience methods that accept `nalgebra::Matrix3`, `Vector3`, `Point3` |
 
-## Testing
-
-196 integration tests covering primitives, booleans, transforms, mesh
-round-trips, plane operations, slicing, 2D cross-sections, extrusion,
-triangulation, callback APIs (warp, SDF, OBJ I/O, set_properties), `Send`
-safety, and f64 precision. The test suite runs on Linux, macOS, and Windows
-in CI.
-
 ## Documentation
 
 - **[API_COVERAGE.md](API_COVERAGE.md)** — maps every manifold3d C function to
   its safe wrapper, with source links
-- **[docs.rs](https://docs.rs/manifold-csg)** — generated API docs (once published)
+- **[docs.rs](https://docs.rs/manifold-csg)** — generated API docs
 - **[examples/](crates/manifold-csg/examples/)** — runnable code examples
+- **[Upstream docs](https://elalish.github.io/manifold/docs/html/)** — manifold3d
+  C++ API documentation (helpful for understanding parameter semantics)
 
 ## License
 

--- a/crates/manifold-csg/src/bounding_box.rs
+++ b/crates/manifold-csg/src/bounding_box.rs
@@ -18,6 +18,10 @@ pub struct BoundingBox {
 // so transferring ownership across threads is safe.
 unsafe impl Send for BoundingBox {}
 
+// SAFETY: BoundingBox is a simple value type (two vec3s) with no lazy evaluation
+// or mutable internal state. Concurrent read access is safe.
+unsafe impl Sync for BoundingBox {}
+
 impl Clone for BoundingBox {
     fn clone(&self) -> Self {
         Self::new(self.min(), self.max())

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -90,6 +90,9 @@ impl Default for Rect2 {
 /// Represents a 2D region suitable for Boolean operations, offsetting,
 /// and extrusion to 3D. Memory is automatically freed when dropped.
 ///
+/// See the [upstream `CrossSection` docs](https://elalish.github.io/manifold/docs/html/classmanifold_1_1_cross_section.html)
+/// for details on the underlying algorithms and parameter semantics.
+///
 /// # Example
 ///
 /// ```rust,ignore

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -1,7 +1,9 @@
 //! Safe Rust bindings to [manifold3d](https://github.com/elalish/manifold) —
 //! a geometry kernel for constructive solid geometry (CSG).
 //!
-//! This crate provides safe, ergonomic wrappers around the manifold3d C API:
+//! This crate provides safe, ergonomic wrappers around the manifold3d C API.
+//! For details on the underlying algorithms and behavior, see the
+//! [upstream documentation](https://elalish.github.io/manifold/docs/html/).
 //!
 //! - [`Manifold`] — 3D solid with boolean operations (union, difference, intersection)
 //! - [`CrossSection`] — 2D region with offset, boolean, and hull operations
@@ -11,7 +13,7 @@
 //! # Key features
 //!
 //! - **f64 precision**: Uses MeshGL64 to avoid f32 precision loss
-//! - **`Send` + `Sync` safe**: Manifolds can be moved across threads and shared for concurrent reads
+//! - **`Send` + `Sync` safe**: All types can be moved across threads and shared for concurrent reads
 //! - **Memory safe**: All C handles are freed automatically via `Drop`
 
 pub mod bounding_box;

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -30,6 +30,9 @@ use crate::types::CsgError;
 ///
 /// Represents a closed, manifold 3D solid suitable for Boolean operations.
 /// Memory is automatically freed when the value is dropped.
+///
+/// See the [upstream `Manifold` docs](https://elalish.github.io/manifold/docs/html/classmanifold_1_1_manifold.html)
+/// for details on the underlying algorithms and parameter semantics.
 pub struct Manifold {
     pub(crate) ptr: *mut ManifoldManifold,
 }

--- a/crates/manifold-csg/src/mesh.rs
+++ b/crates/manifold-csg/src/mesh.rs
@@ -7,6 +7,9 @@
 use manifold_csg_sys::*;
 
 /// Safe wrapper around a manifold3d MeshGL object (f32 vertices, u32 indices).
+///
+/// See the [upstream `MeshGL` docs](https://elalish.github.io/manifold/docs/html/structmanifold_1_1_mesh_g_l_p.html)
+/// for field semantics (run indices, merge vectors, tangents, etc.).
 pub struct MeshGL {
     ptr: *mut ManifoldMeshGL,
 }
@@ -289,6 +292,9 @@ impl Clone for MeshGL {
 ///
 /// This is the high-precision variant — use this when sub-mm features matter
 /// at large coordinates (e.g., 0.6mm indents at z=128mm).
+///
+/// See the [upstream `MeshGL` docs](https://elalish.github.io/manifold/docs/html/structmanifold_1_1_mesh_g_l_p.html)
+/// for field semantics (run indices, merge vectors, tangents, etc.).
 pub struct MeshGL64 {
     ptr: *mut ManifoldMeshGL64,
 }

--- a/crates/manifold-csg/src/rect.rs
+++ b/crates/manifold-csg/src/rect.rs
@@ -18,6 +18,10 @@ pub struct Rect {
 // so transferring ownership across threads is safe.
 unsafe impl Send for Rect {}
 
+// SAFETY: Rect is a simple value type (two vec2s) with no lazy evaluation
+// or mutable internal state. Concurrent read access is safe.
+unsafe impl Sync for Rect {}
+
 impl Clone for Rect {
     fn clone(&self) -> Self {
         Self::new(self.min(), self.max())

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -1457,6 +1457,54 @@ fn meshgl64_send_across_thread() {
     assert!(nv > 0);
 }
 
+// ── Binding-specific: Sync (concurrent shared reads) ───────────────────
+
+#[test]
+fn manifold_sync_concurrent_reads() {
+    let cube = std::sync::Arc::new(Manifold::cube(10.0, 10.0, 10.0, true));
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let c = std::sync::Arc::clone(&cube);
+            std::thread::spawn(move || c.volume())
+        })
+        .collect();
+    for h in handles {
+        let vol = h.join().unwrap();
+        assert_relative_eq!(vol, 1000.0, epsilon = 1.0);
+    }
+}
+
+#[test]
+fn cross_section_sync_concurrent_reads() {
+    let cs = std::sync::Arc::new(CrossSection::square(10.0, 10.0, false));
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let c = std::sync::Arc::clone(&cs);
+            std::thread::spawn(move || c.area())
+        })
+        .collect();
+    for h in handles {
+        let area = h.join().unwrap();
+        assert_relative_eq!(area, 100.0, epsilon = 1.0);
+    }
+}
+
+#[test]
+fn meshgl64_sync_concurrent_reads() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let mesh = std::sync::Arc::new(MeshGL64::new(&verts, n_props, &indices));
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let m = std::sync::Arc::clone(&mesh);
+            std::thread::spawn(move || m.num_vert())
+        })
+        .collect();
+    for h in handles {
+        assert!(h.join().unwrap() > 0);
+    }
+}
+
 // ── Binding-specific: FFI data integrity ───────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Implement `Sync` for `BoundingBox` and `Rect` (simple value types, consistent with Manifold/CrossSection/MeshGL)
- Add concurrent read tests for `Manifold`, `CrossSection`, and `MeshGL64` via `Arc` + multiple threads
- Add upstream manifold3d doc links to all main type docstrings (`Manifold`, `CrossSection`, `MeshGL`, `MeshGL64`) and crate-level docs
- README: fix Send+Sync, remove stale version/count references, add MSRV, badges, platform support, upstream doc link
- API_COVERAGE.md: remove brittle function-count blurb
- Review skill: add docstring quality and stale-docs checks

## Test plan

- [x] `cargo test --features nalgebra` — 209 tests pass (3 new Sync tests)
- [x] `cargo doc --no-deps` — no warnings
- [x] `cargo clippy --features nalgebra -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)