### PR TITLE
Add ray casting bindings and safe wrapper

### DIFF
--- a/crates/manifold-csg-sys/src/lib.rs
+++ b/crates/manifold-csg-sys/src/lib.rs
@@ -48,6 +48,13 @@ pub struct ManifoldSimplePolygon {
     _private: [u8; 0],
 }
 
+/// Opaque handle to a manifold3d `RayHitVec` (vector of ray hit results).
+#[repr(C)]
+#[derive(Debug)]
+pub struct ManifoldRayHitVec {
+    _private: [u8; 0],
+}
+
 /// Opaque handle to a manifold3d `Triangulation` result.
 #[repr(C)]
 #[derive(Debug)]
@@ -151,6 +158,16 @@ pub struct ManifoldProperties {
     pub volume: f64,
 }
 
+/// Result of a ray-manifold intersection test.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ManifoldRayHit {
+    pub face_id: u64,
+    pub distance: f64,
+    pub position: ManifoldVec3,
+    pub normal: ManifoldVec3,
+}
+
 /// Options for constructing a `MeshGL` with additional metadata.
 #[repr(C)]
 #[derive(Debug)]
@@ -251,6 +268,7 @@ unsafe extern "C" {
     pub fn manifold_box_size() -> usize;
     pub fn manifold_rect_size() -> usize;
     pub fn manifold_triangulation_size() -> usize;
+    pub fn manifold_ray_hit_vec_size() -> usize;
 
     // ── Allocation ─────────────────────────────────────────────────────
 
@@ -265,6 +283,7 @@ unsafe extern "C" {
     pub fn manifold_alloc_box() -> *mut ManifoldBox;
     pub fn manifold_alloc_rect() -> *mut ManifoldRect;
     pub fn manifold_alloc_triangulation() -> *mut ManifoldTriangulation;
+    pub fn manifold_alloc_ray_hit_vec() -> *mut ManifoldRayHitVec;
 
     // ── Destruction (destruct only, does not free) ─────────────────────
 
@@ -279,6 +298,7 @@ unsafe extern "C" {
     pub fn manifold_destruct_box(b: *mut ManifoldBox);
     pub fn manifold_destruct_rect(b: *mut ManifoldRect);
     pub fn manifold_destruct_triangulation(m: *mut ManifoldTriangulation);
+    pub fn manifold_destruct_ray_hit_vec(v: *mut ManifoldRayHitVec);
 
     // ── Deletion (destruct + free) ─────────────────────────────────────
 
@@ -293,6 +313,7 @@ unsafe extern "C" {
     pub fn manifold_delete_box(b: *mut ManifoldBox);
     pub fn manifold_delete_rect(b: *mut ManifoldRect);
     pub fn manifold_delete_triangulation(m: *mut ManifoldTriangulation);
+    pub fn manifold_delete_ray_hit_vec(v: *mut ManifoldRayHitVec);
 
     // ── Polygons ───────────────────────────────────────────────────────
 
@@ -1037,6 +1058,26 @@ unsafe extern "C" {
         normal_idx: c_int,
         min_sharp_angle: f64,
     ) -> *mut ManifoldManifold;
+
+    // ── Ray casting ─────────────────────────────────────────────────────
+
+    /// Cast a ray from `origin` to `end` against a manifold, returning all hits.
+    pub fn manifold_ray_cast(
+        mem: *mut ManifoldRayHitVec,
+        m: *const ManifoldManifold,
+        origin_x: f64,
+        origin_y: f64,
+        origin_z: f64,
+        end_x: f64,
+        end_y: f64,
+        end_z: f64,
+    ) -> *mut ManifoldRayHitVec;
+
+    /// Number of hits in a ray hit vector.
+    pub fn manifold_ray_hit_vec_length(v: *const ManifoldRayHitVec) -> usize;
+
+    /// Get a hit by index from a ray hit vector.
+    pub fn manifold_ray_hit_vec_get(v: *const ManifoldRayHitVec, idx: usize) -> ManifoldRayHit;
 
     // ── Bounding box ────────────────────────────────────────────────────
 

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -20,6 +20,7 @@ pub mod bounding_box;
 pub mod cross_section;
 pub mod manifold;
 pub mod mesh;
+pub mod ray;
 pub mod rect;
 pub mod triangulation;
 pub mod types;
@@ -33,6 +34,7 @@ pub use manifold::{
 };
 pub use manifold_csg_sys::ManifoldOpType as OpType;
 pub use mesh::{MeshGL, MeshGL64};
+pub use ray::RayHit;
 pub use rect::Rect;
 pub use triangulation::triangulate_polygons;
 pub use types::CsgError;

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -1224,6 +1224,41 @@ impl Manifold {
         unsafe { manifold_min_gap(self.ptr, other.ptr, search_length) }
     }
 
+    // ── Ray casting ─────────────────────────────────────────────────
+
+    /// Cast a ray against this manifold, returning all intersection hits.
+    ///
+    /// The ray goes from `origin` to `end`. Returns a list of [`RayHit`](crate::RayHit)
+    /// results, each containing the face ID, distance, hit position, and
+    /// surface normal.
+    #[must_use]
+    pub fn ray_cast(&self, origin: [f64; 3], end: [f64; 3]) -> Vec<crate::RayHit> {
+        // SAFETY: manifold_alloc_ray_hit_vec returns a valid handle.
+        let vec_ptr = unsafe { manifold_alloc_ray_hit_vec() };
+        // SAFETY: vec_ptr and self.ptr are valid.
+        unsafe {
+            manifold_ray_cast(
+                vec_ptr, self.ptr, origin[0], origin[1], origin[2], end[0], end[1], end[2],
+            )
+        };
+        // SAFETY: vec_ptr is valid.
+        let len = unsafe { manifold_ray_hit_vec_length(vec_ptr) };
+        let mut result = Vec::with_capacity(len);
+        for i in 0..len {
+            // SAFETY: vec_ptr is valid, i is in range.
+            let hit = unsafe { manifold_ray_hit_vec_get(vec_ptr, i) };
+            result.push(crate::RayHit {
+                face_id: hit.face_id,
+                distance: hit.distance,
+                position: [hit.position.x, hit.position.y, hit.position.z],
+                normal: [hit.normal.x, hit.normal.y, hit.normal.z],
+            });
+        }
+        // SAFETY: vec_ptr is valid and no longer needed.
+        unsafe { manifold_delete_ray_hit_vec(vec_ptr) };
+        result
+    }
+
     /// Calculate normals and store them as vertex properties at `normal_idx`.
     ///
     /// Edges sharper than `min_sharp_angle` (degrees) get sharp normals.

--- a/crates/manifold-csg/src/ray.rs
+++ b/crates/manifold-csg/src/ray.rs
@@ -1,0 +1,20 @@
+//! Ray casting against manifold solids.
+//!
+//! Cast rays against a [`Manifold`](crate::Manifold) to find intersection
+//! points, surface normals, and face IDs.
+
+/// Result of a single ray-manifold intersection.
+///
+/// See the [upstream ray casting docs](https://elalish.github.io/manifold/docs/html/structmanifold_1_1_ray_hit.html)
+/// for details on the fields.
+#[derive(Debug, Clone, Copy)]
+pub struct RayHit {
+    /// Index of the face that was hit.
+    pub face_id: u64,
+    /// Distance from the ray origin to the hit point.
+    pub distance: f64,
+    /// World-space position of the hit.
+    pub position: [f64; 3],
+    /// Surface normal at the hit point.
+    pub normal: [f64; 3],
+}

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -790,6 +790,43 @@ fn min_gap_between_separated_cubes() {
     assert_relative_eq!(gap, 6.0, epsilon = 0.5);
 }
 
+// ── Ray casting tests ──────────────────────────────────────────────
+
+#[test]
+fn ray_cast_through_cube() {
+    // Cube from [0,0,0] to [10,10,10].
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    // Ray along +X through the center of the cube.
+    let hits = cube.ray_cast([-5.0, 5.0, 5.0], [15.0, 5.0, 5.0]);
+    // Should hit two faces (entry and exit).
+    assert_eq!(hits.len(), 2);
+    // Entry hit near x=0, exit hit near x=10.
+    let mut distances: Vec<f64> = hits.iter().map(|h| h.position[0]).collect();
+    distances.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    assert_relative_eq!(distances[0], 0.0, epsilon = 0.1);
+    assert_relative_eq!(distances[1], 10.0, epsilon = 0.1);
+}
+
+#[test]
+fn ray_cast_miss() {
+    let cube = Manifold::cube(10.0, 10.0, 10.0, true);
+    // Ray that misses entirely.
+    let hits = cube.ray_cast([100.0, 100.0, 100.0], [200.0, 200.0, 200.0]);
+    assert!(hits.is_empty());
+}
+
+#[test]
+fn ray_cast_hit_has_normal() {
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    let hits = cube.ray_cast([-5.0, 5.0, 5.0], [15.0, 5.0, 5.0]);
+    assert!(!hits.is_empty());
+    for hit in &hits {
+        // Normal should be unit length.
+        let len = (hit.normal[0].powi(2) + hit.normal[1].powi(2) + hit.normal[2].powi(2)).sqrt();
+        assert_relative_eq!(len, 1.0, epsilon = 0.01);
+    }
+}
+
 // ── Minkowski tests ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Bind 7 new C API functions for ray casting from upstream PR #1654
- Add `ManifoldRayHit` value type and `ManifoldRayHitVec` opaque handle to sys crate
- Add safe `Manifold::ray_cast(origin, end)` returning `Vec<RayHit>` with face ID, distance, position, and surface normal
- New `RayHit` type exported from `manifold_csg::ray`

## Test plan

- [x] `cargo test --features nalgebra` — 212 tests pass (3 new ray casting tests)
- [x] Tests cover: through-cast with entry/exit hits, complete miss, normal unit-length validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)