### PR TITLE
Add manifold3d and manifold3d-sys facade crates

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -6,13 +6,15 @@ user-invocable: true
 
 # Publish
 
-Publish `manifold-csg-sys` and/or `manifold-csg` to crates.io with pre-flight validation.
+Publish our 4 crates to crates.io with pre-flight validation. The workspace
+has two canonical crates (`manifold-csg-sys`, `manifold-csg`) and two thin
+facade re-exports (`manifold3d-sys`, `manifold3d`) under the same version
+numbers. Facades always ship in lockstep with their canonical counterparts
+via `=` version pins.
 
 ## Arguments
 
-- No arguments: publish both crates (sys first, then safe)
-- `sys`: publish only `manifold-csg-sys`
-- `safe`: publish only `manifold-csg`
+- No arguments: publish all 4 crates in dependency order
 - `--dry-run`: run all checks but don't actually publish
 
 ## Pre-flight checks
@@ -31,7 +33,7 @@ Must be on `main` with no uncommitted changes. Refuse to publish from a feature 
 
 ```
 cargo test --features nalgebra
-cargo clippy --all-targets --features nalgebra -- -D warnings
+cargo clippy --all-targets --all-features -- -D warnings
 ```
 
 ### 3. Version bump
@@ -40,9 +42,11 @@ Version bumps happen at publish time, not in feature PRs. Read CLAUDE.md for the
 
 - Check if versions have already been bumped (breaking PRs may have bumped to pass semver CI).
 - If not already bumped:
-  - **sys crate**: bump the patch component (e.g., `3.4.102` → `3.4.103`) whenever the upstream contents differ from the last publish — pinned commit changed, carry-patches added/removed, or FFI declarations changed. If the upstream major.minor changed (new manifold3d release), update major.minor accordingly.
-  - **safe crate**: bump patch for additive changes, minor for breaking changes (pre-1.0, minor bumps can break).
-  - Update the safe crate's `manifold-csg-sys` dependency version to match the new sys version.
+  - **`manifold-csg-sys`**: bump the patch component (e.g., `3.4.102` → `3.4.103`) whenever the upstream contents differ from the last publish — pinned commit changed, carry-patches added/removed, or FFI declarations changed. If the upstream major.minor changed (new manifold3d release), update major.minor accordingly.
+  - **`manifold-csg`** (workspace version): bump patch for additive changes, minor for breaking changes (pre-1.0, minor bumps can break).
+  - **`manifold3d-sys`** version must match the new `manifold-csg-sys` version exactly (= pin).
+  - **`manifold3d`** inherits the workspace version, so bumps automatically. Its `manifold-csg` dependency `=` pin must be updated to the new workspace version.
+  - Update `manifold-csg`'s `manifold-csg-sys` dependency version to match. Update `manifold3d-sys`'s `manifold-csg-sys` `=` pin and `manifold3d`'s `manifold-csg` `=` pin.
 - Commit the version bumps on a branch, open a PR, and get it merged before proceeding. Branch protection requires this — you cannot push version bumps directly to main.
 
 ### 4. Carry-patch audit
@@ -62,12 +66,18 @@ git push origin v<version>
 
 ### 6. Dry run
 
+Run a dry run for each crate in publish order:
+
 ```
 cargo publish --dry-run -p manifold-csg-sys
+cargo publish --dry-run -p manifold3d-sys
 cargo publish --dry-run -p manifold-csg
+cargo publish --dry-run -p manifold3d
 ```
 
