### PR TITLE
Use `MANIFOLD_USE_BUILTIN_CLIPPER2`

### DIFF
--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -183,6 +183,7 @@ fn main() {
         "-DMANIFOLD_JSBIND=OFF".to_string(),
         "-DMANIFOLD_CBIND=ON".to_string(),
         "-DMANIFOLD_CROSS_SECTION=ON".to_string(),
+        "-DMANIFOLD_USE_BUILTIN_CLIPPER2=ON".to_string(),
         "-DBUILD_SHARED_LIBS=OFF".to_string(),
         "-DCMAKE_POSITION_INDEPENDENT_CODE=ON".to_string(),
     ];


### PR DESCRIPTION
And so just by poking around for 5 minutes, I was able to solve the problem I had I am dumb and should spend time actually doing things rather then immediately ask for help.

Using `MANIFOLD_USE_BUILTIN_CLIPPER2` makes it so it clones Clipper2 and builds it.

Closes #28 