### PR TITLE
Enable semver CI and make doc tests runnable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,6 @@ jobs:
 
   semver:
     name: Semver
-    # TODO: Re-enable once manifold-csg is published on crates.io —
-    # cargo-semver-checks needs a published baseline to compare against.
-    # To re-enable: remove the `if: false` line below.
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/TODO.md
+++ b/TODO.md
@@ -22,10 +22,6 @@
 
 ## Documentation & Publishing
 
-- [ ] Re-enable `semver` CI job once manifold-csg is published on crates.io (disabled via `if: false` in `ci.yml`)
-- [ ] README badges (crates.io version, docs.rs, CI status) — add once published
-- [ ] Make doc-tests runnable (currently `rust,ignore`) — runnable examples exist in `examples/` but inline doc examples still need `rust,ignore` due to build infra requirements
-
 ## Ergonomics (nice-to-have)
 
 - [ ] Extract vec-building helper to reduce boilerplate in batch operations

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -95,7 +95,7 @@ impl Default for Rect2 {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```
 /// use manifold_csg::{Manifold, CrossSection, JoinType};
 ///
 /// let section = CrossSection::square(10.0, 10.0, true);

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```
 //! use manifold_csg::Manifold;
 //!
 //! let cube = Manifold::cube(10.0, 10.0, 10.0, true);


### PR DESCRIPTION
## Summary

- Enable `cargo-semver-checks` CI job now that `manifold-csg` is published on crates.io
- Make doc examples on `Manifold` and `CrossSection` runnable (was `rust,ignore`)
- Remove completed TODO items

## Test plan

- [x] `cargo test --doc` — 2 doc tests pass
- [x] CI semver job should run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)