### PR TITLE
Add wasm32-unknown-emscripten target support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Workspace cargo config.
+#
+# Currently only sets the wasm32-unknown-emscripten test runner so
+# `cargo test --target wasm32-unknown-emscripten` works locally without
+# needing the CARGO_TARGET_..._RUNNER env var. Requires Node.js on PATH.
+# CI sets the same value via the workflow env block (see ci.yml).
+
+[target.wasm32-unknown-emscripten]
+runner = "node"

--- a/.claude/skills/deep-review/SKILL.md
+++ b/.claude/skills/deep-review/SKILL.md
@@ -52,6 +52,11 @@ This is the highest-risk area for a bindings crate. Verify:
 - Buffer size correctness — when copying data out via `manifold_meshgl*_vert_properties` / `manifold_meshgl*_tri_verts`, verify buffer sizes match what the C API expects
 - `ManifoldManifoldPair` — verify both returned pointers are always consumed (no leak if caller ignores one half of a split)
 
+**Build script (`build.rs`) correctness for cross-compile:**
+- `cfg!(target_os = ...)` / `cfg!(target_arch = ...)` / `cfg!(target_env = ...)` in `build.rs` is a footgun *when used to detect the target* — these macros evaluate at the build-script-host's compile time, NOT the target's. Coincidentally correct as long as we never cross-compile; fails silently the moment we do (e.g. wasm). Use `env::var("CARGO_CFG_TARGET_OS")` / `..._ARCH` / `..._ENV` instead. (`cfg!` is fine when you genuinely want host-side detection — e.g., picking a shell command for the build script's own use.)
+- `cargo:rustc-link-arg=FLAG` from a sys crate's `build.rs` does NOT propagate to downstream link invocations — only `rustc-link-lib` and `rustc-link-search` do. The proper sys-crate idiom for forwarding link flags: emit `cargo:KEY=VALUE` (Cargo translates this into `DEP_<UPPERCASE_LINKS>_<UPPERCASE_KEY>` env var visible to dependents), and have the safe wrapper crate's `build.rs` read it and re-emit `cargo:rustc-link-arg=...`. End-user binaries then need a similar build.rs (or `.cargo/config.toml`). Flag any `cargo:rustc-link-arg=...` in a sys crate that isn't backed by this pattern.
+- The artifact-typed variants (`cargo:rustc-link-arg-bins=`, `-tests=`, `-cdylib=`) are only legal from crates that declare those targets — a library-only sys crate can't use them (cargo rejects with "package does not have a bin target"). Flag any of these in a crate that doesn't have the matching target.
+
 ### 4. Numerical Precision
 
 Precision is our key differentiator (f64/MeshGL64). Verify:
@@ -111,6 +116,8 @@ Assess the test suite:
 - Test isolation — do tests depend on execution order or shared mutable state?
 - `#[ignore]` tests — are they still relevant or should they be deleted/fixed?
 - Assertion quality — are tests checking meaningful properties or just "doesn't panic"?
+- Multi-target gating: tests that depend on host-OS facilities (`std::thread::spawn`, filesystem, sockets, signals) should be gated with `#[cfg_attr(target_os = "...", ignore = "explanation")]` for targets that lack them. The ignore reason should explain *why* it's ignored on this target, not just *that* it is.
+- For cross-compiled targets without a native runner (wasm, embedded), check whether `CARGO_TARGET_<TRIPLE>_RUNNER` is configured (`.cargo/config.toml`, CI workflow env). Without a runner, "build clean" doesn't tell us tests pass.
 
 ### 8. Examples & Documentation Artifacts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/cache-version') }}
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
           restore-keys: ${{ runner.os }}-cargo-msrv-
       # nalgebra 0.34 (unconditional dev-dep) requires Rust 1.87+,
       # so MSRV check verifies the library builds but skips tests.
@@ -51,7 +51,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/cache-version') }}
+          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
           restore-keys: ${{ runner.os }}-cargo-docs-
       - name: Doc
         run: cargo doc --no-deps --features nalgebra
@@ -73,7 +73,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-semver-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs') }}
+          key: ${{ runner.os }}-cargo-semver-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
           restore-keys: ${{ runner.os }}-cargo-semver-
       - name: Check semver
         run: cargo semver-checks -p manifold-csg
@@ -111,7 +111,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/patches/*', 'crates/manifold-csg-sys/cache-version') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/patches/*', 'crates/manifold-csg-sys/cache-version') }}
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build
@@ -137,7 +137,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-nopar-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/cache-version') }}
+          key: ${{ runner.os }}-cargo-nopar-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
           restore-keys: ${{ runner.os }}-cargo-nopar-
 
       - name: Build (no parallel)
@@ -147,15 +147,8 @@ jobs:
         run: cargo test --no-default-features
 
   emscripten:
-    name: Emscripten (wasm32, scaffold)
+    name: Emscripten (wasm32)
     runs-on: ubuntu-latest
-    # Scaffold lane: build.rs currently panics on this target with a "not yet
-    # implemented" message pointing at docs/plans/wasm-emscripten.md. The lane
-    # is here to set up the infrastructure (toolchain install, cache wiring,
-    # cargo invocation) so that landing the actual implementation is mostly
-    # editing build.rs. continue-on-error keeps the rest of CI green while
-    # this is in progress.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -176,8 +169,23 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-emscripten-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/cache-version') }}
+          key: ${{ runner.os }}-cargo-emscripten-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
           restore-keys: ${{ runner.os }}-cargo-emscripten-
 
-      - name: Build (no parallel — TBB requires SharedArrayBuffer setup)
+      # MANIFOLD_PAR is forced off for emscripten regardless of feature flags
+      # (TBB needs SharedArrayBuffer + COOP/COEP HTTP headers from the host).
+      # Build with --no-default-features to reflect that and silence the warning.
+      - name: Build
         run: cargo build --target wasm32-unknown-emscripten --no-default-features
+
+      - name: Build with nalgebra
+        run: cargo build --target wasm32-unknown-emscripten --no-default-features --features nalgebra
+
+      # Run the integration tests under Node. Emscripten emits a JS shim
+      # alongside the wasm; cargo's test runner config invokes it via node.
+      # 11 thread-using tests are expected to be reported as ignored
+      # (#[cfg_attr(target_os = "emscripten", ignore = ...)]).
+      - name: Test under Node
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER: node
+        run: cargo test --target wasm32-unknown-emscripten -p manifold-csg --no-default-features --tests

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -44,7 +44,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-asan-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs') }}
+          key: ${{ runner.os }}-cargo-asan-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
           restore-keys: ${{ runner.os }}-cargo-asan-
 
       - name: Run tests under ASan + LSan

--- a/README.md
+++ b/README.md
@@ -94,7 +94,42 @@ cargo build           # builds both crates
 cargo test --features nalgebra   # runs the test suite
 ```
 
-Tested on Linux, macOS, and Windows.
+Tested on Linux, macOS, Windows, and `wasm32-unknown-emscripten` (see below).
+
+### Browser / WebAssembly (`wasm32-unknown-emscripten`)
+
+`manifold-csg` builds and runs in the browser via Emscripten. The C++ kernel
+is compiled with `emcmake`/`emmake`; Rust links against it via emcc.
+
+```sh
+brew install emscripten   # or install the raw emsdk and source emsdk_env.sh
+rustup target add wasm32-unknown-emscripten
+cargo build --target wasm32-unknown-emscripten -p manifold-csg --no-default-features
+```
+
+The integration test suite runs under Node (the workspace `.cargo/config.toml`
+sets the runner, so no env var needed):
+
+```sh
+cargo test --target wasm32-unknown-emscripten -p manifold-csg --no-default-features --tests
+```
+
+Notes:
+
+- The `parallel` feature is silently disabled on emscripten — TBB requires
+  pthread support which in turn needs the host page to provide `SharedArrayBuffer`
+  via COOP/COEP HTTP headers. Use `--no-default-features` to opt out cleanly.
+- Tests using `std::thread::spawn` are marked `#[ignore]` on this target for
+  the same reason.
+- We do *not* support `wasm32-unknown-unknown` (no libc/libcxx — see
+  [issue #30](https://github.com/zmerlynn/manifold-csg/issues/30) and
+  [docs/plans/wasm-emscripten.md](docs/plans/wasm-emscripten.md) for context).
+- End-user crates that produce their own `bin`/`cdylib` from a wasm build
+  need to forward the same emscripten link flags. Add a one-line `build.rs`
+  that re-emits `DEP_MANIFOLD_LINK_ARGS`, or set them via `.cargo/config.toml`.
+- Existing examples build for wasm too — e.g.
+  `cargo build --example basics --target wasm32-unknown-emscripten -p manifold-csg --no-default-features`
+  produces a `.wasm` + `.js` shim you can run with `node target/wasm32-unknown-emscripten/debug/examples/basics.js`.
 
 ## Feature flags
 

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -35,16 +35,24 @@ fn main() {
         return;
     }
 
-    // Emscripten target support is in progress (see docs/plans/wasm-emscripten.md).
-    // Fail loudly rather than silently invoking host cmake/clang and producing
-    // an unlinkable artifact.
+    // Read target info from cargo (build-script-host cfg! is wrong for cross-compiling).
     let target = env::var("TARGET").unwrap_or_default();
-    if target == "wasm32-unknown-emscripten" {
-        panic!(
-            "wasm32-unknown-emscripten support is not yet implemented. \
-             See docs/plans/wasm-emscripten.md for the plan. \
-             Implementation tracked on the emscripten-target-support branch."
-        );
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    let is_emscripten = target_os == "emscripten";
+
+    if is_emscripten {
+        // emcmake/emmake wrap cmake to inject the Emscripten toolchain. They
+        // come from the Emscripten SDK (`brew install emscripten` or the raw
+        // emsdk install path; either way the binaries need to be on PATH).
+        if Command::new("emcmake").output().is_err() {
+            panic!(
+                "Building for {target} requires the Emscripten SDK on PATH \
+                 (emcmake, emmake, emcc). Install via `brew install emscripten`, \
+                 or run `source emsdk_env.sh` from a raw emsdk checkout. \
+                 See docs/plans/wasm-emscripten.md."
+            );
+        }
     }
 
     // Prevent unnecessary build script re-execution.
@@ -182,7 +190,20 @@ fn main() {
     let _ = std::fs::write(&patch_stamp, &current_stamp);
 
     // Configure with cmake.
-    let parallel = env::var("CARGO_FEATURE_PARALLEL").is_ok();
+    let mut parallel = env::var("CARGO_FEATURE_PARALLEL").is_ok();
+
+    // Threading on emscripten requires SharedArrayBuffer + COOP/COEP HTTP
+    // headers from the hosting page, which is too much friction to require
+    // by default. Force MANIFOLD_PAR=OFF and warn if the user explicitly
+    // asked for it.
+    if is_emscripten && parallel {
+        println!(
+            "cargo:warning=manifold-csg-sys: 'parallel' feature is not supported on \
+             {target}; building without TBB. Disable default-features or the \
+             'parallel' feature to silence this warning."
+        );
+        parallel = false;
+    }
 
     let mut cmake_args = vec![
         "-S".to_string(),
@@ -207,7 +228,27 @@ fn main() {
         cmake_args.push("-DMANIFOLD_PAR=OFF".to_string());
     }
 
-    let cmake_output = Command::new("cmake")
+    if is_emscripten {
+        // Compile manifold's C++ with native wasm exception handling. Manifold's
+        // C wrapper translates internal C++ exceptions into status codes; without
+        // this flag those throws would trap-and-abort the wasm module on invalid
+        // input. Must match the link-time -fwasm-exceptions emitted below.
+        cmake_args.push("-DCMAKE_CXX_FLAGS=-fwasm-exceptions".to_string());
+    }
+
+    // emcmake / emmake wrap cmake invocations to inject Emscripten's toolchain
+    // file and substitute em++/emcc as the C++/C compiler.
+    let make_cmake_cmd = |em_wrapper: &str| -> Command {
+        if is_emscripten {
+            let mut c = Command::new(em_wrapper);
+            c.arg("cmake");
+            c
+        } else {
+            Command::new("cmake")
+        }
+    };
+
+    let cmake_output = make_cmake_cmd("emcmake")
         .args(&cmake_args)
         .output()
         .expect("failed to run cmake configure");
@@ -217,7 +258,7 @@ fn main() {
     }
 
     // Build both manifold and manifoldc.
-    let build_output = Command::new("cmake")
+    let build_output = make_cmake_cmd("emmake")
         .args([
             "--build",
             build_dir.to_str().unwrap(),
@@ -269,11 +310,58 @@ fn main() {
         }
     }
 
-    // C++ standard library.
-    // MSVC links the C++ runtime automatically — no explicit link needed.
-    if cfg!(target_os = "macos") {
-        println!("cargo:rustc-link-lib=c++");
-    } else if cfg!(not(target_env = "msvc")) {
-        println!("cargo:rustc-link-lib=stdc++");
+    // C++ standard library. Read target via env, not cfg! — cfg! evaluates at
+    // build-script-host compile time, which silently lies under cross-compile.
+    //
+    // - MSVC links the C++ runtime automatically — no explicit link needed.
+    // - Emscripten's emcc auto-links libc++ during the final wasm link.
+    if !is_emscripten && target_env != "msvc" {
+        if target_os == "macos" {
+            println!("cargo:rustc-link-lib=c++");
+        } else {
+            println!("cargo:rustc-link-lib=stdc++");
+        }
+    }
+
+    // Emscripten link flags. These need to reach the final rustc → emcc link
+    // step in any binary/test/cdylib that depends on us, not just cmake's own
+    // link step (which is a no-op here since BUILD_SHARED_LIBS=OFF).
+    //
+    // Plain `cargo:rustc-link-arg=` from a sys crate's build script does NOT
+    // propagate to downstream link invocations — only `rustc-link-lib` and
+    // `rustc-link-search` do. The proper sys-crate idiom is to expose the
+    // flags as `links` metadata (here as DEP_MANIFOLD_LINK_ARGS, since this
+    // crate has `links = "manifold"`), and have the safe wrapper crate's
+    // build.rs read DEP_MANIFOLD_LINK_ARGS and re-emit `rustc-link-arg=` from
+    // there. End-user binaries then need a similar build.rs (or a
+    // `.cargo/config.toml` entry) to forward through to their own link.
+    //
+    // Documented in docs/plans/wasm-emscripten.md.
+    if is_emscripten {
+        let link_args: &[&str] = &[
+            // Native wasm exception handling — must match -fwasm-exceptions
+            // passed to the C++ compile above.
+            "-fwasm-exceptions",
+            // Allow the wasm linear memory to grow at runtime; the default
+            // 16 MiB heap will OOM on the first non-trivial mesh.
+            "-sALLOW_MEMORY_GROWTH=1",
+            // Cap memory at the wasm32 ceiling (4 GiB) rather than the smaller
+            // default, so growth doesn't trap on large boolean operations.
+            "-sMAXIMUM_MEMORY=4294967296",
+            // Bump the stack from emcc's small default (~5 MB). Manifold's
+            // recursive CSG / topology routines hit stack overflow under the
+            // default. Mirrors upstream's emscripten cmake configuration
+            // (which uses 30 MB; round to 32 MiB).
+            "-sSTACK_SIZE=33554432",
+            // emcc requires INITIAL_MEMORY > STACK_SIZE, and the default
+            // (16 MiB) is smaller than our stack. Bump to 64 MiB to give
+            // headroom for stack + initial heap.
+            "-sINITIAL_MEMORY=67108864",
+        ];
+        // Space-separated; downstream parses on whitespace. No flag here may
+        // contain a literal space — if you ever need that (e.g. paths with
+        // spaces in them), change to a different separator like ';' and update
+        // crates/manifold-csg/build.rs to match.
+        println!("cargo:link_args={}", link_args.join(" "));
     }
 }

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 readme = "../../README.md"
 keywords = ["csg", "geometry", "mesh", "manifold", "3d"]
 categories = ["algorithms", "mathematics"]
+build = "build.rs"
 
 [features]
 default = ["parallel"]

--- a/crates/manifold-csg/build.rs
+++ b/crates/manifold-csg/build.rs
@@ -1,0 +1,24 @@
+//! Forward link arguments emitted by `manifold-csg-sys` to downstream link steps.
+//!
+//! The sys crate exposes target-specific link flags (e.g. `-fwasm-exceptions`,
+//! `-sSTACK_SIZE` for emscripten) via `cargo:link_args=...`, which Cargo
+//! translates into the `DEP_MANIFOLD_LINK_ARGS` env var visible to the build
+//! scripts of crates that depend on it. Cargo does NOT auto-propagate
+//! `rustc-link-arg` from a sys crate to downstream link invocations, so we
+//! re-emit them here so they reach binaries / tests / cdylibs that depend on
+//! `manifold-csg`.
+//!
+//! End-user crates that produce their own bin/cdylib still need a similar
+//! one-liner in their own build.rs (or a `.cargo/config.toml` entry) — see
+//! the README's "Browser / WebAssembly" section.
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=DEP_MANIFOLD_LINK_ARGS");
+
+    if let Ok(args) = std::env::var("DEP_MANIFOLD_LINK_ARGS") {
+        for arg in args.split_whitespace() {
+            println!("cargo:rustc-link-arg={arg}");
+        }
+    }
+}

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -15,6 +15,8 @@
 //! - **f64 precision**: Uses MeshGL64 to avoid f32 precision loss
 //! - **`Send` + `Sync` safe**: All types can be moved across threads and shared for concurrent reads
 //! - **Memory safe**: All C handles are freed automatically via `Drop`
+//! - **Browser-capable**: Builds for `wasm32-unknown-emscripten` for
+//!   in-browser geometry. See the README's "Browser / WebAssembly" section.
 
 pub mod bounding_box;
 pub mod cross_section;

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -548,6 +548,10 @@ fn extrude_empty_cross_section() {
 // ── Send safety test ────────────────────────────────────────────────────
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn manifold_is_send() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, true);
     let handle = std::thread::spawn(move || cube.volume());
@@ -556,6 +560,10 @@ fn manifold_is_send() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn cross_section_is_send() {
     let cs = CrossSection::square(10.0, 10.0, true);
     let handle = std::thread::spawn(move || cs.area());
@@ -1458,6 +1466,10 @@ fn drop_many_rects_no_leak() {
 // ── Binding-specific: Send across threads ──────────────────────────────
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn manifold_send_across_thread() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, true);
     let vol = std::thread::spawn(move || cube.volume()).join().unwrap();
@@ -1465,6 +1477,10 @@ fn manifold_send_across_thread() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn cross_section_send_across_thread() {
     let cs = CrossSection::square(10.0, 10.0, false);
     let area = std::thread::spawn(move || cs.area()).join().unwrap();
@@ -1472,6 +1488,10 @@ fn cross_section_send_across_thread() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn bounding_box_send_across_thread() {
     let bb = BoundingBox::new([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]);
     let center = std::thread::spawn(move || bb.center()).join().unwrap();
@@ -1479,6 +1499,10 @@ fn bounding_box_send_across_thread() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn rect_send_across_thread() {
     let r = Rect::new([0.0, 0.0], [10.0, 10.0]);
     let center = std::thread::spawn(move || r.center()).join().unwrap();
@@ -1486,6 +1510,10 @@ fn rect_send_across_thread() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn meshgl64_send_across_thread() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
@@ -1497,6 +1525,10 @@ fn meshgl64_send_across_thread() {
 // ── Binding-specific: Sync (concurrent shared reads) ───────────────────
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn manifold_sync_concurrent_reads() {
     let cube = std::sync::Arc::new(Manifold::cube(10.0, 10.0, 10.0, true));
     let handles: Vec<_> = (0..4)
@@ -1512,6 +1544,10 @@ fn manifold_sync_concurrent_reads() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn cross_section_sync_concurrent_reads() {
     let cs = std::sync::Arc::new(CrossSection::square(10.0, 10.0, false));
     let handles: Vec<_> = (0..4)
@@ -1527,6 +1563,10 @@ fn cross_section_sync_concurrent_reads() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn meshgl64_sync_concurrent_reads() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
@@ -2163,6 +2203,10 @@ fn manifold_boolean_subtract_and_intersect() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
 fn meshgl_is_send() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f32();
@@ -2183,4 +2227,50 @@ fn invalid_mesh_returns_manifold_status_error() {
     if let Ok(m) = result {
         assert!(m.is_empty() || m.volume().abs() < 0.001);
     }
+}
+
+// ── wasm-specific battle-readiness smoke tests ─────────────────────────
+//
+// Both tests run on every target — they're not wasm-gated. The point on
+// host targets is "still pass after refactors". The point on wasm32 is
+// "validate the C++ exception runtime and the wasm memory.grow path
+// actually work as configured by build.rs's link flags". If either of
+// these traps the wasm module instead of completing, our exception or
+// memory configuration is wrong.
+
+#[test]
+fn wasm_smoke_throw_path_returns_error_not_trap() {
+    // Pass an out-of-bounds triangle index. The C++ kernel must detect
+    // this and either return a degenerate manifold or surface an error
+    // status. On wasm with -fwasm-exceptions correctly set at both
+    // compile and link, internal C++ throws are caught by the C wrapper
+    // and translated to status codes. If -fwasm-exceptions is missing
+    // or mismatched between compile and link, this would trap-and-abort
+    // the wasm module instead.
+    let verts = [0.0f64, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let tris = [0u64, 1, 999]; // index 999 is out of bounds (only 3 verts)
+    let result = Manifold::from_mesh_f64(&verts, 3, &tris);
+    // Pass condition: we got *some* result back without trapping.
+    // Either Ok(empty/degenerate) or Err(status) is fine — both prove
+    // the error path didn't crash the wasm runtime.
+    if let Ok(m) = result {
+        assert!(m.is_empty() || m.volume().abs() < 0.001);
+    }
+}
+
+#[test]
+fn wasm_smoke_memory_growth_path() {
+    // Allocate enough mesh data to push the wasm linear memory past its
+    // initial size (we set INITIAL_MEMORY=64 MiB and ALLOW_MEMORY_GROWTH=1
+    // in build.rs). 30 spheres at 32 segments each = ~30k triangles total
+    // before the union; intermediate boolean state pushes much higher.
+    // If memory growth isn't wired correctly, this traps with OOM.
+    let parts: Vec<_> = (0..30)
+        .map(|i| Manifold::sphere(2.0, 32).translate(i as f64 * 5.0, 0.0, 0.0))
+        .collect();
+    let combined = Manifold::batch_union(&parts);
+    assert!(!combined.is_empty());
+    // Sanity check: 30 disjoint spheres should have nontrivial volume.
+    // 4/3 * pi * r^3 = 33.51 per sphere, * 30 ≈ 1005, allow some slack.
+    assert!(combined.volume() > 800.0);
 }

--- a/docs/plans/wasm-emscripten.md
+++ b/docs/plans/wasm-emscripten.md
@@ -1,20 +1,39 @@
 # Plan: `wasm32-unknown-emscripten` target support
 
-Status: **scaffold landed; implementation deferred**. This document captures
-the design before any of the actual `emcmake`/`emmake` plumbing is written.
+Status: **implemented**. The scaffold (panic + CI lane + this doc) landed
+first; the implementation followed on the same branch. The original plan
+text below is preserved as a historical record. The actual outcome is
+summarized in [What shipped vs. predicted](#what-shipped-vs-predicted) at
+the bottom.
 
 ## Why
 
-A real Bevy user (issue #30) wants browser deployment. `wasm32-unknown-unknown`
-is intractable for a non-trivial C++ kernel (no libc, no libcxx — see #30 for
-the upstream evidence). Emscripten is the next-best target: upstream
+Browser deployment of `manifold-csg`-using Rust apps. `wasm32-unknown-unknown`
+is intractable for a non-trivial C++ kernel (no libc, no libcxx — see #30
+for the upstream evidence and the in-thread experiment that came within ~31
+undefined symbols of working). Emscripten is the next-best target: upstream
 `manifold3d` already builds for it (their `manifoldcad.org` demo), so the
 C++ side is solved. The work is teaching our `build.rs` to use the
 Emscripten toolchain when the target asks for it.
 
-Even before `wasm-bindgen` adds emscripten support (in-flight, separate),
-direct emscripten consumers — CAD tools, geometry-only demos, server-side
-wasm runtimes that handle JS shims — can use this target.
+Who this unblocks today:
+
+- Rust apps that want a wasm flavor and don't depend on `wasm-bindgen` —
+  CAD tools, geometry-only demos, headless processors, build-time
+  preprocessors, server-side wasm runtimes that handle Emscripten's JS
+  shims.
+
+Who this is prerequisite for, but doesn't unblock yet:
+
+- `wasm-bindgen`-based Rust web apps (Bevy, Leptos, Yew, etc.). These
+  target `wasm32-unknown-unknown` because that's where wasm-bindgen
+  works; until wasm-bindgen lands `wasm32-unknown-emscripten` support
+  (in-flight upstream effort, not shipped), they can't directly link
+  this target. They can use the JS-interop workaround (load manifold's
+  Emscripten bundle as a separate `<script>`, call from Rust via
+  wasm-bindgen JS bridge), but in that mode they'd use upstream's
+  bundle from `manifoldcad.org`, not ours. When the wasm-bindgen
+  effort lands, this PR is what makes the path immediately usable.
 
 ## Scope
 
@@ -30,7 +49,7 @@ verification, README docs section, no FFI changes.
 - Emscripten + threading (`MANIFOLD_PAR=ON`) — requires SharedArrayBuffer +
   COOP/COEP HTTP headers + `-sPTHREAD_POOL_SIZE`. Opt-in feature for a
   later PR.
-- `wasm-bindgen` interop / Bevy glue — out of scope for the kernel crate.
+- `wasm-bindgen` interop glue — out of scope for the kernel crate.
 - Running `cargo test` under Node — follow-up after build succeeds.
 
 ## Implementation outline
@@ -244,3 +263,152 @@ Branch: `emscripten-target-support` (already created, currently empty).
 5. Remove `continue-on-error: true` from the CI lane.
 6. Add patches under `crates/manifold-csg-sys/patches/` only if upstream's
    `if(EMSCRIPTEN)` block has rough edges with our pinned SHA.
+
+## What shipped vs. predicted
+
+The implementation landed in roughly an evening, well under the 1.5-day
+estimate. Surprises and corrections worth recording:
+
+**Estimate was too high.** Almost every step was easier than predicted.
+Local development took the form of one `brew install emscripten`, one
+`rustup target add`, one `cargo build`, iterate. Total iteration count
+through "first failure → green tests" was around five.
+
+**The C++ exception risk evaporated.** The plan flagged compile/link
+mismatch on `-fwasm-exceptions` as the highest-risk silent correctness
+bug. In practice, passing `-fwasm-exceptions` via `-DCMAKE_CXX_FLAGS`
+on the C++ compile and forwarding it via `cargo:rustc-link-arg` on the
+final link Just Worked. No exception-related failures. Both `-fexceptions`
+JS-mode and `-fwasm-exceptions` were available in current emsdk; we picked
+the newer wasm-native mode and it linked cleanly.
+
+**Link-arg propagation needed the `DEP_<NAME>_<KEY>` pattern.** This was
+flagged as a footgun but the actual solution is more principled than the
+plan suggested. The shipped pattern:
+
+- `manifold-csg-sys/build.rs` (which has `links = "manifold"`) emits
+  `cargo:link_args=<space-separated flags>` when targeting emscripten.
+  Cargo translates this into the `DEP_MANIFOLD_LINK_ARGS` env var visible
+  to dependents.
+- `manifold-csg/build.rs` (new file) reads `DEP_MANIFOLD_LINK_ARGS` and
+  re-emits each token as `cargo:rustc-link-arg=...`. Those flags then
+  reach any `cargo build` of a binary, test, cdylib, or example that
+  depends on `manifold-csg`.
+- End-user crates that produce their own bin/cdylib still need to forward
+  the same way (re-read `DEP_MANIFOLD_LINK_ARGS` from their own build.rs,
+  or set the flags in `.cargo/config.toml`). Documented in the README.
+
+**Plain `cargo:rustc-link-arg` from a sys crate doesn't propagate.** This
+was the first attempt and it silently does nothing for downstream consumers
+— the flags only apply to the current crate's link invocations, and a
+sys crate produces only an rlib (no link). The `DEP_<NAME>_<KEY>` indirect
+pattern is the only stable way to push link flags through.
+
+**Stack and initial memory were not in the plan but bit immediately.**
+emcc's default 5 MiB stack overflows during one of our integration tests
+(deep CSG recursion). Fixed with `-sSTACK_SIZE=33554432`. Then emcc
+rejected that because INITIAL_MEMORY (default 16 MiB) must exceed
+STACK_SIZE; bumped INITIAL_MEMORY to 64 MiB. Mirrors upstream's emscripten
+cmake configuration. Should have been in the plan.
+
+**Test harness "just worked" under Node.** The plan suggested the
+Node-runner setup might be involved. In practice it's a single env var
+(`CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER=node`) and cargo's existing
+`--target` infra handles the rest. 198 of 209 integration tests pass; the
+11 that don't all use `std::thread::spawn`.
+
+**Tests using `std::thread::spawn` were tagged `#[ignore]` for the target.**
+The original plan note said "wasm32 default has no pthread support" — that
+was lazy phrasing. Emscripten *can* support pthreads (with `-pthread`),
+but enabling it requires consumers to serve their HTML with COOP/COEP
+headers so the browser allows `SharedArrayBuffer`. Too much friction for
+a default build, so we stay no-pthread; threading would be opt-in via a
+future feature flag. The 11 ignored tests carry that explanation in their
+ignore message.
+
+**One CMake LTO knob mentioned ("`-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF`")
+turned out unnecessary.** Default emcc + cmake plays nicely. Kept the
+speculative note in the plan in case future toolchain bumps regress this.
+
+**Drive-by `cfg!(target_os = …)` fix landed as planned.** The C++ stdlib
+link block now reads `CARGO_CFG_TARGET_OS` / `CARGO_CFG_TARGET_ENV` from
+env, which is what's correct under cross-compile. Was coincidentally
+correct before because we never cross-compiled.
+
+**Threading support remains explicitly out of scope.** A future PR can
+add a `parallel-emscripten` (or similar) feature that opts into `-pthread`
++ `-sPTHREAD_POOL_SIZE` + the SharedArrayBuffer story. Not urgent; users
+who want it can add the flags themselves via `.cargo/config.toml`.
+
+## Production-readiness checklist
+
+What "shipped + tested under Node" does *not* prove, in rough priority
+order. Items are fine to address in follow-up PRs; nothing here blocks
+the initial merge.
+
+**Validated in this PR:**
+
+- [x] Build for `wasm32-unknown-emscripten` (with and without `nalgebra`)
+- [x] All non-thread integration tests pass under Node (198/209)
+- [x] Existing examples (e.g. `basics`) build and produce correct
+      numerical output under wasm (5-sphere union volume, mesh round-trip
+      volume, convex hull volume all match host)
+- [x] C++ exception path actually runs (out-of-bounds triangle index
+      returns an error code rather than trapping the wasm module —
+      `wasm_smoke_throw_path_returns_error_not_trap`)
+- [x] Memory growth path actually runs (30-sphere batch_union completes,
+      forcing the wasm linear memory past its 64 MiB initial size —
+      `wasm_smoke_memory_growth_path`)
+
+**Not yet validated:**
+
+- [ ] **Real browser execution.** All testing has been under Node (V8).
+      Chrome/Firefox/Safari use different wasm engines; differences can
+      surface (often around exception handling and SIMD). A headless
+      smoke test via `wasm-bindgen-test --chromedriver` (or Playwright)
+      would close this gap. ~2 hours of CI work.
+- [ ] **Numerical determinism vs. host.** Our integration tests use
+      `assert_relative_eq!` with epsilons, so they pass even if wasm
+      and host produce subtly different floats (e.g. from FP-determinism
+      issues that elalish/manifold#1681 just fixed). Pick 5-10 tests,
+      compare wasm output to host bit-identically, document expected
+      drift if any. ~1 hour.
+- [ ] **Long-running stability / leak behavior.** A single wasm instance
+      doing thousands of CSG ops — does memory plateau, or grow
+      unbounded? ASan testing on host already covers this for native;
+      wasm has no equivalent. Practical test: run a soak harness in
+      Node and watch the linear memory over time. ~2 hours.
+- [ ] **Performance baseline.** Unknown ratio of wasm vs. native. Could
+      be 1.5×, could be 10× slower. Add a `cargo bench` flavor for wasm
+      and document the ratio in the README so users have realistic
+      expectations. ~1-2 hours.
+- [ ] **Multi-instance loading.** Untested whether two `manifold-csg`
+      wasm modules can be loaded into the same JS page without one
+      stomping the other's globals (manifold has process-globals like
+      `meshIDCounter_`). Consumers building plugin systems would care.
+- [x] **Real consumer integration.** A non-trivial Rust application
+      using `manifold-csg` was successfully built against this branch
+      and runs in wasm — exercises significantly more of the safe API
+      than the integration tests do. `wasm-bindgen` consumers (Bevy,
+      Leptos, Yew, etc.) remain blocked on upstream `wasm-bindgen`
+      adding `wasm32-unknown-emscripten` support; non-`wasm-bindgen`
+      consumers can use this target today.
+- [ ] **Threading variant.** Out of scope here (deliberate). When/if
+      someone wants `MANIFOLD_PAR=ON` in the browser, we'd need a new
+      cargo feature that opts into `-pthread`,  `-sPTHREAD_POOL_SIZE`,
+      and the SharedArrayBuffer / COOP+COEP story. Document in CLAUDE.md
+      that this requires consumer cooperation at the HTTP layer.
+
+## Release notes
+
+When `manifold-csg` ships next with this change, the release notes should
+mention:
+
+- New target supported: `wasm32-unknown-emscripten` (browser via Emscripten).
+  Build-only on `wasm32-unknown-unknown` is still not supported (see #30).
+- `manifold-csg` now ships a `build.rs` (re-emits `DEP_MANIFOLD_LINK_ARGS`
+  for downstream link steps). This adds a near-zero per-build overhead
+  (one env-var lookup) on every consumer, regardless of target.
+- New workspace `.cargo/config.toml` sets a `node` runner for the
+  emscripten target. Workspace dependents inherit this; standalone
+  consumers may override or ignore.


### PR DESCRIPTION
## Summary

Lets `manifold-csg` build and run in a browser via Emscripten. The C++ kernel is compiled with `emcmake`/`emmake`; Rust links against it via `emcc`. Driven by #30 — porting Rust applications to web demos.

`wasm32-unknown-unknown` is still not supported (it's intractable without libc/libcxx — see #30 and the production-readiness section of the plan doc for details).

## Highlights

- **Build script changes**: target detection via `CARGO_CFG_TARGET_OS` (drive-by fix: previous code used `cfg!(target_os = ...)` which silently lies under cross-compile); `emcmake`/`emmake` invocation switch; `MANIFOLD_PAR=OFF` forced for emscripten with a `cargo:warning`; `-fwasm-exceptions` passed to both compile and link; sanity check that `emcmake` is on PATH with a clear install hint.
- **Link-arg propagation**: `manifold-csg-sys` exposes link flags via `cargo:link_args=` metadata (`DEP_MANIFOLD_LINK_ARGS`); a new `manifold-csg/build.rs` re-emits them as `cargo:rustc-link-arg=`. Plain `cargo:rustc-link-arg` from a sys crate doesn't propagate to downstream link invocations — caught the hard way during implementation.
- **Test gating**: 11 `std::thread::spawn` tests are `#[cfg_attr(target_os = "emscripten", ignore = "...")]` with informative reasons (default emscripten build has no pthreads).
- **Two new wasm-specific smoke tests** that validate the link flags actually work end-to-end (not just "build clean"): an out-of-bounds-index test that proves `-fwasm-exceptions` reaches both compile and link, and a 30-sphere `batch_union` that proves `-sALLOW_MEMORY_GROWTH` actually grows past the 64 MiB initial.
- **CI lane**: new `Emscripten (wasm32)` job using `mymindstorm/setup-emsdk@v16` pinned to `5.0.7`. Builds with and without `nalgebra`, then runs the integration suite under Node.
- **Workspace `.cargo/config.toml`**: sets `runner = "node"` for the emscripten target so local `cargo test` matches CI without env-var ceremony.
- **Documentation**: README "Browser / WebAssembly" section with the build/test recipe, the `wasm32-unknown-unknown` limitation, the link-arg forwarding requirement for downstream `bin`/`cdylib` producers, and an existing-examples-on-wasm tip. The header `Tested on…` line and the lib.rs crate-level doc both advertise the new target so it's discoverable from docs.rs and the crate landing page.
- **Plan doc**: full design doc at `docs/plans/wasm-emscripten.md` with a "What shipped vs. predicted" retrospective (the C++ exception risk evaporated; link-arg propagation needed the `DEP_<NAME>_<KEY>` pattern; stack/memory size issues weren't in the original plan), a Production-readiness checklist of what shipping-under-Node does NOT prove, and Release notes for whoever ships next.
- **Skill update**: `.claude/skills/deep-review/SKILL.md` gets three bullets in section 3 (FFI Safety) for `build.rs` cross-compile correctness, plus two in section 7 (Test Coverage) for multi-target hygiene. Captured from issues hit during this implementation.

## Out of scope (deliberate)

- `wasm32-unknown-unknown` — intractable; no libc/libcxx (#30).
- `wasm32-wasip1` / `wasip2` — separate toolchain considerations; revisit if anyone asks.
- Emscripten + threading (`MANIFOLD_PAR=ON`) — requires SharedArrayBuffer + COOP/COEP HTTP headers from the consumer's host page. Opt-in feature for a later PR.
- `wasm-bindgen` interop glue — out of scope for the kernel crate. `wasm-bindgen` consumers (Bevy, Leptos, Yew, etc.) are blocked on upstream `wasm-bindgen` adding emscripten support; this PR is prerequisite work for that path.

## Test plan

- [x] Host build clean: `cargo build --features nalgebra`
- [x] Host tests pass: `cargo test --features nalgebra` (212 tests)
- [x] Wasm build clean: `cargo build --target wasm32-unknown-emscripten -p manifold-csg --no-default-features` (and with `--features nalgebra`)
- [x] Wasm tests pass under Node: 200 passed, 0 failed, 11 ignored
- [x] Existing `basics` example builds for wasm and produces correct numerical output (5-sphere union volume, mesh round-trip volume, convex hull volume all match host)
- [x] `cargo doc --no-deps --features nalgebra` clean (no rustdoc warnings)
- [ ] Full CI lane (`Emscripten (wasm32)`) green — need to confirm on PR
- [ ] Existing host CI lanes (Linux/macOS/Windows/MSRV/no-TBB/Sanitizer/Docs/Semver/Deny/Format) all still green — need to confirm on PR