### PR TITLE
Bump manifold-csg-sys to 3.4.103, manifold-csg to 0.1.4

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -43,7 +43,7 @@ Version bumps happen at publish time, not in feature PRs. Read CLAUDE.md for the
   - **sys crate**: bump the patch component (e.g., `3.4.102` → `3.4.103`) whenever the upstream contents differ from the last publish — pinned commit changed, carry-patches added/removed, or FFI declarations changed. If the upstream major.minor changed (new manifold3d release), update major.minor accordingly.
   - **safe crate**: bump patch for additive changes, minor for breaking changes (pre-1.0, minor bumps can break).
   - Update the safe crate's `manifold-csg-sys` dependency version to match the new sys version.
-- Commit the version bumps before proceeding to dry run.
+- Commit the version bumps on a branch, open a PR, and get it merged before proceeding. Branch protection requires this — you cannot push version bumps directly to main.
 
 ### 4. Carry-patch audit
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.4.102"
+version = "3.4.103"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -15,7 +15,7 @@ parallel = ["manifold-csg-sys/parallel"]
 nalgebra = ["dep:nalgebra"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.102", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.103", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }


### PR DESCRIPTION
## Summary

- Version bump for publish. Changes since v0.1.3: upstream pin update (#19), ray casting bindings (#20).

## Test plan

- [x] Version-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)