-Both must succeed. Check the output for:
+Facade dry runs will fail if their canonical counterparts aren't already on crates.io at the expected version — this is expected for first publish and version bumps. The real dry-run validation for facades happens after their canonical is published.
+
+For each crate, check:
 - **Crate size** — warn if over 500KB (we don't vendor C++ source, so it should be small)
 - **File list** — `cargo package --list -p <crate>` — verify no secrets, build artifacts, or unnecessary files are included
 - **License files** — `LICENSE-APACHE` and `LICENSE-MIT` must be present
@@ -75,10 +85,11 @@ Both must succeed. Check the output for:
 ### 7. docs.rs build simulation
 
 ```
-DOCS_RS=1 cargo doc --no-deps --features nalgebra -p manifold-csg-sys -p manifold-csg
+DOCS_RS=1 cargo doc --no-deps --features nalgebra \
+  -p manifold-csg-sys -p manifold-csg -p manifold3d-sys -p manifold3d
 ```
 
-Must build without errors. docs.rs runs with `--network=none`, so `build.rs` must detect `DOCS_RS` and skip the C clone/build. This catches the failure mode where docs.rs can't build our crate.
+Must build without errors. docs.rs runs with `--network=none`, so `build.rs` must detect `DOCS_RS` and skip the C clone/build.
 
 ### 8. API stability check
 
@@ -101,26 +112,34 @@ Only after all checks pass. **Always get explicit user confirmation before runni
 
 ### Order matters
 
-1. **Publish sys crate first** — the safe crate depends on it via `version = "x.y.z"`, and crates.io must have it before the safe crate can resolve.
-2. **Wait for crates.io indexing** — there can be a brief delay. Retry the safe crate publish if it fails with "no matching package" on the first attempt.
-3. **Publish safe crate**.
+Dependencies must reach crates.io before their dependents:
+
+1. `manifold-csg-sys` (no internal deps)
+2. `manifold3d-sys` (facade of `manifold-csg-sys`)
+3. `manifold-csg` (depends on `manifold-csg-sys`)
+4. `manifold3d` (facade of `manifold-csg`)
+
+Between each publish, crates.io may take a moment to index the new version. If the next publish fails with "no matching package", wait and retry.
 
 ```
 cargo publish -p manifold-csg-sys
-# wait a moment for indexing
+cargo publish -p manifold3d-sys
 cargo publish -p manifold-csg
+cargo publish -p manifold3d
 ```
 
 ### Post-publish
 
-- Tag the release: `git tag -a v<safe-version> -m "Release <safe-version>"`
-- Push the tag: `git push origin v<safe-version>`
-- Verify on crates.io that both crates appear and docs.rs builds succeed
+- Tag the release: `git tag -a v<version> -m "Release <version>"` (using the `manifold-csg` version number — facades share the workspace version)
+- Push the tag: `git push origin v<version>`
+- Verify on crates.io that all 4 crates appear at the new version
+- Verify docs.rs builds succeed for all 4
 
 ## Rules
 
 - **NEVER publish without explicit user confirmation** — dry run is the default mindset
 - Do NOT publish from a dirty working tree or a non-main branch
 - Do NOT publish if tests or clippy fail
-- If the sys crate publish succeeds but the safe crate fails, report this clearly — the sys crate is already live and can't be unpublished (only yanked)
+- If any publish succeeds but a later one fails, report this clearly — published versions can only be yanked, not deleted. Common failure: facade fails because its canonical isn't indexed yet; retry after a delay.
 - Sys crate patch bumps must be semver-compatible (additions only)
+- Facade crates must always share the exact version of their canonical counterpart (`=` pin in Cargo.toml enforces this)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
     "crates/manifold-csg-sys",
     "crates/manifold-csg",
+    "crates/manifold3d-sys",
+    "crates/manifold3d",
 ]
 resolver = "2"
 

--- a/crates/manifold3d-sys/Cargo.toml
+++ b/crates/manifold3d-sys/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "manifold3d-sys"
+description = "Raw FFI bindings to the manifold3d C API (facade crate — re-exports manifold-csg-sys)"
+version = "3.4.103"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["csg", "geometry", "mesh", "manifold", "ffi"]
+categories = ["algorithms", "external-ffi-bindings"]
+
+[features]
+default = ["parallel"]
+parallel = ["manifold-csg-sys/parallel"]
+
+[dependencies]
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.4.103", default-features = false }
+
+[package.metadata.docs.rs]
+features = ["parallel"]
+
+[lints]
+workspace = true

