### PR TITLE
Try dropping LSan suppressions with upstream #1667 as carry-patch

### DIFF
--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -7,14 +7,6 @@
 # IMPORTANT: keep these targeted at upstream C++ symbols. Suppressing on
 # our own functions (e.g. `manifold_alloc_manifold`) would hide bugs in
 # our Drop impls.
-
-# Upstream manifold leaks: these are objects allocated by manifold's own
-# constructors that survive manifold_delete_manifold/manifold_delete_cross_section.
-# Most appear to be shared_ptr<CsgLeafNode> caches from lazy CSG tree
-# evaluation.
-leak:manifold::Manifold::Manifold
-leak:manifold::CrossSection::CrossSection
-leak:manifold::CsgLeafNode
-
-# Upstream Clipper2 internal allocations (used by CrossSection).
-leak:Clipper2Lib
+#
+# Currently empty — upstream PR #1667 fixes the default-constructed leak
+# in manifold_alloc_*, so no suppressions should be needed.

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -25,7 +25,7 @@ fn find_lib_recursive(dir: &Path, name: &str) -> Option<PathBuf> {
 }
 
 /// Pinned upstream version — can be a tag (e.g., "v3.4.1"), branch, or commit SHA.
-const MANIFOLD_VERSION: &str = "cfe7b563adae70d267cf82ec8eee8e1b51b50de7";
+const MANIFOLD_VERSION: &str = "eae153d628f915172494ea508f769af265e73ce6";
 
 fn main() {
     // docs.rs builds with --network=none, so we can't clone manifold3d.


### PR DESCRIPTION
## Summary

- Add upstream PR [#1667](https://github.com/elalish/manifold/pull/1667) as a carry-patch. It fixes `manifold_alloc_*` leaking a default-constructed `T`'s internal allocations (the `shared_ptr<CsgLeafNode>` / `shared_ptr<PathImpl>` leaks we identified as the source of our LSan baseline noise).
- Drop the LSan suppressions entirely to confirm the patch is sufficient.
- Update `TODO.md` to reflect that the suppressions are a carry-patch dependency, not a permanent fix.

Label the PR with `sanitizer` to run the full ASan + LSan job.

## Test plan

- [x] Local clean rebuild with the carry-patch applies; 212 tests pass
- [ ] Sanitizer CI comes back clean (add the `sanitizer` label to trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)