### PR TITLE
Bump pin to upstream master; carry-patch #1687 + #1688 (release 0.1.5 / 3.4.104)

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -182,6 +182,14 @@ This crate tracks manifold3d upstream, pinning to a specific commit SHA.
   - Does the patch still apply cleanly?
   - Is any safety justification in our code (e.g., `unsafe impl Sync`) dependent on this patch?
 - Are there upstream fixes we need that aren't in our pin or patches?
+- Patch scope: restricted to `src/` (and `bindings/` if relevant) — no `test/` since we build with `MANIFOLD_TEST=OFF`, no docs/JS/python.
+- Patch size roughly matches the upstream PR's stated diff. A patch that's much larger than the linked PR is a red flag — it usually means whoever generated it used `git diff master..pr-branch` instead of `git diff $(git merge-base master pr-branch)..pr-branch`, and silently picked up the reverse of master's intervening commits.
+- Patch filename has a numeric prefix (e.g., `0001-`) that encodes apply order, and references the upstream PR number.
+
+**Release PR descriptions and commit messages:**
+- Cross-repo PR refs use `elalish/manifold#NNNN` (no backticks) — bare `#NNNN` resolves to our own repo, and backticks suppress GitHub's auto-link entirely.
+- Same-repo PR refs (`#NNNN`) are correct and auto-link as-is.
+- When the release window includes a contributor PR (e.g., from a non-maintainer), credit them by `@username` in the release PR body.
 
 **Known upstream bugs:**
 - Check manifold3d issues for bugs affecting functions we bind

--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -7,14 +7,6 @@
 # IMPORTANT: keep these targeted at upstream C++ symbols. Suppressing on
 # our own functions (e.g. `manifold_alloc_manifold`) would hide bugs in
 # our Drop impls.
-
-# Upstream manifold leaks: these are objects allocated by manifold's own
-# constructors that survive manifold_delete_manifold/manifold_delete_cross_section.
-# Most appear to be shared_ptr<CsgLeafNode> caches from lazy CSG tree
-# evaluation.
-leak:manifold::Manifold::Manifold
-leak:manifold::CrossSection::CrossSection
-leak:manifold::CsgLeafNode
-
-# Upstream Clipper2 internal allocations (used by CrossSection).
-leak:Clipper2Lib
+#
+# Currently empty — upstream PR #1667 fixes the default-constructed leak
+# in manifold_alloc_*, so no suppressions should be needed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.4.103"
+version = "3.4.104"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -25,7 +25,7 @@ fn find_lib_recursive(dir: &Path, name: &str) -> Option<PathBuf> {
 }
 
 /// Pinned upstream version — can be a tag (e.g., "v3.4.1"), branch, or commit SHA.
