### PR TITLE
Add manifold3d-macros tombstone crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/manifold-csg",
     "crates/manifold3d-sys",
     "crates/manifold3d",
+    "crates/manifold3d-macros",
 ]
 resolver = "2"
 

--- a/crates/manifold3d-macros/Cargo.toml
+++ b/crates/manifold3d-macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "manifold3d-macros"
+description = "DEPRECATED: Use closures with the manifold3d crate instead. See the migration guide."
+version = "0.0.4"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["manifold"]
+categories = ["rendering"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/manifold3d-macros/README.md
+++ b/crates/manifold3d-macros/README.md
@@ -1,0 +1,35 @@
+# manifold3d-macros
+
+> **DEPRECATED.** This crate's macros have been removed from the `manifold3d` API.
+
+The [`manifold3d`](https://crates.io/crates/manifold3d) crate (0.1+) uses
+closures for the `warp` and `set_properties` callbacks instead of proc
+macros, so there is nothing left for this crate to provide.
+
+Using either macro (`#[manifold_warp]` or `#[manifold_manage_vertex_properties]`)
+from this crate will produce a compile error pointing at the migration guide.
+
+## Migration
+
+See the [migration guide](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md#callbacks-warp-and-set_properties).
+
+**Before:**
+
+```rust
+#[manifold_warp]
+struct MyWarp;
+impl WarpVertex for MyWarp {
+    fn warp_vertex(&self, p: Point3) -> Point3 { ... }
+}
+let warped = manifold.warp(Pin::new(&MyWarp));
+```
+
+**After:**
+
+```rust
+let warped = manifold.warp(|x, y, z| [x + 1.0, y, z]);
+```
+
+## License
+
+Apache-2.0 OR MIT

--- a/crates/manifold3d-macros/src/lib.rs
+++ b/crates/manifold3d-macros/src/lib.rs
@@ -1,0 +1,34 @@
+//! # DEPRECATED
+//!
+//! This crate is deprecated. The `manifold3d` crate (0.1+) uses closures
+//! for the `warp` and `set_properties` callbacks instead of proc macros,
+//! so there is nothing left for this crate to provide.
+//!
+//! **Migration:** see the
+//! [migration guide](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md#callbacks-warp-and-set_properties).
+//!
+//! Using either attribute macro (`#[manifold_warp]` or
+//! `#[manifold_manage_vertex_properties]`) from this crate will produce
+//! a compile error pointing you at the migration guide.
+
+use proc_macro::TokenStream;
+
+/// DEPRECATED — use a closure with `Manifold::warp` instead.
+///
+/// See <https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md#warp>.
+#[proc_macro_attribute]
+pub fn manifold_warp(_attr: TokenStream, _input: TokenStream) -> TokenStream {
+    r#"compile_error!("the #[manifold_warp] attribute is deprecated. The manifold3d crate (0.1+) uses closures for the warp callback instead of proc macros. Replace `#[manifold_warp] struct MyWarp; impl WarpVertex for MyWarp { ... }` with `manifold.warp(|x, y, z| [...])`. See https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md#warp");"#
+        .parse()
+        .unwrap()
+}
+
+/// DEPRECATED — use a closure with `Manifold::set_properties` instead.
+///
+/// See <https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md#set-properties>.
+#[proc_macro_attribute]
+pub fn manifold_manage_vertex_properties(_attr: TokenStream, _input: TokenStream) -> TokenStream {
+    r#"compile_error!("the #[manifold_manage_vertex_properties] attribute is deprecated. The manifold3d crate (0.1+) uses closures for set_properties callbacks instead of proc macros. Replace `#[manifold_manage_vertex_properties] struct MyReplacer; impl ReplaceVertexProperties for MyReplacer { ... }` with `manifold.set_properties(num_prop, |new, pos, old| { ... })`. See https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md#set-properties");"#
+        .parse()
+        .unwrap()
+}


### PR DESCRIPTION
## Summary

- Adds `crates/manifold3d-macros/` as a deprecation tombstone for the transferred `manifold3d-macros` crate. Publishes as 0.0.4.
- Both proc macros (`#[manifold_warp]`, `#[manifold_manage_vertex_properties]`) emit `compile_error!` when invoked, with a message pointing at the migration guide.
- Having the dependency in Cargo.toml is harmless — only *using* the macros errors. This avoids breaking `manifold3d = "0.0.6"` users (who pin `manifold3d-macros = "0.0.3"`, leaving 0.0.3 resolvable).

## Test plan

- [x] `cargo build -p manifold3d-macros` — builds clean
- [x] `cargo publish --dry-run -p manifold3d-macros` — passes
- [x] Verified with a test crate that `#[manifold_warp]` on a struct emits the expected error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)