--- a/crates/manifold3d-sys/README.md
+++ b/crates/manifold3d-sys/README.md
@@ -1,0 +1,26 @@
+# manifold3d-sys
+
+Raw FFI bindings to the [manifold3d](https://github.com/elalish/manifold) C API.
+
+This crate is a **facade** that re-exports [`manifold-csg-sys`](https://crates.io/crates/manifold-csg-sys).
+Both crates expose the same FFI surface — use whichever name you prefer.
+
+## Migrating from 0.0.x
+
+If you were using the original `manifold3d-sys` 0.0.x (by @NickUfer, transferred
+to this project), the API has changed significantly. See the
+[migration guide](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md).
+
+Notable changes:
+- No `export` feature (upstream removed `MeshIO` in v3.4.0)
+- No `static` feature (always statically linked)
+- Version scheme now tracks upstream manifold3d version in major.minor
+
+## See also
+
+- [`manifold3d`](https://crates.io/crates/manifold3d) — safe Rust wrapper (start here)
+- [`manifold-csg`](https://crates.io/crates/manifold-csg) / [`manifold-csg-sys`](https://crates.io/crates/manifold-csg-sys) — same crates, different names
+
+## License
+
+Apache-2.0 OR MIT

--- a/crates/manifold3d-sys/src/lib.rs
+++ b/crates/manifold3d-sys/src/lib.rs
@@ -1,0 +1,12 @@
+//! Raw FFI bindings to the manifold3d C API.
+//!
+//! This crate is a thin re-export of [`manifold-csg-sys`](https://crates.io/crates/manifold-csg-sys).
+//! The two crates provide the same FFI surface under different names — use
+//! whichever one you prefer.
+//!
+//! **If you are migrating from `manifold3d-sys` 0.0.x (the original crate by
+//! @NickUfer, now transferred to this project), see the
+//! [migration guide](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md).**
+//! The API has changed significantly between 0.0.x and 3.4+.
+
+pub use manifold_csg_sys::*;

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "manifold3d"
+description = "Safe Rust bindings to manifold3d (facade crate — re-exports manifold-csg)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["csg", "geometry", "mesh", "manifold", "3d"]
+categories = ["algorithms", "mathematics"]
+
+[features]
+default = ["parallel"]
+parallel = ["manifold-csg/parallel"]
+nalgebra = ["manifold-csg/nalgebra"]
+
+[dependencies]
+manifold-csg = { path = "../manifold-csg", version = "=0.1.4", default-features = false }
+
+[package.metadata.docs.rs]
+features = ["nalgebra", "parallel"]
+
+[lints]
+workspace = true

--- a/crates/manifold3d/README.md
+++ b/crates/manifold3d/README.md
@@ -1,0 +1,41 @@
+# manifold3d
+
+Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold)
+geometry kernel for constructive solid geometry (CSG).
+
+This crate is a **facade** that re-exports [`manifold-csg`](https://crates.io/crates/manifold-csg).
+Both crates expose the same API — use whichever name you prefer.
+
+## Migrating from 0.0.x
+
+If you were using the original `manifold3d` 0.0.x (by @NickUfer, transferred
+to this project), the API has changed significantly. See the
+[migration guide](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md),
+which is structured for AI-assisted migration.
+
+Notable changes:
+- Newtype wrappers (`PositiveF64`, `Point3`, `Vec3`, `Matrix4x3`, ...) replaced by plain primitives (`f64`, `[f64; 3]`, `[f64; 12]`)
+- `manifold3d-macros` crate removed — warp/set_properties callbacks are now closures
+- Method names aligned with the manifold3d C API (`new_cuboid` → `cube`, `convex_hull` → `hull`, etc.)
+- `nalgebra_interop` feature renamed to `nalgebra`
+- No `export` feature (upstream removed `MeshIO` in v3.4.0; use a dedicated mesh I/O crate)
+
+## Quick start
+
+```rust
+use manifold3d::{Manifold, CrossSection, JoinType};
+
+let cube = Manifold::cube(20.0, 20.0, 20.0, true);
+let hole = Manifold::cylinder(30.0, 5.0, 5.0, 32, false);
+let result = &cube - &hole;
+```
+
+## See also
+
+- [Full documentation](https://docs.rs/manifold3d)
+- [`manifold-csg`](https://crates.io/crates/manifold-csg) — same crate, different name
+- [API coverage](https://github.com/zmerlynn/manifold-csg/blob/main/API_COVERAGE.md)
+
+## License
+
+Apache-2.0 OR MIT

--- a/crates/manifold3d/src/lib.rs
+++ b/crates/manifold3d/src/lib.rs
@@ -1,0 +1,13 @@
+//! Safe Rust bindings to [manifold3d](https://github.com/elalish/manifold) —
+//! a geometry kernel for constructive solid geometry (CSG).
+//!
+//! This crate is a thin re-export of [`manifold-csg`](https://crates.io/crates/manifold-csg).
+//! The two crates provide the same API under different names — use whichever
+//! one you prefer.
+//!
+//! **If you are migrating from `manifold3d` 0.0.x (the original crate by
+//! @NickUfer, now transferred to this project), see the
+//! [migration guide](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md).**
+//! The API has changed significantly between 0.0.x and 0.1+.
+
+pub use manifold_csg::*;


### PR DESCRIPTION
## Summary

- Add `manifold3d` and `manifold3d-sys` as thin facade crates under `crates/` — both re-export our existing `manifold-csg` / `manifold-csg-sys` code unchanged
- Crate names come from @NickUfer's transferred crates. Versions start at 0.1.4 / 3.4.103 respectively
- Exact `=` version pins between facades and real crates so they can't drift
- READMEs point users at `MIGRATION_FROM_0.0.6.md` for upgrading from 0.0.x

Workspace now has 4 crates: 2 canonical (`manifold-csg`, `manifold-csg-sys`) and 2 facades (`manifold3d`, `manifold3d-sys`).

## Test plan

- [x] `cargo build --all-features` — all 4 crates build
- [x] `cargo test --features nalgebra` — 212 tests + 2 doc tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo publish --dry-run -p manifold3d-sys` / `-p manifold3d` — both succeed
- [x] `DOCS_RS=1 cargo doc --no-deps --features nalgebra -p manifold3d-sys -p manifold3d` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)