-const MANIFOLD_VERSION: &str = "cfe7b563adae70d267cf82ec8eee8e1b51b50de7";
+const MANIFOLD_VERSION: &str = "65943caaab531ff9e135fe061868fde91760a372";
 
 fn main() {
     // docs.rs builds with --network=none, so we can't clone manifold3d.

--- a/crates/manifold-csg-sys/patches/0001-upstream-1687-mergeRec-stability.patch
+++ b/crates/manifold-csg-sys/patches/0001-upstream-1687-mergeRec-stability.patch
@@ -1,0 +1,27 @@
+diff --git a/src/parallel.h b/src/parallel.h
+index e983056..2db0ad9 100644
+--- a/src/parallel.h
++++ b/src/parallel.h
+@@ -89,13 +89,21 @@ void mergeRec(SrcIter src, DestIter dest, size_t p1, size_t r1, size_t p2,
+     std::merge(src + p1, src + r1, src + p2, src + r2, dest + p3, comp);
+   } else {
+     size_t q1, q2;
++    // For stability: equal-keyed elements from the left half must precede
++    // those from the right in the output. Pivot from the larger half and
++    // use the bound that puts equal-to-pivot from the OPPOSITE half on the
++    // pivot's stable side.
+     if (length1 > length2) {
++      // Left pivot: right-side equals belong after pivot. lower_bound on
++      // right places them at q2+ (second sub-merge with pivot).
+       q1 = p1 + length1 / 2;
+       auto end = std::lower_bound(src + p2, src + r2, src[q1], comp);
+       q2 = std::distance(src, end);
+     } else {
++      // Right pivot: left-side equals belong before pivot. upper_bound on
++      // left places them strictly before q1 (first sub-merge).
+       q2 = p2 + length2 / 2;
+-      auto end = std::lower_bound(src + p1, src + r1, src[q2], comp);
++      auto end = std::upper_bound(src + p1, src + r1, src[q2], comp);
+       q1 = std::distance(src, end);
+     }
+     size_t q3 = p3 + (q1 - p1) + (q2 - p2);

--- a/crates/manifold-csg-sys/patches/0002-upstream-1688-snapshot-meshIDCounter.patch
+++ b/crates/manifold-csg-sys/patches/0002-upstream-1688-snapshot-meshIDCounter.patch
@@ -1,0 +1,39 @@
+diff --git a/src/csg_tree.cpp b/src/csg_tree.cpp
+index 6f47619..261f2cc 100644
+--- a/src/csg_tree.cpp
++++ b/src/csg_tree.cpp
+@@ -273,11 +273,15 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
+   if (nodes.size() > 1 && policy == ExecutionPolicy::Par)
+     policy = ExecutionPolicy::Seq;
+ 
++  // Snapshot once and reuse for both shifts; two reads can disagree under
++  // cross-thread CSG and leave triRef.meshID values not in meshIDtransform.
++  const uint32_t meshIDCounterSnapshot = Manifold::Impl::meshIDCounter_;
++
+   for_each_n(
+       nodes.size() > 1 ? ExecutionPolicy::Par : ExecutionPolicy::Seq,
+       countAt(0), nodes.size(),
+       [&nodes, &vertIndices, &edgeIndices, &triIndices, &propVertIndices,
+-       numPropOut, &combined, policy](int i) {
++       numPropOut, &combined, policy, meshIDCounterSnapshot](int i) {
+         auto& node = nodes[i];
+         copy(node->pImpl_->halfedgeTangent_.begin(),
+              node->pImpl_->halfedgeTangent_.end(),
+@@ -357,7 +361,7 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
+         // Since the nodes may be copies containing the same meshIDs, it is
+         // important to add an offset so that each node instance gets
+         // unique meshIDs.
+-        const int offset = i * Manifold::Impl::meshIDCounter_;
++        const int offset = i * meshIDCounterSnapshot;
+         transform(node->pImpl_->meshRelation_.triRef.begin(),
+                   node->pImpl_->meshRelation_.triRef.end(),
+                   combined.meshRelation_.triRef.begin() + triIndices[i],
+@@ -369,7 +373,7 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
+ 
+   for (size_t i = 0; i < nodes.size(); i++) {
+     auto& node = nodes[i];
+-    const int offset = i * Manifold::Impl::meshIDCounter_;
++    const int offset = i * meshIDCounterSnapshot;
+ 
+     for (const auto& pair : node->pImpl_->meshRelation_.meshIDtransform) {
+       Manifold::Impl::Relation rel = pair.second;

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -15,7 +15,7 @@ parallel = ["manifold-csg-sys/parallel"]
 nalgebra = ["dep:nalgebra"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.103", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.104", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }

--- a/crates/manifold3d-sys/Cargo.toml
+++ b/crates/manifold3d-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold3d-sys"
 description = "Raw FFI bindings to the manifold3d C API (facade crate — re-exports manifold-csg-sys)"
-version = "3.4.103"
+version = "3.4.104"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,7 +14,7 @@ default = ["parallel"]
 parallel = ["manifold-csg-sys/parallel"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.4.103", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.4.104", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["parallel"]

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -15,7 +15,7 @@ parallel = ["manifold-csg/parallel"]
 nalgebra = ["manifold-csg/nalgebra"]
 
 [dependencies]
-manifold-csg = { path = "../manifold-csg", version = "=0.1.4", default-features = false }
+manifold-csg = { path = "../manifold-csg", version = "=0.1.5", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]


### PR DESCRIPTION
## Summary

- Advances the manifold3d pin from `eae153d` (post-3.4.1) to `65943ca` (current upstream master).
- Adds two carry-patches awaiting upstream merge: `0001-upstream-1687` (parallel `mergeRec` stability) and `0002-upstream-1688` (snapshot `meshIDCounter_` once in `CsgLeafNode::Compose`).
- Bumps versions: `manifold-csg-sys` / `manifold3d-sys` `3.4.103` → `3.4.104`; `manifold-csg` / `manifold3d` `0.1.4` → `0.1.5`. All bumps are additive only — no public-API changes.
- Empties `.github/lsan-suppressions.txt` (elalish/manifold#1667 is now upstream of the pin).
- Supersedes #27 — the `eae153d` bump it carried is included in this larger advance.
- Builds on top of #29 (Clipper2 builtin fix from @JaminKoke), which is the first community contribution and lands in this same release window.

## What the carry-patches fix

elalish/manifold#1687 corrects parallel mergeSort stability when the pivot comes from the right half. The prior code used `lower_bound` on the left, which placed equal-keyed elements *after* the pivot and broke stable ordering.

elalish/manifold#1688 is the load-bearing one. `CsgLeafNode::Compose` was reading `Manifold::Impl::meshIDCounter_` twice to compute the per-component offset — once inside the parallel `for_each_n` and once in the sequential loop afterwards. Under cross-thread CSG, another thread could advance the atomic between the two reads, leaving `triRef.meshID` values that aren't present in `meshIDtransform`. The corrupted refs then changed `SimplifyTopology`'s `SameFace` decisions inside `Manifold::SetTolerance`, producing a deterministic alt-output. The fix snapshots the counter once and reuses the snapshot for both shifts.

## Other upstream changes pulled in

The pin advance also includes:

- elalish/manifold#1673 — fixes `CsgOpNode` destructor corrupting shared subtrees
- elalish/manifold#1681 — uses `std::sqrt` in `svd.h` to avoid an FP-determinism risk
- elalish/manifold#1671 — additional smoothing fixes
- elalish/manifold#1685 — improves import transformation for complex models
- elalish/manifold#1668 / elalish/manifold#1669 — adds `ExecutionContext` C API surface (not yet bound on the safe side; can be wrapped in a follow-up)

## Test plan

- [ ] `cargo test --features nalgebra` (Linux / macOS / Windows / no-TBB / MSRV)
- [ ] `cargo doc`
- [ ] `cargo deny`
- [ ] `cargo semver-checks` against published `0.1.4` / `3.4.103`
- [ ] Sanitizer label run (ASan + LSan) to verify the empty suppressions list is still clean