### PR TITLE
Bump manifold-csg to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"


### PR DESCRIPTION
## Summary

- Bump `manifold-csg` 0.1.1 → 0.1.2 for the Sync additions in #15

## Test plan

- [x] Version-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)