### PR TITLE
Fix docs.rs build and bump for republish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,6 @@ jobs:
 
   semver:
     name: Semver
-    # TODO: Re-enable once manifold-csg is published on crates.io —
-    # cargo-semver-checks needs a published baseline to compare against.
-    # To re-enable: remove the `if: false` line below.
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Integration tests cover all public methods, Drop safety, Send across threads, Cl
 - **NEVER create a pull request unless the user explicitly asks for one.**
 - Prefer creating new commits over amending existing ones during a session.
 - When pushing, squash all branch commits into one unless told otherwise.
+- Before force-pushing to a PR branch, check if the PR has already been merged (`gh pr view <N> --json state`). If merged, sync main and create a new branch instead of force-pushing on a dead branch.
 - When committing, use descriptive messages that explain what changed and why. Wrap commit message bodies at ~72 chars per git convention.
 - Do NOT include Claude session links in commit messages or PR descriptions.
 - Do NOT hard-wrap lines in PR/issue descriptions — GitHub renders each line break literally in markdown. Each bullet or paragraph should be a single long line.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/TODO.md
+++ b/TODO.md
@@ -22,10 +22,6 @@
 
 ## Documentation & Publishing
 
-- [ ] Re-enable `semver` CI job once manifold-csg is published on crates.io (disabled via `if: false` in `ci.yml`)
-- [ ] README badges (crates.io version, docs.rs, CI status) — add once published
-- [ ] Make doc-tests runnable (currently `rust,ignore`) — runnable examples exist in `examples/` but inline doc examples still need `rust,ignore` due to build infra requirements
-
 ## Ergonomics (nice-to-have)
 
 - [ ] Extract vec-building helper to reduce boilerplate in batch operations

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.4.101"
+version = "3.4.102"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -17,6 +17,9 @@ parallel = []
 
 [build-dependencies]
 cmake = "0.1"
+
+[package.metadata.docs.rs]
+features = ["parallel"]
 
 [lints]
 workspace = true

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -28,6 +28,13 @@ fn find_lib_recursive(dir: &Path, name: &str) -> Option<PathBuf> {
 const MANIFOLD_COMMIT: &str = "93c1b4bf3cc35663ad5a9ab0c8f27196dc9f846f";
 
 fn main() {
+    // docs.rs builds with --network=none, so we can't clone manifold3d.
+    // The FFI declarations are just extern signatures — skip the C build
+    // entirely and let rustdoc generate docs from the Rust source alone.
+    if env::var("DOCS_RS").is_ok() {
+        return;
+    }
+
     // Prevent unnecessary build script re-execution.
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/lib.rs");

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -15,7 +15,7 @@ parallel = ["manifold-csg-sys/parallel"]
 nalgebra = ["dep:nalgebra"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.101", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.102", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }
@@ -23,6 +23,9 @@ nalgebra = { version = "0.34", optional = true }
 [dev-dependencies]
 approx = "0.5"
 nalgebra = "0.34"
+
+[package.metadata.docs.rs]
+features = ["nalgebra", "parallel"]
 
 [lints]
 workspace = true

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -95,7 +95,7 @@ impl Default for Rect2 {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```
 /// use manifold_csg::{Manifold, CrossSection, JoinType};
 ///
 /// let section = CrossSection::square(10.0, 10.0, true);

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -10,7 +10,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```
 //! use manifold_csg::Manifold;
 //!
 //! let cube = Manifold::cube(10.0, 10.0, 10.0, true);


### PR DESCRIPTION
## Summary

- Fix docs.rs build: skip C clone/build when `DOCS_RS` env var is set (docs.rs runs with `--network=none`)
- Add `[package.metadata.docs.rs]` to both crates for feature coverage
- Bump `manifold-csg-sys` to 3.4.102, `manifold-csg` to 0.1.3

## Test plan

- [x] `DOCS_RS=1 cargo doc --no-deps --features nalgebra` builds clean
- [x] Normal `cargo test --features nalgebra` still passes (209 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)