### PR TITLE
Add /update-upstream skill, allow version bumps in feature PRs

### DIFF
--- a/.claude/skills/update-upstream/SKILL.md
+++ b/.claude/skills/update-upstream/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: update-upstream
+description: Bump the manifold3d pin, add FFI + safe wrappers for new upstream C API functions, bump versions, open a PR
+user-invocable: true
+---
+
+# Update upstream
+
+Guided workflow for picking up upstream manifold3d changes: bump the pin,
+audit carry-patches, bind new C API, add safe wrappers, bump versions,
+open a PR. The user still makes API shape decisions for new wrappers;
+this skill handles the mechanical parts.
+
+## Arguments
+
+- No arguments: bump to current upstream master HEAD
+- A commit SHA, tag, or branch name: bump to that ref instead (e.g., `v3.5.0`, `abc123def`)
+
+## Steps
+
+Work through these in order. Stop and surface any decision to the user.
+
+### 1. Clean working tree, new branch
+
+```
+git status               # must be clean on main
+git checkout main && git pull
+git checkout -b update-upstream-<ref>
+```
+
+### 2. Determine the target ref
+
+- If the user gave a ref, use it directly.
+- Otherwise, query upstream master HEAD: `gh api repos/elalish/manifold/git/refs/heads/master --jq '.object.sha'`
+- Show the user: current pin (from `MANIFOLD_VERSION` in `crates/manifold-csg-sys/build.rs`), the target, and a one-line commit summary of what's between them: `gh api repos/elalish/manifold/compare/<current>...<target> --jq '{ahead_by: .ahead_by, commits: [.commits[] | {sha: .sha[0:8], message: (.commit.message | split("\n")[0])}]}'`
+- Confirm before proceeding.
+
+### 3. Update the pin
+
+Edit `MANIFOLD_VERSION` in `crates/manifold-csg-sys/build.rs`. The constant accepts tags, branches, or commit SHAs — prefer SHAs for reproducibility (commit on master) or tags for tagged releases.
+
+### 4. Carry-patch audit
+
+For each patch in `crates/manifold-csg-sys/patches/`:
+- Check if the referenced upstream PR has been merged (`gh api repos/elalish/manifold/pulls/<N>`).
+- If merged AND included in the new pin, the patch can be removed — propose deletion to the user and remove if they agree.
+- Run `cargo clean -p manifold-csg-sys && cargo build -p manifold-csg-sys`. If any patch fails to apply, stop and surface the conflict — the user needs to either update the patch or drop it.
+
+### 5. Clean build and test
+
+```
+cargo clean -p manifold-csg-sys
+cargo test --features nalgebra
+```
+
+Any test failure stops the flow. Common causes: upstream changed behavior (e.g., numerical differences from deterministic math changes), signature changes (will show as compile errors), or carry-patch conflicts.
+
+### 6. Diff the C header against our FFI bindings
+
+The built C header is at `target/debug/build/manifold-csg-sys-*/out/manifold-src/bindings/c/include/manifold/manifoldc.h`. Find it and extract every `manifold_*` function declaration, compare against `pub fn manifold_*` in `crates/manifold-csg-sys/src/lib.rs`.
+
+Also look for new types (structs, enums, opaque handles) in `bindings/c/include/manifold/types.h`.
+
+Report:
+- **New functions** (present in header, missing from sys crate) — grouped by category (memory management, allocation, ray casting, etc.)
+- **Changed signatures** (present in both but different) — these are breaking upstream changes that need attention
+- **Removed functions** (in sys crate, missing from header) — should be deleted from our FFI
+
+### 7. Decide what to bind (user choice)
+
+Show the list of new functions to the user. Ask which to bind in this PR. Some guidelines:
+- Standalone features (e.g., ray casting) — usually yes
+- Allocation/destruct helpers for new types — bind along with the feature they support
+- Deeply specialized accessors — may defer if no clear safe API maps to them
+- Internal size queries — bind but mark as internal
+
+If the user says "bind everything new," proceed without individual approval.
+
+### 8. Add FFI declarations
+
+In `crates/manifold-csg-sys/src/lib.rs`:
+- Add any new opaque handle types (e.g., `pub struct ManifoldXyzVec { _private: [u8; 0] }`).
+- Add any new value types with `#[repr(C)]`.
+- Add new size/alloc/destruct/delete functions in their respective sections.
+- Add new operational functions in a logical section (or create a new section with a `// ── <Name> ──` header).
+
+Match the upstream C header signature exactly. Use `*const` for read-only pointers where the C uses non-const but we can tell the function is read-only.
+
+### 9. Add safe wrappers
+
+For each new function, write a safe wrapper method or free function in the appropriate `crates/manifold-csg/src/` file. If the new functionality deserves its own module (like ray casting did), create it and register in `lib.rs`.
+
+Follow existing patterns:
+- Allocate with `manifold_alloc_*`, call the FFI, delete the allocation, return a new wrapper.
+- For methods returning multiple values, define a value-type struct in the safe crate with `[f64; 3]` arrays for 3D vectors.
+- Safety comments: every `unsafe` block gets a `// SAFETY: ...` explaining the invariant.
+- `#[must_use]` on pure transforms returning `Self`.
+- Link to upstream docs in the doc comment if the semantics are non-obvious.
+
+### 10. Add tests
+
+New tests go in `crates/manifold-csg/tests/integration.rs`. Cover:
+- Happy path (does the feature work?)
+- Edge case (empty input, miss, degenerate geometry)
+- Any invariants (e.g., unit-length normals, non-negative distances)
+
+Run `cargo test --features nalgebra` and `cargo clippy --all-targets --features nalgebra -- -D warnings`.
+
+### 11. Update API_COVERAGE.md
+
+Add rows for new wrappers. Update the summary if present (but prefer prose over hardcoded counts — see CLAUDE.md).
+
+### 12. Bump versions
+
+Per CLAUDE.md versioning policy:
+- `manifold-csg-sys`: patch bump (e.g., `3.4.103` → `3.4.104`) since upstream contents changed. If the upstream major.minor changed (new manifold3d release), update major.minor accordingly.
+- `manifold-csg` (workspace version): patch bump for additive changes, minor for breaking.
+- `manifold-csg`'s `manifold-csg-sys` dep: update to new sys version.
+- `manifold3d-sys` and `manifold3d` share their canonical counterparts' versions via `=` pins; update those pins.
+
+### 13. Commit and open PR
+
+One commit. Commit message explains:
+- New pin SHA or tag
+- Any carry-patches added or removed
+- New bindings added
+- Version bumps
+
+Use `/pr` skill or `gh pr create` directly. Show the user the draft before posting — the `feedback_no_public_posts` rule applies.
+
+### 14. (Optional) publish
+
+If the user wants to publish after the PR merges, invoke `/publish`.
+
+## Rules
+
+- Do NOT invoke this skill on a dirty working tree.
+- Do NOT skip the clean rebuild — it's what confirms the new pin actually works.
+- Do NOT bind functions blindly — judgment about what deserves a safe wrapper is part of the job.
+- Surface any upstream API breakage loudly — it's easy to miss and expensive to ship.
+- All rules from CLAUDE.md apply (no hard-wrap in PR descriptions, no Claude session links in commits, show PR drafts before posting, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@ The sys crate clones manifold3d (pinned to a specific commit on master, post-v3.
 - **`manifold-csg`** uses standard semver (`0.1.0`, etc.) independent of the upstream version. Its `Cargo.toml` pins the sys crate version it depends on.
 - When bumping the manifold3d pin in `build.rs`, the sys crate version must be updated to match (e.g., manifold3d v3.5.0 -> sys crate `3.5.100`).
 - The sys crate pins upstream to a specific commit SHA rather than a tag. This is necessary because upstream doesn't follow strict semver — minor releases can include breaking changes. Pinning to a commit gives us the same reproducibility as a tag, while allowing us to pick up post-release fixes and carry-patches between releases.
-- **Version bumps**: bump in a PR only when needed to pass `cargo-semver-checks` CI (e.g., a breaking change requires a minor bump). Otherwise, the `/publish` skill bumps versions at publish time if not already bumped.
+- **Version bumps**: feature PRs may (and usually should) include their own version bump so the merge is ready to publish. The `/publish` skill will bump at publish time only if no PR has done so since the last release. Note that `cargo-semver-checks` CI requires a bump whenever the PR changes the public API in a way the current version doesn't allow (e.g., a breaking change requires a minor bump pre-1.0).
+- **Facade crates** (`manifold3d`, `manifold3d-sys`) always ship in lockstep with their canonical counterparts (`manifold-csg`, `manifold-csg-sys`) via `=` version pins. Bumping the canonical means bumping the facade.
 
 ## Key design decisions
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,27 +1,9 @@
 # TODO
 
-## Skills
-
-- [ ] `/release` skill — automate crate publishing. Should handle:
-  - Version bumping (with sys crate versioning scheme: `{upstream_major}.{upstream_minor}.{100+N}`)
-  - Publishing order (sys crate first, then safe crate)
-  - `cargo publish --dry-run` verification before actual publish
-  - Git tagging (`v0.1.0` for safe crate, `sys-v3.4.100` for sys crate)
-  - Changelog generation from git log
-
-- [ ] `/update-upstream` skill — bump the manifold3d pin. Should handle:
-  - Updating the git tag in `build.rs`
-  - Diffing the C header (`manifoldc.h`) for new/changed/removed functions
-  - Updating `manifold-csg-sys` version to match new upstream
-  - Updating `manifold-csg` dependency on sys crate
-  - Running tests to verify nothing broke
-
 ## Safe wrapper gaps (low priority)
 
 - [ ] MeshGL/MeshGL64 construction with full options (`w_options` — merge vectors + run data)
 
-## Documentation & Publishing
-
 ## Ergonomics (nice-to-have)
 
-- [ ] Extract vec-building helper to reduce boilerplate in batch operations
+- [ ] Extract vec-building helper to reduce boilerplate in batch operations (`batch_boolean`, `batch_hull`, `compose` in both Manifold and CrossSection)


### PR DESCRIPTION
## Summary

- New `/update-upstream` skill: guided workflow for bumping the manifold3d pin, auditing carry-patches, diffing the C header to find new bindings, wrapping them, bumping versions, and opening a PR. Intended flow: `/update-upstream` → merge → `/publish`.
- CLAUDE.md: feature PRs may (and usually should) bump their own versions so merges are publish-ready. `/publish` still bumps at publish time if no PR has done so since the last release.
- CLAUDE.md: note that facade crates ship in lockstep with canonicals via `=` version pins.
- TODO.md: remove stale items — the `/release` skill exists as `/publish`, and the Documentation & Publishing items are all done.

## Test plan

- [x] Skill authoring only — no code changes
- [x] Verified skill loads (appears in the skills list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)