### PR TITLE
Add wasm32-unknown-unknown target support via wasm-cxx-shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
-          restore-keys: ${{ runner.os }}-cargo-msrv-
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-msrv-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
       # nalgebra 0.34 (unconditional dev-dep) requires Rust 1.87+,
       # so MSRV check verifies the library builds but skips tests.
       - name: Build
@@ -51,8 +51,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
-          restore-keys: ${{ runner.os }}-cargo-docs-
+          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-docs-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
       - name: Doc
         run: cargo doc --no-deps --features nalgebra
         env:
@@ -73,8 +73,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-semver-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
-          restore-keys: ${{ runner.os }}-cargo-semver-
+          key: ${{ runner.os }}-cargo-semver-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-semver-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
       - name: Check semver
         run: cargo semver-checks -p manifold-csg
 
@@ -111,8 +111,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/patches/*', 'crates/manifold-csg-sys/cache-version') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/patches/*') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
 
       - name: Build
         run: cargo build --features nalgebra
@@ -137,8 +137,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-nopar-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
-          restore-keys: ${{ runner.os }}-cargo-nopar-
+          key: ${{ runner.os }}-cargo-nopar-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-nopar-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
 
       - name: Build (no parallel)
         run: cargo build --no-default-features
@@ -169,8 +169,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-emscripten-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs', 'crates/manifold-csg-sys/cache-version') }}
-          restore-keys: ${{ runner.os }}-cargo-emscripten-
+          key: ${{ runner.os }}-cargo-emscripten-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-emscripten-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
 
       # MANIFOLD_PAR is forced off for emscripten regardless of feature flags
       # (TBB needs SharedArrayBuffer + COOP/COEP HTTP headers from the host).
@@ -189,3 +189,82 @@ jobs:
         env:
           CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER: node
         run: cargo test --target wasm32-unknown-emscripten -p manifold-csg --no-default-features --tests
+
+  wasm32-uu:
+    name: Wasm32 (unknown-unknown)
+    runs-on: ubuntu-latest
+    env:
+      # Pinned LLVM bin dir for build.rs's find_llvm() to skip detection
+      # ladder. apt.llvm.org installs the toolchain here on Debian-family.
+      WASM_CXX_SHIM_LLVM_BIN_DIR: /usr/lib/llvm-20/bin
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      # Install LLVM 20 with libc++/libc++abi headers and lld for the
+      # wasm-cxx-shim build path. The shim's toolchain file probes
+      # /usr/lib/llvm-N/bin so this layout is what it expects. wabt
+      # provides wasm-objdump for the import-section assertions below.
+      - name: Install LLVM 20 + libc++ + lld + wabt
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install -y clang-20 lld-20 libc++-20-dev libc++abi-20-dev wabt
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm32-uu-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/wasm32-uu/**', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-wasm32-uu-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
+
+      # Build the sys crate first to surface cmake/clang errors clearly.
+      # `unstable-wasm-uu` is required by build.rs for this target.
+      - name: Build manifold-csg-sys
+        run: cargo build --target wasm32-unknown-unknown -p manifold-csg-sys --features unstable-wasm-uu
+
+      - name: Build manifold-csg (with tests + examples)
+        # --examples catches new examples that aren't portable to this target
+        # (e.g. an OBJ-using example that needs cfg-gating).
+        run: cargo build --target wasm32-unknown-unknown -p manifold-csg --no-default-features --features unstable-wasm-uu --tests --examples
+
+      # Verify the produced test wasm has zero unexpected imports —
+      # confirms the shim covered every C/C++ runtime symbol manifold needs
+      # and the iostream patches successfully eliminated the OBJ I/O imports.
+      - name: Verify zero imports (integration test wasm)
+        run: |
+          WASM=$(ls -t target/wasm32-unknown-unknown/debug/deps/integration-*.wasm | head -1)
+          echo "Inspecting: $WASM"
+          # wasm-objdump prints "Section not found: Import" when there's no Import section.
+          if wasm-objdump -x -j Import "$WASM" 2>&1 | grep -q "Section not found"; then
+            echo "✓ wasm has no Import section — clean link"
+          else
+            echo "✗ wasm has unexpected imports:"
+            wasm-objdump -x -j Import "$WASM"
+            exit 1
+          fi
+
+      # The smoke wasm was already built by the --examples step above.
+      # Verify it links cleanly and runs under Node — exercises a real
+      # CSG operation (cube + translated cube → boolean union → triangle
+      # count) end-to-end, proving the link cocktail actually works at
+      # runtime, not just at link time.
+      - name: Verify zero imports (smoke example wasm)
+        run: |
+          WASM=target/wasm32-unknown-unknown/debug/examples/wasm32_uu_smoke.wasm
+          if wasm-objdump -x -j Import "$WASM" 2>&1 | grep -q "Section not found"; then
+            echo "✓ smoke wasm has no Import section"
+          else
+            echo "✗ smoke wasm has unexpected imports:"
+            wasm-objdump -x -j Import "$WASM"
+            exit 1
+          fi
+
+      - name: Run smoke under Node
+        run: node crates/manifold-csg/wasm32-uu-runner/run.mjs target/wasm32-unknown-unknown/debug/examples/wasm32_uu_smoke.wasm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold) geom
 
 - `crates/manifold-csg-sys/` — Raw C FFI bindings (`links = "manifold"`)
 - `crates/manifold-csg/` — Safe Rust wrapper (the primary public API)
+- `crates/manifold-csg-sys/wasm32-uu/` — Vendored helper files (config_site, mutex stub, libcxx-extras.cpp, iostream-stripping patches) used only when building for `wasm32-unknown-unknown`. See `docs/plans/wasm-unknown-unknown.md`.
 - `docs/plans/` — Design docs for in-flight or speculative work (e.g. new target support, large refactors). Lives in the repo so it travels with branches and stays reviewable; preferred over scattered GitHub issue prose for anything bigger than a paragraph.
 
 ## Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ cargo build           # builds both crates
 cargo test --features nalgebra   # runs the test suite
 ```
 
-Tested on Linux, macOS, Windows, and `wasm32-unknown-emscripten` (see below).
+Tested on Linux, macOS, Windows, `wasm32-unknown-emscripten`, and
+`wasm32-unknown-unknown` (see below).
 
 ### Browser / WebAssembly (`wasm32-unknown-emscripten`)
 
@@ -121,9 +122,8 @@ Notes:
   via COOP/COEP HTTP headers. Use `--no-default-features` to opt out cleanly.
 - Tests using `std::thread::spawn` are marked `#[ignore]` on this target for
   the same reason.
-- We do *not* support `wasm32-unknown-unknown` (no libc/libcxx — see
-  [issue #30](https://github.com/zmerlynn/manifold-csg/issues/30) and
-  [docs/plans/wasm-emscripten.md](docs/plans/wasm-emscripten.md) for context).
+- For `wasm32-unknown-unknown` support (the wasm-bindgen-compatible
+  target), see the next section.
 - End-user crates that produce their own `bin`/`cdylib` from a wasm build
   need to forward the same emscripten link flags. Add a one-line `build.rs`
   that re-emits `DEP_MANIFOLD_LINK_ARGS`, or set them via `.cargo/config.toml`.
@@ -131,12 +131,73 @@ Notes:
   `cargo build --example basics --target wasm32-unknown-emscripten -p manifold-csg --no-default-features`
   produces a `.wasm` + `.js` shim you can run with `node target/wasm32-unknown-emscripten/debug/examples/basics.js`.
 
+### Browser without Emscripten (`wasm32-unknown-unknown`)
+
+`manifold-csg` also builds for the bare-wasm target — the same one
+`wasm-bindgen` consumers (Bevy, Leptos, Yew, etc.) target. The C++
+runtime gap (`wasm32-unknown-unknown` ships no libc, no libc++, no
+libc++abi) is filled by [`wasm-cxx-shim`](https://github.com/zmerlynn/wasm-cxx-shim),
+which is cloned and built automatically by `build.rs`.
+
+**This target is provisional.** The build carries patches against upstream
+manifold and Clipper2, ships without an exception runtime (implicit STL
+throws abort), and disables OBJ I/O. To acknowledge these constraints,
+the `unstable-wasm-uu` cargo feature is required for any build targeting
+`wasm32-unknown-unknown`. Without it, `build.rs` aborts with an instructive
+error.
+
+```toml
+manifold-csg = { version = "...", default-features = false, features = ["unstable-wasm-uu"] }
+```
+
+Requirements:
+
+- A wasm-capable LLVM 20+ install:
+  - macOS: `brew install llvm` (then add `/opt/homebrew/opt/llvm@20/bin` to PATH)
+  - Debian: `apt install clang-20 lld-20 libc++-20-dev libc++abi-20-dev`
+- Rust target: `rustup target add wasm32-unknown-unknown`
+- If LLVM is in a non-standard location, set
+  `WASM_CXX_SHIM_LLVM_BIN_DIR=/path/to/llvm/bin` in your environment.
+
+```sh
+cargo build --target wasm32-unknown-unknown -p manifold-csg \
+    --no-default-features --features unstable-wasm-uu
+```
+
+A runnable smoke example exercises a real CSG operation under Node:
+
+```sh
+cargo build --example wasm32_uu_smoke --target wasm32-unknown-unknown \
+    -p manifold-csg --no-default-features --features unstable-wasm-uu
+node crates/manifold-csg/wasm32-uu-runner/run.mjs \
+    target/wasm32-unknown-unknown/debug/examples/wasm32_uu_smoke.wasm
+# wasm32-uu-smoke: smoke_run() = 36 (triangle count, > 0) ✓
+```
+
+Notes:
+
+- First build is slow (clones manifold + Clipper2 + wasm-cxx-shim, builds
+  three cmake projects in cross-compile). Subsequent builds use the cached
+  artifacts.
+- The `parallel` feature is unavailable on this target (no threads in
+  default `wasm32-unknown-unknown`).
+- OBJ I/O is unavailable on this target (`Manifold::from_obj`/`to_obj` and
+  `MeshGL64::from_obj`/`to_obj` are `#[cfg]`-elided). Manifold's iostream-
+  based OBJ paths depend on libc++ machinery the freestanding wasm build
+  excludes; use the binary `MeshGL64` API to round-trip mesh data instead.
+- Exceptions abort. Compiled with `-fno-exceptions`; implicit STL throws
+  (`bad_alloc`, etc.) become unrecoverable wasm traps.
+- See [`docs/plans/wasm-unknown-unknown.md`](docs/plans/wasm-unknown-unknown.md)
+  for the design background and production-readiness checklist.
+- If the build fails, run `bash crates/manifold-csg-sys/wasm32-uu/diagnose.sh > bugreport.txt 2>&1` and attach the output to your issue — it captures the LLVM probe ladder, env vars, and cached build state.
+
 ## Feature flags
 
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `parallel` | yes | Enables TBB-based parallelism for boolean operations |
 | `nalgebra` | no | Adds convenience methods that accept `nalgebra::Matrix3`, `Vector3`, `Point3` |
+| `unstable-wasm-uu` | no | **Required** when targeting `wasm32-unknown-unknown`. Acknowledges that target's provisional status (carry-patches, no exceptions, no OBJ I/O). Has no effect on other targets. |
 
 ## Documentation
 

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.4.104"
+version = "3.4.105"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -14,6 +14,11 @@ build = "build.rs"
 [features]
 default = ["parallel"]
 parallel = []
+# Acknowledges that wasm32-unknown-unknown support is provisional. Required
+# to build for that target. See the "Browser without Emscripten" section of
+# the README for the rationale (carry-patches against upstream, no exception
+# runtime, OBJ I/O disabled).
+unstable-wasm-uu = []
 
 [build-dependencies]
 cmake = "0.1"

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -38,8 +38,20 @@ fn main() {
     // Read target info from cargo (build-script-host cfg! is wrong for cross-compiling).
     let target = env::var("TARGET").unwrap_or_default();
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
     let is_emscripten = target_os == "emscripten";
+    // wasm32-unknown-unknown — bare wasm without WASI or Emscripten. Browser
+    // target for wasm-bindgen consumers. Has its own dedicated build path
+    // that consumes wasm-cxx-shim for the C/C++ runtime; the rest of this
+    // function (clone manifold, host cmake, etc.) is bypassed.
+    let is_wasm_unknown_unknown =
+        target_arch == "wasm32" && target_os == "unknown" && target_env.is_empty();
+
+    if is_wasm_unknown_unknown {
+        build_wasm_unknown_unknown();
+        return;
+    }
 
     if is_emscripten {
         // emcmake/emmake wrap cmake to inject the Emscripten toolchain. They
@@ -364,4 +376,690 @@ fn main() {
         // crates/manifold-csg/build.rs to match.
         println!("cargo:link_args={}", link_args.join(" "));
     }
+}
+
+// ── wasm32-unknown-unknown build path ────────────────────────────────────
+//
+// Bare wasm — no WASI, no Emscripten. Targets the wasm-bindgen Rust web
+// ecosystem (Bevy, Leptos, Yew, etc., once wasm-bindgen lands emscripten
+// support; usable today by any wasm-bindgen-style consumer that doesn't
+// need wasm-bindgen itself). Depends on `wasm-cxx-shim` for the C/C++
+// runtime layer that wasm32-unknown-unknown is missing (no libc, no
+// libcxx, no libcxxabi).
+//
+// The build path here is fundamentally different from the host/emscripten
+// path: a different toolchain (clang via wasm-cxx-shim's toolchain file),
+// different cmake flags (-fno-exceptions, -fno-rtti, -nostdlib, -nostdinc++,
+// MANIFOLD_PAR=OFF, etc.), additional dependencies (Clipper2 cloned
+// separately so we can patch it), additional carry-patches to manifold
+// (iostream gating), and a libcxx-extras.cpp consumer-side file that
+// provides the libc++ source-file symbols (shared_ptr internals, etc.)
+// the shim deliberately doesn't ship.
+//
+// See docs/plans/wasm-unknown-unknown.md for the design and
+// `crates/manifold-csg-sys/wasm32-uu/` for the vendored helper files.
+//
+// Reference implementation: wasm-cxx-shim's
+// `test/manifold-link/CMakeLists.txt` (the same recipe, expressed as a
+// build.rs instead of a cmake file).
+
+const WASM_CXX_SHIM_GIT: &str = "https://github.com/zmerlynn/wasm-cxx-shim.git";
+const WASM_CXX_SHIM_TAG: &str = "v0.2.0";
+
+// Clipper2 SHA — must match what manifold pins (cmake/manifoldDeps.cmake).
+// If manifold bumps its Clipper2 pin, this must move in lockstep, or the
+// FETCHCONTENT_SOURCE_DIR_CLIPPER2 override + iostream patch may fail to
+// apply against the version manifold actually expects.
+const CLIPPER2_GIT: &str = "https://github.com/AngusJohnson/Clipper2.git";
+const CLIPPER2_SHA: &str = "46f639177fe418f9689e8ddb74f08a870c71f5b4";
+
+fn build_wasm_unknown_unknown() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=patches");
+    println!("cargo:rerun-if-changed=wasm32-uu");
+
+    // wasm32-unknown-unknown support is provisional: the build path carries
+    // patches against upstream manifold and Clipper2, ships without an
+    // exception runtime (implicit STL throws abort), disables OBJ I/O, and
+    // depends on a precise LLVM toolchain. Require an explicit feature flag
+    // so this is acknowledged at the consumer's Cargo.toml.
+    if env::var("CARGO_FEATURE_UNSTABLE_WASM_UU").is_err() {
+        panic!(
+            "Building manifold-csg-sys for wasm32-unknown-unknown requires \
+             the `unstable-wasm-uu` cargo feature. Add it to your dependency:\n\
+             \n    \
+             manifold-csg = {{ version = \"...\", features = [\"unstable-wasm-uu\"] }}\n\
+             \n\
+             See the README's \"Browser without Emscripten\" section for the \
+             constraints (no exceptions, no OBJ I/O, requires LLVM 20+)."
+        );
+    }
+    println!(
+        "cargo:warning=manifold-csg-sys: wasm32-unknown-unknown support is \
+         provisional. Carry-patches against upstream manifold and Clipper2; \
+         no exception runtime; OBJ I/O disabled. See README for details."
+    );
+    // Env vars that influence toolchain selection. Without these,
+    // Cargo treats them as untracked and may skip rerunning build.rs
+    // when the user changes their LLVM install pointer.
+    println!("cargo:rerun-if-env-changed=WASM_CXX_SHIM_LLVM_BIN_DIR");
+    println!("cargo:rerun-if-env-changed=WASM_CXX_SHIM_LIBCXX_HEADERS");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let wasm_dir = manifest_dir.join("wasm32-uu");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+    // ---- Toolchain sanity check ----------------------------------------
+    //
+    // Resolve LLVM up front (instead of probing for stock `clang`, which on
+    // macOS is Apple's clang and lacks libc++ headers in the layout we
+    // need). find_llvm() panics with a focused install hint if the lookup
+    // fails, so the user sees the right error before any cmake work
+    // starts.
+    if Command::new("cmake").arg("--version").output().is_err() {
+        panic!(
+            "Building for wasm32-unknown-unknown requires cmake on PATH. \
+             Install via `brew install cmake` or your distro's package manager."
+        );
+    }
+    let (clangpp, libcxx_headers, llvm_candidates) = find_llvm();
+
+    // Diagnostic context for cmake/clang failures. Populated before any
+    // cmake invocation so bail_with_diagnostics can report what build.rs
+    // actually resolved (vs. what cmake might have re-discovered).
+    let ctx = BuildContext {
+        clangpp: clangpp.clone(),
+        libcxx_headers: libcxx_headers.clone(),
+        llvm_candidates,
+    };
+
+    // Warn loudly if the user has the `parallel` feature on for this
+    // target (it's a no-op — wasm32-unknown-unknown has no threads — but
+    // a silent downgrade is worse than a noisy one). Mirrors the
+    // emscripten path's behavior.
+    if env::var("CARGO_FEATURE_PARALLEL").is_ok() {
+        println!(
+            "cargo:warning=manifold-csg-sys: 'parallel' feature is not supported on \
+             wasm32-unknown-unknown; building without TBB. Disable default-features \
+             or the 'parallel' feature to silence this warning."
+        );
+    }
+
+    // ---- Stage 1: clone + build wasm-cxx-shim ---------------------------
+
+    let shim_src = out_dir.join("wasm-cxx-shim-src");
+    let shim_build = out_dir.join("wasm-cxx-shim-build");
+    let shim_stamp = out_dir.join(".shim-version-stamp");
+    let shim_old = std::fs::read_to_string(&shim_stamp).unwrap_or_default();
+    if shim_old.trim() != WASM_CXX_SHIM_TAG && shim_src.exists() {
+        let _ = std::fs::remove_dir_all(&shim_src);
+        let _ = std::fs::remove_dir_all(&shim_build);
+    }
+    if !shim_src.join("CMakeLists.txt").exists() {
+        // Partial clone from a previous failed run? Wipe and retry.
+        if shim_src.exists() {
+            let _ = std::fs::remove_dir_all(&shim_src);
+        }
+        let status = Command::new("git")
+            .args([
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                WASM_CXX_SHIM_TAG,
+                WASM_CXX_SHIM_GIT,
+                shim_src.to_str().unwrap(),
+            ])
+            .status()
+            .expect("failed to run git clone for wasm-cxx-shim");
+        assert!(status.success(), "git clone wasm-cxx-shim failed");
+        let _ = std::fs::write(&shim_stamp, WASM_CXX_SHIM_TAG);
+    }
+
+    let shim_toolchain = shim_src.join("cmake/toolchain-wasm32.cmake");
+    assert!(
+        shim_toolchain.exists(),
+        "wasm-cxx-shim missing toolchain at {}",
+        shim_toolchain.display()
+    );
+
+    if !shim_build.join("libc/libwasm-cxx-shim-libc.a").exists() {
+        let status = Command::new("cmake")
+            .args([
+                "-S",
+                shim_src.to_str().unwrap(),
+                "-B",
+                shim_build.to_str().unwrap(),
+                &format!("-DCMAKE_TOOLCHAIN_FILE={}", shim_toolchain.display()),
+                "-DCMAKE_BUILD_TYPE=Release",
+            ])
+            .status()
+            .expect("failed to run cmake configure for wasm-cxx-shim");
+        if !status.success() {
+            bail_with_diagnostics(&ctx, "wasm-cxx-shim cmake configure", &shim_build);
+        }
+
+        let status = Command::new("cmake")
+            .args([
+                "--build",
+                shim_build.to_str().unwrap(),
+                "--config",
+                "Release",
+                "--parallel",
+            ])
+            .status()
+            .expect("failed to run cmake build for wasm-cxx-shim");
+        if !status.success() {
+            bail_with_diagnostics(&ctx, "wasm-cxx-shim cmake build", &shim_build);
+        }
+    }
+
+    // ---- Stage 2: clone + patch Clipper2 --------------------------------
+    //
+    // We pin Clipper2 ourselves (matching what manifold pins) and apply
+    // the iostream-strip patch. We then point manifold's FetchContent at
+    // our pre-cloned source via FETCHCONTENT_SOURCE_DIR_CLIPPER2, so
+    // manifold's cmake reuses our patched copy instead of re-cloning.
+
+    let clipper2_src = out_dir.join("clipper2-src");
+    let clipper2_stamp = out_dir.join(".clipper2-version-stamp");
+    let clipper2_old = std::fs::read_to_string(&clipper2_stamp).unwrap_or_default();
+    if clipper2_old.trim() != CLIPPER2_SHA && clipper2_src.exists() {
+        let _ = std::fs::remove_dir_all(&clipper2_src);
+    }
+    if !clipper2_src.join("CMakeLists.txt").exists() {
+        if clipper2_src.exists() {
+            let _ = std::fs::remove_dir_all(&clipper2_src);
+        }
+        // Clipper2 doesn't have shallow tags here — clone full history then
+        // checkout the SHA. The repo is small.
+        let status = Command::new("git")
+            .args(["clone", CLIPPER2_GIT, clipper2_src.to_str().unwrap()])
+            .status()
+            .expect("failed to run git clone for Clipper2");
+        assert!(status.success(), "git clone Clipper2 failed");
+
+        let status = Command::new("git")
+            .args(["checkout", CLIPPER2_SHA])
+            .current_dir(&clipper2_src)
+            .status()
+            .expect("failed to checkout Clipper2 SHA");
+        assert!(status.success(), "git checkout Clipper2 failed");
+
+        // Apply iostream patch.
+        let patch = wasm_dir.join("patches/0002-clipper2-strip-iostream.patch");
+        let status = Command::new("git")
+            .args(["apply", "--ignore-whitespace", "-p0"])
+            .arg(&patch)
+            .current_dir(&clipper2_src)
+            .status()
+            .expect("failed to apply Clipper2 iostream patch");
+        assert!(
+            status.success(),
+            "Clipper2 iostream patch failed to apply at SHA {CLIPPER2_SHA}"
+        );
+
+        let _ = std::fs::write(&clipper2_stamp, CLIPPER2_SHA);
+    }
+
+    // ---- Stage 3: clone + patch manifold (separate tree from host build)
+    //
+    // The host/emscripten codepath uses out_dir.join("manifold-src") and
+    // applies its own patches (#1687, #1688). We need the same source but
+    // also our wasm32-uu iostream patch, AND a separate cmake build dir so
+    // the two configurations don't fight.
+    //
+    // Cleanest: a separate clone path so artifacts don't collide.
+
+    let manifold_src = out_dir.join("manifold-src-wasm32-uu");
+    let manifold_build = out_dir.join("manifold-build-wasm32-uu");
+    let manifold_stamp = out_dir.join(".manifold-wasm32-uu-version-stamp");
+    let manifold_old = std::fs::read_to_string(&manifold_stamp).unwrap_or_default();
+    if manifold_old.trim() != MANIFOLD_VERSION && manifold_src.exists() {
+        let _ = std::fs::remove_dir_all(&manifold_src);
+        let _ = std::fs::remove_dir_all(&manifold_build);
+    }
+    if !manifold_src.join("CMakeLists.txt").exists() {
+        if manifold_src.exists() {
+            let _ = std::fs::remove_dir_all(&manifold_src);
+        }
+        let status = Command::new("git")
+            .args([
+                "-c",
+                "core.autocrlf=false",
+                "clone",
+                "https://github.com/elalish/manifold.git",
+                manifold_src.to_str().unwrap(),
+            ])
+            .status()
+            .expect("failed to run git clone for manifold (wasm32-uu)");
+        assert!(status.success(), "git clone manifold failed");
+
+        let status = Command::new("git")
+            .args(["checkout", MANIFOLD_VERSION])
+            .current_dir(&manifold_src)
+            .status()
+            .expect("failed to checkout manifold pinned commit");
+        assert!(status.success(), "git checkout manifold failed");
+
+        // Apply our existing carry-patches first (#1687, #1688), then the
+        // wasm32-uu-specific ones.
+        let host_patches_dir = manifest_dir.join("patches");
+        if host_patches_dir.exists() {
+            let mut patches: Vec<_> = std::fs::read_dir(&host_patches_dir)
+                .unwrap()
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.extension().is_some_and(|e| e == "patch"))
+                .collect();
+            patches.sort();
+            for patch in &patches {
+                let status = Command::new("git")
+                    .args(["apply", "--ignore-whitespace", "--whitespace=nowarn"])
+                    .arg(patch)
+                    .current_dir(&manifold_src)
+                    .status()
+                    .expect("failed to apply carry-patch");
+                assert!(
+                    status.success(),
+                    "failed to apply carry-patch {}",
+                    patch.display()
+                );
+            }
+        }
+
+        // wasm32-uu iostream patch.
+        let patch = wasm_dir.join("patches/0001-manifold-ifdef-iostream.patch");
+        let status = Command::new("git")
+            .args(["apply", "--ignore-whitespace", "-p0"])
+            .arg(&patch)
+            .current_dir(&manifold_src)
+            .status()
+            .expect("failed to apply wasm32-uu iostream patch to manifold");
+        assert!(
+            status.success(),
+            "wasm32-uu iostream patch failed to apply against manifold @ {MANIFOLD_VERSION}"
+        );
+
+        let _ = std::fs::write(&manifold_stamp, MANIFOLD_VERSION);
+    }
+
+    // ---- Stage 4: cmake-configure + build manifold for wasm32-uu --------
+    //
+    // The compile flags here mirror what wasm-cxx-shim's
+    // test/manifold-link/CMakeLists.txt sets via add_compile_options. We
+    // pass them via CMAKE_C_FLAGS_INIT / CMAKE_CXX_FLAGS_INIT so they
+    // reach manifold's compile rules without needing a wrapper
+    // CMakeLists.txt.
+
+    // -nostdlibinc (clang-specific) drops standard system include
+    // directories but preserves the compiler resource dir, so builtin
+    // headers like <stdint.h> and <stddef.h> still resolve. Belt-and-
+    // suspenders alongside -nostdinc++: even if the explicit -isystem
+    // chain misbehaves, the host C and C++ system paths stay excluded.
+    let cxxflags = format!(
+        "-fno-exceptions -fno-rtti -nostdlib -nostdinc++ -nostdlibinc \
+         -DMANIFOLD_NO_IOSTREAM=1 \
+         -DCLIPPER2_MAX_DECIMAL_PRECISION=8 \
+         -isystem {wasm_inc} \
+         -isystem {libcxx_inc} \
+         -isystem {shim_libm_inc} \
+         -isystem {shim_libc_inc}",
+        wasm_inc = wasm_dir.join("include").display(),
+        libcxx_inc = libcxx_headers.display(),
+        shim_libm_inc = shim_src.join("libm/include").display(),
+        shim_libc_inc = shim_src.join("libc/include").display(),
+    );
+    let cflags = format!(
+        "-nostdlib -nostdlibinc \
+         -isystem {shim_libc_inc}",
+        shim_libc_inc = shim_src.join("libc/include").display(),
+    );
+
+    let status = Command::new("cmake")
+        .args([
+            "-S",
+            manifold_src.to_str().unwrap(),
+            "-B",
+            manifold_build.to_str().unwrap(),
+            &format!("-DCMAKE_TOOLCHAIN_FILE={}", shim_toolchain.display()),
+            "-DCMAKE_BUILD_TYPE=Release",
+            &format!("-DCMAKE_C_FLAGS_INIT={cflags}"),
+            &format!("-DCMAKE_CXX_FLAGS_INIT={cxxflags}"),
+            // Use our pre-patched Clipper2 instead of letting manifold clone its own.
+            &format!(
+                "-DFETCHCONTENT_SOURCE_DIR_CLIPPER2={}",
+                clipper2_src.display()
+            ),
+            "-DMANIFOLD_TEST=OFF",
+            "-DMANIFOLD_PYBIND=OFF",
+            "-DMANIFOLD_JSBIND=OFF",
+            "-DMANIFOLD_CBIND=ON",
+            "-DMANIFOLD_CROSS_SECTION=ON",
+            "-DMANIFOLD_PAR=OFF",
+            "-DMANIFOLD_USE_BUILTIN_CLIPPER2=ON",
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=OFF",
+            // Clipper2 default-on options pull in things we don't have.
+            "-DCLIPPER2_TESTS=OFF",
+            "-DCLIPPER2_UTILS=OFF",
+            "-DCLIPPER2_EXAMPLES=OFF",
+        ])
+        .status()
+        .expect("failed to run cmake configure for manifold (wasm32-uu)");
+    if !status.success() {
+        bail_with_diagnostics(&ctx, "manifold cmake configure", &manifold_build);
+    }
+
+    let status = Command::new("cmake")
+        .args([
+            "--build",
+            manifold_build.to_str().unwrap(),
+            "--config",
+            "Release",
+            "--parallel",
+        ])
+        .status()
+        .expect("failed to run cmake build for manifold (wasm32-uu)");
+    if !status.success() {
+        bail_with_diagnostics(&ctx, "manifold cmake build", &manifold_build);
+    }
+
+    // ---- Stage 5: compile + archive libcxx-extras.cpp -------------------
+    //
+    // libcxx-extras provides the libc++ source-file symbols (shared_ptr
+    // internals, std::nothrow, etc.) the shim deliberately doesn't ship.
+    // We compile it here and wrap the .o in a static archive so we can
+    // emit it via cargo:rustc-link-lib=static and let cargo control
+    // link order alongside the other archives.
+
+    let extras_o = out_dir.join("libcxx-extras.o");
+    let extras_a = out_dir.join("libcxx_extras.a");
+    let extras_cpp = wasm_dir.join("libcxx-extras.cpp");
+
+    let status = Command::new(&clangpp)
+        .args([
+            "--target=wasm32-unknown-unknown",
+            "-std=c++17",
+            "-Os",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-nostdlib",
+            "-nostdinc++",
+            "-nostdlibinc",
+        ])
+        .arg(format!("-isystem{}", wasm_dir.join("include").display()))
+        .arg(format!("-isystem{}", libcxx_headers.display()))
+        .arg(format!(
+            "-isystem{}",
+            shim_src.join("libm/include").display()
+        ))
+        .arg(format!(
+            "-isystem{}",
+            shim_src.join("libc/include").display()
+        ))
+        .arg("-c")
+        .arg(&extras_cpp)
+        .arg("-o")
+        .arg(&extras_o)
+        .status()
+        .expect("failed to compile libcxx-extras.cpp");
+    if !status.success() {
+        bail_with_diagnostics(&ctx, "libcxx-extras compile", &out_dir);
+    }
+
+    let _ = std::fs::remove_file(&extras_a);
+    // Use the llvm-ar that ships with our clang (next to it in the LLVM
+    // bin/ dir). System `ar` won't produce wasm-friendly archives.
+    let llvm_ar = clangpp
+        .parent()
+        .map(|d| d.join("llvm-ar"))
+        .filter(|p| p.exists())
+        .unwrap_or_else(|| PathBuf::from("llvm-ar"));
+    let status = Command::new(&llvm_ar)
+        .args(["rcs"])
+        .arg(&extras_a)
+        .arg(&extras_o)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run {} for libcxx-extras: {e}", llvm_ar.display()));
+    if !status.success() {
+        bail_with_diagnostics(&ctx, "libcxx-extras llvm-ar", &out_dir);
+    }
+
+    // ---- Stage 6: emit cargo metadata -----------------------------------
+    //
+    // Link order matters for static archives. Wasm-ld processes archives
+    // left-to-right and pulls .o files as needed by previously-seen
+    // undefined symbols. The order below mirrors wasm-cxx-shim's
+    // test/manifold-link/CMakeLists.txt:
+    //
+    //   user obj/rlib (Rust crate) → libcxx_extras → manifoldc → manifold
+    //     → Clipper2 → wasm-cxx-shim-libcxx → wasm-cxx-shim-libc
+    //     → wasm-cxx-shim-libm
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=cxx_extras");
+
+    let manifold_lib_dirs = [
+        manifold_build.join("bindings/c"), // libmanifoldc.a
+        manifold_build.join("src"),        // libmanifold.a
+        manifold_build.join("_deps/clipper2-build"),
+    ];
+    for d in &manifold_lib_dirs {
+        if d.exists() {
+            println!("cargo:rustc-link-search=native={}", d.display());
+        }
+    }
+    println!("cargo:rustc-link-lib=static=manifoldc");
+    println!("cargo:rustc-link-lib=static=manifold");
+    println!("cargo:rustc-link-lib=static=Clipper2");
+
+    let shim_lib_dirs = [
+        shim_build.join("libcxx"),
+        shim_build.join("libc"),
+        shim_build.join("libm"),
+    ];
+    for d in &shim_lib_dirs {
+        println!("cargo:rustc-link-search=native={}", d.display());
+    }
+    println!("cargo:rustc-link-lib=static=wasm-cxx-shim-libcxx");
+    println!("cargo:rustc-link-lib=static=wasm-cxx-shim-libc");
+    println!("cargo:rustc-link-lib=static=wasm-cxx-shim-libm");
+
+    // No `cargo:rustc-link-lib=c++/stdc++` on this target — wasm-cxx-shim
+    // covers the C++ runtime. (Same reason emscripten skips it: emcc's
+    // libc++ is auto-linked; ours is provided by the shim.)
+}
+
+/// Diagnostic context populated up-front in `build_wasm_unknown_unknown()`,
+/// passed to `bail_with_diagnostics()` so cmake/clang failures emit the
+/// resolved toolchain paths the user actually needs to debug.
+struct BuildContext {
+    clangpp: PathBuf,
+    libcxx_headers: PathBuf,
+    /// Bin dirs the LLVM probe actually checked, in the order they were tried.
+    /// Surfaces the discovery ladder without making the user re-derive it.
+    llvm_candidates: Vec<PathBuf>,
+}
+
+/// Print a diagnostic dump and panic. Called from each cmake/clang
+/// failure site in the wasm32-uu path.
+///
+/// We don't capture cmake's stdout/stderr (they stream live), so this
+/// dump comes *after* whatever cmake/make printed. It adds context the
+/// user can't see otherwise: what build.rs resolved as the LLVM
+/// toolchain, the env vars that influence it, and tails of cmake's own
+/// configure-time logs.
+fn bail_with_diagnostics(ctx: &BuildContext, stage: &str, build_dir: &Path) -> ! {
+    eprintln!("\n=== manifold-csg-sys: wasm32-unknown-unknown build failed ({stage}) ===");
+    eprintln!("clang++:        {}", ctx.clangpp.display());
+    eprintln!("libc++ headers: {}", ctx.libcxx_headers.display());
+    eprintln!("build dir:      {}", build_dir.display());
+    eprintln!("LLVM candidates probed (in order):");
+    for c in &ctx.llvm_candidates {
+        eprintln!("  {}", c.display());
+    }
+    eprintln!("environment:");
+    for k in [
+        "WASM_CXX_SHIM_LLVM_BIN_DIR",
+        "WASM_CXX_SHIM_LIBCXX_HEADERS",
+        "CC",
+        "CXX",
+        "CFLAGS",
+        "CXXFLAGS",
+        "LDFLAGS",
+        "RUSTFLAGS",
+    ] {
+        let v = env::var(k).unwrap_or_else(|_| "<unset>".into());
+        eprintln!("  {k}={v}");
+    }
+    // cmake's own diagnostic logs — most useful for configure-time
+    // failures (try-compile, missing tools). For build-time compile
+    // errors the relevant output already streamed live above; these
+    // will simply be absent or stale.
+    for log in ["CMakeFiles/CMakeError.log", "CMakeFiles/CMakeOutput.log"] {
+        let p = build_dir.join(log);
+        if let Ok(contents) = std::fs::read_to_string(&p) {
+            let lines: Vec<&str> = contents.lines().collect();
+            let start = lines.len().saturating_sub(200);
+            eprintln!(
+                "\n--- {} (last 200 lines) ---\n{}",
+                p.display(),
+                lines[start..].join("\n")
+            );
+        }
+    }
+    eprintln!(
+        "\nFor a full bug report, run:\n  \
+         bash crates/manifold-csg-sys/wasm32-uu/diagnose.sh > bugreport.txt 2>&1\n\
+         and attach bugreport.txt to the issue.\n"
+    );
+    panic!("wasm32-unknown-unknown build failed at stage: {stage}");
+}
+
+/// Locate an LLVM install with wasm32 support, returning
+/// (clang++ path, libc++ headers dir, candidates probed in order).
+///
+/// The candidates list is returned alongside the resolved paths so that
+/// `bail_with_diagnostics()` can show what the probe ladder considered
+/// even on a successful resolve (which still might be wrong — e.g. an
+/// LLVM that's too old, or a libc++ that doesn't actually match).
+///
+/// Mirrors wasm-cxx-shim's toolchain-wasm32.cmake discovery ladder so we
+/// pick the same LLVM the cmake build is using. Order:
+///   1. `WASM_CXX_SHIM_LLVM_BIN_DIR` env var (explicit override)
+///   2. Common per-platform locations:
+///        - macOS: /opt/homebrew/opt/llvm[@N]/bin
+///        - Linux Debian-family: /usr/lib/llvm-N/bin
+///   3. PATH lookup (Apple's stock clang lacks libc++ headers, so this is
+///      a last resort)
+///
+/// `WASM_CXX_SHIM_LIBCXX_HEADERS` env var separately overrides just the
+/// header path, for cases where the user wants a non-default libc++.
+fn find_llvm() -> (PathBuf, PathBuf, Vec<PathBuf>) {
+    let candidates = candidate_llvm_bin_dirs();
+
+    if let Ok(headers) = env::var("WASM_CXX_SHIM_LIBCXX_HEADERS") {
+        let headers = PathBuf::from(headers);
+        let clangpp = which("clang++")
+            .or_else(|| which("clang"))
+            .expect("clang++/clang not found on PATH");
+        warn_if_system_libcxx(&headers);
+        return (clangpp, headers, candidates);
+    }
+
+    for bin_dir in &candidates {
+        let clangpp = bin_dir.join("clang++");
+        if !clangpp.exists() {
+            continue;
+        }
+        let llvm_root = bin_dir.parent().unwrap();
+        // LLVM ships libc++ headers either at <root>/include/c++/v1 or
+        // <root>/lib/c++/v1, depending on layout. Try both.
+        for rel in ["include/c++/v1", "lib/c++/v1"] {
+            let headers = llvm_root.join(rel);
+            if headers.join("vector").exists() {
+                warn_if_system_libcxx(&headers);
+                return (clangpp, headers, candidates);
+            }
+        }
+    }
+
+    panic!(
+        "Could not find an LLVM install with libc++ headers and wasm32 support.\n\
+         Tried: {candidates:?}\n\
+         Install via:\n\
+         \x20  - macOS:  brew install llvm  (then add to PATH per brew's instructions)\n\
+         \x20  - Debian: apt install clang-20 lld-20 libc++-20-dev libc++abi-20-dev\n\
+         Or set WASM_CXX_SHIM_LLVM_BIN_DIR to the directory containing clang++\n\
+         (and ensure ../include/c++/v1 contains libc++ headers).\n\
+         See docs/plans/wasm-unknown-unknown.md."
+    );
+}
+
+/// Warn if `headers` (after symlink resolution) lives under a system
+/// include path. On Debian-family distros, `/usr/lib/llvm-N/include/c++/v1`
+/// is sometimes a symlink to `/usr/include/c++/v1` — meaning even though
+/// we pass a versioned LLVM path to `-isystem`, clang ends up reading the
+/// system libc++. That's the failure mode we hit when the system libc++
+/// is newer (or older) than what our vendored `__config_site` covers.
+///
+/// We warn rather than reject because the symlink layout sometimes works
+/// fine; only flag it so the user can correlate the warning with a build
+/// failure and override via `WASM_CXX_SHIM_LIBCXX_HEADERS`.
+fn warn_if_system_libcxx(headers: &Path) {
+    let canonical = std::fs::canonicalize(headers).unwrap_or_else(|_| headers.to_path_buf());
+    if canonical.starts_with("/usr/include/") || canonical.starts_with("/usr/local/include/") {
+        println!(
+            "cargo:warning=manifold-csg-sys: libc++ headers at {} resolve to a system path \
+             ({}). System libc++ may be incompatible with our vendored __config_site; \
+             if the build fails with _LIBCPP_* config errors, set \
+             WASM_CXX_SHIM_LIBCXX_HEADERS to a non-symlinked LLVM-versioned path.",
+            headers.display(),
+            canonical.display()
+        );
+    }
+}
+
+fn candidate_llvm_bin_dirs() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(d) = env::var("WASM_CXX_SHIM_LLVM_BIN_DIR") {
+        out.push(PathBuf::from(d));
+    }
+    // Newest first; first match wins. Mirrors the toolchain file's range.
+    for v in [22, 21, 20, 19, 18] {
+        // macOS Homebrew (Apple Silicon and Intel)
+        out.push(PathBuf::from(format!("/opt/homebrew/opt/llvm@{v}/bin")));
+        out.push(PathBuf::from(format!("/usr/local/opt/llvm@{v}/bin")));
+        // Debian-family
+        out.push(PathBuf::from(format!("/usr/lib/llvm-{v}/bin")));
+    }
+    // Unversioned brew paths
+    out.push(PathBuf::from("/opt/homebrew/opt/llvm/bin"));
+    out.push(PathBuf::from("/usr/local/opt/llvm/bin"));
+    // Last-resort PATH lookup. (Nested-if rather than let-chain so we
+    // stay compatible with our 1.85 MSRV; let-chains landed in 1.88.)
+    #[allow(clippy::collapsible_if)]
+    if let Some(p) = which("clang++") {
+        if let Some(parent) = p.parent() {
+            out.push(parent.to_path_buf());
+        }
+    }
+    out
+}
+
+fn which(name: &str) -> Option<PathBuf> {
+    let output = Command::new(if cfg!(target_os = "windows") {
+        "where"
+    } else {
+        "which"
+    })
+    .arg(name)
+    .output()
+    .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8(output.stdout).ok()?;
+    Some(PathBuf::from(path.lines().next()?.trim()))
 }

--- a/crates/manifold-csg-sys/cache-version
+++ b/crates/manifold-csg-sys/cache-version
@@ -1,1 +1,10 @@
-1
+# Cache-busting marker for CI's actions/cache stanzas.
+#
+# Workflow `key:` and `restore-keys:` both hash this file, so bumping
+# anything below invalidates every matching cache the next time CI runs.
+# Use this when restored caches contain stale state that the normal
+# Cargo.lock / build.rs hash doesn't catch — e.g. a cmake build dir
+# that hardcoded a per-runner-job temp path that no longer exists.
+#
+# Bump procedure: increment the integer below, commit, push.
+2

--- a/crates/manifold-csg-sys/src/lib.rs
+++ b/crates/manifold-csg-sys/src/lib.rs
@@ -1469,11 +1469,18 @@ unsafe extern "C" {
     pub fn manifold_reset_to_circular_defaults();
 
     // ── OBJ I/O ─────────────────────────────────────────────────────────
+    //
+    // These four functions live in manifold's iostream-using path, gated by
+    // `MANIFOLD_NO_IOSTREAM` upstream-side. On wasm32-unknown-unknown we
+    // build with that macro defined (the C++ symbols don't exist), so the
+    // FFI declarations are also elided. Consumers reaching for OBJ I/O on
+    // that target should use the binary `MeshGL64` API instead.
 
     /// Import a manifold from a Wavefront obj file.
     ///
     /// The `obj_file` parameter is the content of the obj file (not the filename),
     /// and should be null-terminated.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_read_obj(
         mem: *mut ManifoldManifold,
         obj_file: *const std::ffi::c_char,
@@ -1483,6 +1490,7 @@ unsafe extern "C" {
     ///
     /// The `obj_file` parameter is the content of the obj file (not the filename),
     /// and should be null-terminated.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_meshgl64_read_obj(
         mem: *mut ManifoldMeshGL64,
         obj_file: *const std::ffi::c_char,
@@ -1493,6 +1501,7 @@ unsafe extern "C" {
     /// The callback receives a temporary null-terminated string buffer containing
     /// the obj content, plus a user-provided context pointer. The buffer is freed
     /// automatically after the callback returns.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_write_obj(
         manifold: *const ManifoldManifold,
         callback: Option<unsafe extern "C" fn(*mut std::ffi::c_char, *mut std::ffi::c_void)>,
@@ -1504,6 +1513,7 @@ unsafe extern "C" {
     /// The callback receives a temporary null-terminated string buffer containing
     /// the obj content, plus a user-provided context pointer. The buffer is freed
     /// automatically after the callback returns.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_meshgl64_write_obj(
         mesh: *const ManifoldMeshGL64,
         callback: Option<unsafe extern "C" fn(*mut std::ffi::c_char, *mut std::ffi::c_void)>,

--- a/crates/manifold-csg-sys/wasm32-uu/diagnose.sh
+++ b/crates/manifold-csg-sys/wasm32-uu/diagnose.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Collect host + toolchain info for a wasm32-unknown-unknown build of
+# manifold-csg. Run from the repo root and attach the output to a bug
+# report:
+#
+#   bash crates/manifold-csg-sys/wasm32-uu/diagnose.sh > bugreport.txt 2>&1
+#
+# Read-only and idempotent. Sections mirror the LLVM probe ladder in
+# build.rs (find_llvm / candidate_llvm_bin_dirs) so the report says what
+# build.rs would see.
+
+set -u
+
+# Resolve repo root from this script's location so users can run it
+# from anywhere (./.cargo/config.toml, target/..., etc. below are
+# resolved relative to the repo, not pwd).
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+cd "$repo_root"
+
+section() {
+    printf '\n=== %s ===\n' "$1"
+}
+
+# Run a command if available; otherwise print "(not installed)".
+safe() {
+    if command -v "$1" >/dev/null 2>&1; then
+        "$@" 2>&1 || printf '(exit %d)\n' "$?"
+    else
+        printf '(%s not installed)\n' "$1"
+    fi
+}
+
+# Print the contents of a file if it exists, else a marker line.
+dump_file() {
+    if [ -f "$1" ]; then
+        cat "$1"
+    else
+        printf '(missing: %s)\n' "$1"
+    fi
+}
+
+# Tail a file with a header, capped to N lines, if it exists.
+tail_file() {
+    local path="$1" lines="$2"
+    if [ -f "$path" ]; then
+        printf '\n--- %s (last %s lines) ---\n' "$path" "$lines"
+        tail -n "$lines" "$path"
+    fi
+}
+
+section "Bug report header"
+printf 'date:        %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'pwd:         %s\n' "$(pwd)"
+if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+    printf 'git sha:     %s\n' "$(git rev-parse HEAD)"
+    printf 'git branch:  %s\n' "$(git rev-parse --abbrev-ref HEAD)"
+    printf 'dirty files: %s\n' "$(git status --porcelain | wc -l | tr -d ' ')"
+else
+    printf 'git:         (not a git checkout)\n'
+fi
+
+section "Host"
+printf 'uname:       %s\n' "$(uname -a)"
+if [ -f /etc/os-release ]; then
+    printf -- '--- /etc/os-release ---\n'
+    cat /etc/os-release
+fi
+if command -v sw_vers >/dev/null 2>&1; then
+    printf -- '--- sw_vers ---\n'
+    sw_vers
+fi
+
+section "Rust toolchain"
+safe rustc -vV
+printf -- '--- cargo ---\n'
+safe cargo -vV
+printf -- '--- rustup show active-toolchain ---\n'
+safe rustup show active-toolchain
+printf -- '--- rustup target list (wasm32) ---\n'
+if command -v rustup >/dev/null 2>&1; then
+    rustup target list --installed 2>&1 | grep -i wasm32 || printf '(no wasm32 targets installed)\n'
+else
+    printf '(rustup not installed)\n'
+fi
+
+section "Build tools"
+safe cmake --version
+printf -- '--- make ---\n'
+if command -v make >/dev/null 2>&1; then
+    make --version 2>&1 | head -1
+else
+    printf '(make not installed)\n'
+fi
+printf -- '--- ninja ---\n'
+safe ninja --version
+printf -- '--- git ---\n'
+safe git --version
+printf -- '--- node ---\n'
+safe node --version
+
+section "LLVM probe ladder"
+# Mirrors candidate_llvm_bin_dirs() in build.rs. For each candidate:
+# does clang++ exist there, what does --version say, and are the
+# libc++ headers we'd consume present?
+probe_llvm_dir() {
+    local bin_dir="$1"
+    local clangpp="$bin_dir/clang++"
+    if [ ! -x "$clangpp" ]; then
+        printf '%-50s (no clang++)\n' "$bin_dir"
+        return
+    fi
+    local ver
+    ver=$("$clangpp" --version 2>&1 | head -1)
+    printf '%-50s %s\n' "$bin_dir" "$ver"
+    local llvm_root="${bin_dir%/bin}"
+    local found=""
+    for rel in include/c++/v1 lib/c++/v1; do
+        if [ -f "$llvm_root/$rel/vector" ]; then
+            found="$llvm_root/$rel"
+            break
+        fi
+    done
+    if [ -n "$found" ]; then
+        printf '  libc++ headers: %s\n' "$found"
+    else
+        printf '  libc++ headers: (NOT FOUND under %s)\n' "$llvm_root"
+    fi
+}
+
+# Same order as candidate_llvm_bin_dirs() in build.rs.
+if [ -n "${WASM_CXX_SHIM_LLVM_BIN_DIR-}" ]; then
+    printf 'WASM_CXX_SHIM_LLVM_BIN_DIR is set:\n'
+    probe_llvm_dir "$WASM_CXX_SHIM_LLVM_BIN_DIR"
+    printf '\n'
+fi
+for v in 22 21 20 19 18; do
+    probe_llvm_dir "/opt/homebrew/opt/llvm@${v}/bin"
+    probe_llvm_dir "/usr/local/opt/llvm@${v}/bin"
+    probe_llvm_dir "/usr/lib/llvm-${v}/bin"
+done
+probe_llvm_dir "/opt/homebrew/opt/llvm/bin"
+probe_llvm_dir "/usr/local/opt/llvm/bin"
+printf '\n--- which -a clang++ ---\n'
+if command -v clang++ >/dev/null 2>&1; then
+    # `which -a` is non-portable; fall back to a manual PATH walk.
+    type -a clang++ 2>/dev/null || command -v clang++
+    clang++ --version 2>&1 | head -1
+else
+    printf '(no clang++ on PATH)\n'
+fi
+
+section "System libc++ shadow check"
+# JaminKoke's failure mode: system libc++ at /usr/include/c++/v1
+# leaked into the build instead of the LLVM-versioned one. If this
+# directory exists, it's a candidate culprit.
+for path in /usr/include/c++/v1 /usr/include/c++/v1/__configuration/hardening.h; do
+    if [ -e "$path" ]; then
+        printf 'FOUND: %s\n' "$path"
+    else
+        printf 'absent: %s\n' "$path"
+    fi
+done
+
+section "Environment variables"
+for var in WASM_CXX_SHIM_LLVM_BIN_DIR WASM_CXX_SHIM_LIBCXX_HEADERS \
+           CC CXX CFLAGS CXXFLAGS LDFLAGS \
+           RUSTFLAGS CARGO_BUILD_TARGET \
+           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_LINKER \
+           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS \
+           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER \
+           CMAKE_GENERATOR CMAKE_TOOLCHAIN_FILE; do
+    if [ -n "${!var-}" ]; then
+        printf '%s=%s\n' "$var" "${!var}"
+    else
+        printf '%s=<unset>\n' "$var"
+    fi
+done
+printf -- '\n--- ./.cargo/config.toml ---\n'
+dump_file ./.cargo/config.toml
+printf -- '\n--- ~/.cargo/config.toml ---\n'
+dump_file "$HOME/.cargo/config.toml"
+
+section "Cached build state"
+# Walk target/ for the most recent manifold-csg-sys build dir and
+# report on the cached wasm-cxx-shim / Clipper2 / manifold artifacts
+# that build.rs leaves there. Useful for diagnosing stale-cache issues
+# and for confirming what the build was configured against.
+shopt -s nullglob
+build_dirs=()
+for d in target/*/build/manifold-csg-sys-*/out target/wasm32-unknown-unknown/*/build/manifold-csg-sys-*/out; do
+    [ -d "$d" ] && build_dirs+=("$d")
+done
+if [ "${#build_dirs[@]}" -eq 0 ]; then
+    printf '(no manifold-csg-sys build dirs under target/ — nothing cached yet)\n'
+else
+    # Pick the most recently modified one. `ls -td` is portable enough.
+    out_dir=$(ls -td "${build_dirs[@]}" 2>/dev/null | head -1)
+    printf 'most recent: %s\n' "$out_dir"
+    for stamp in .shim-version-stamp .clipper2-version-stamp .manifold-wasm32-uu-version-stamp; do
+        if [ -f "$out_dir/$stamp" ]; then
+            printf '%s: %s\n' "$stamp" "$(cat "$out_dir/$stamp")"
+        else
+            printf '%s: (missing)\n' "$stamp"
+        fi
+    done
+    for lib in wasm-cxx-shim-build/libc/libwasm-cxx-shim-libc.a \
+               wasm-cxx-shim-build/libcxx/libwasm-cxx-shim-libcxx.a \
+               wasm-cxx-shim-build/libm/libwasm-cxx-shim-libm.a \
+               manifold-build-wasm32-uu/src/libmanifold.a \
+               manifold-build-wasm32-uu/bindings/c/libmanifoldc.a \
+               manifold-build-wasm32-uu/_deps/clipper2-build/libClipper2.a; do
+        if [ -f "$out_dir/$lib" ]; then
+            size=$(wc -c < "$out_dir/$lib" | tr -d ' ')
+            printf '  %s (%s bytes)\n' "$lib" "$size"
+        else
+            printf '  %s (missing)\n' "$lib"
+        fi
+    done
+    # Pull a few interesting lines out of CMakeCache.txt — the full
+    # file is huge and noisy; these tell us what compiler + flags
+    # cmake locked in.
+    for cache in wasm-cxx-shim-build/CMakeCache.txt manifold-build-wasm32-uu/CMakeCache.txt; do
+        path="$out_dir/$cache"
+        if [ -f "$path" ]; then
+            printf '\n--- %s (selected lines) ---\n' "$cache"
+            grep -E '^(CMAKE_(C|CXX)_COMPILER|CMAKE_TOOLCHAIN_FILE|CMAKE_(C|CXX)_FLAGS_INIT|CMAKE_BUILD_TYPE|FETCHCONTENT_SOURCE_DIR_CLIPPER2):' "$path" || \
+                printf '(no matching lines)\n'
+        fi
+    done
+    # CMake's own diagnostic logs — when configure fails these are
+    # the gold-standard artifacts.
+    for log in wasm-cxx-shim-build/CMakeFiles/CMakeError.log \
+               wasm-cxx-shim-build/CMakeFiles/CMakeOutput.log \
+               manifold-build-wasm32-uu/CMakeFiles/CMakeError.log \
+               manifold-build-wasm32-uu/CMakeFiles/CMakeOutput.log; do
+        tail_file "$out_dir/$log" 200
+    done
+fi
+
+section "Footer"
+cat <<'EOF'
+What to attach: the entire output of this script (stdout+stderr).
+
+If you have a partial build failure log from `cargo build`, attach
+that too — the cmake/make output streams live and isn't captured
+here.
+
+Re-run before posting if you've changed env vars or installed new
+toolchain components.
+EOF

--- a/crates/manifold-csg-sys/wasm32-uu/include/__assertion_handler
+++ b/crates/manifold-csg-sys/wasm32-uu/include/__assertion_handler
@@ -1,0 +1,36 @@
+// test/smoke/include/__assertion_handler — libc++ assertion override.
+//
+// Verbatim from pca006132's manifold-on-wasm experiment:
+//   https://github.com/elalish/manifold/discussions/1046#discussioncomment-11302257
+// Routes libc++ hardening assertions to a trap rather than printf+abort.
+//
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___ASSERTION_HANDLER
+#define _LIBCPP___ASSERTION_HANDLER
+
+#include <__config>
+#include <__verbose_abort>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+#if _LIBCPP_HARDENING_MODE == _LIBCPP_HARDENING_MODE_DEBUG
+
+#  define _LIBCPP_ASSERTION_HANDLER(message) _LIBCPP_VERBOSE_ABORT("%s", message)
+
+#else
+
+// TODO(hardening): use `__builtin_verbose_trap(message)` once that becomes available.
+#  define _LIBCPP_ASSERTION_HANDLER(message) ((void)message, __builtin_trap())
+
+#endif // _LIBCPP_HARDENING_MODE == _LIBCPP_HARDENING_MODE_DEBUG
+
+#endif // _LIBCPP___ASSERTION_HANDLER

--- a/crates/manifold-csg-sys/wasm32-uu/include/__config_site
+++ b/crates/manifold-csg-sys/wasm32-uu/include/__config_site
@@ -1,0 +1,73 @@
+// test/smoke/include/__config_site — libc++ site config override.
+//
+// Adapted from pca006132's manifold-on-wasm config:
+//   https://github.com/elalish/manifold/discussions/1046#discussioncomment-11302257
+// Updated for LLVM 20+'s numeric-value config macros (LLVM 19 used
+// defined/undefined; LLVM 20 switched to numeric 0/1).
+//
+// Reference (LLVM 20–22+; knobs added across versions are noted inline):
+//   https://github.com/llvm/llvm-project/blob/main/libcxx/include/__config_site.in
+//
+// Disables libc++'s assumptions about threads, filesystem, locale,
+// wide chars, monotonic clock, etc. Without this, libc++ headers drag
+// in symbols our shim doesn't and shouldn't ship.
+//
+// Placed on the include path BEFORE libc++'s own config so libc++
+// picks ours up instead of the install-tree-baked one.
+//
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___CONFIG_SITE
+#define _LIBCPP___CONFIG_SITE
+
+#define _LIBCPP_ABI_VERSION 1
+#define _LIBCPP_ABI_NAMESPACE __1
+#define _LIBCPP_ABI_FORCE_ITANIUM 0
+#define _LIBCPP_ABI_FORCE_MICROSOFT 0
+
+#define _LIBCPP_HAS_THREADS 0              // no pthreads on wasm32-unknown-unknown
+#define _LIBCPP_HAS_MONOTONIC_CLOCK 0      // no clock_gettime
+#define _LIBCPP_HAS_TERMINAL 0
+#define _LIBCPP_HAS_MUSL_LIBC 1            // wasm-cxx-shim provides musl-style headers
+#define _LIBCPP_HAS_THREAD_API_PTHREAD 0
+#define _LIBCPP_HAS_THREAD_API_EXTERNAL 0
+#define _LIBCPP_HAS_THREAD_API_WIN32 0
+#define _LIBCPP_HAS_THREAD_API_C11 0
+#define _LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS 0
+#define _LIBCPP_HAS_FILESYSTEM 0           // no filesystem syscalls
+#define _LIBCPP_HAS_RANDOM_DEVICE 0        // no /dev/urandom
+#define _LIBCPP_HAS_LOCALIZATION 0         // disables iostreams + locale machinery
+#define _LIBCPP_HAS_UNICODE 0
+#define _LIBCPP_HAS_WIDE_CHARACTERS 0      // no wchar_t API surface
+#define _LIBCPP_HAS_TIME_ZONE_DATABASE 0
+#define _LIBCPP_INSTRUMENTED_WITH_ASAN 0
+
+// PSTL backend — serial (no threading) for the few PSTL paths we hit.
+#define _LIBCPP_PSTL_BACKEND_SERIAL
+
+// Hardening — extensive (level 2). Hardening assertions route through
+// our __assertion_handler override, which traps.
+#define _LIBCPP_HARDENING_MODE_DEFAULT 2
+
+// LLVM 21+ split hardening into "mode" (above) + "semantic" (below).
+// Older libc++ ignores this knob; newer libc++ aborts at __config time
+// without it. ENFORCE matches our trapping __assertion_handler and the
+// extensive hardening level above.
+#define _LIBCPP_ASSERTION_SEMANTIC_DEFAULT _LIBCPP_ASSERTION_SEMANTIC_ENFORCE
+
+#ifdef __clang__
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wmacro-redefined"
+#endif
+
+#ifdef __clang__
+#  pragma clang diagnostic pop
+#endif
+
+#endif // _LIBCPP___CONFIG_SITE

--- a/crates/manifold-csg-sys/wasm32-uu/include/mutex
+++ b/crates/manifold-csg-sys/wasm32-uu/include/mutex
@@ -1,0 +1,83 @@
+// test/manifold-link/include/mutex — stub <mutex> for no-thread builds.
+//
+// libc++ gates std::mutex / std::recursive_mutex etc. behind
+// `#if _LIBCPP_HAS_THREADS`. We compile manifold with
+// `_LIBCPP_HAS_THREADS=0` (via __config_site override), so libc++'s
+// <mutex> doesn't declare those types. Manifold's source still
+// references them — the upstream-friendly fix is to ifdef the mutex
+// usage out, but the smaller intervention is to provide stub
+// implementations here so manifold compiles unchanged. With threads
+// off, all mutex operations are trivially correct as no-ops.
+//
+// On the include path BEFORE libc++'s <mutex>; libc++'s gets shadowed.
+//
+// Smoke-test-companion only; consumers use real libc++ <mutex> in
+// threaded builds.
+#ifndef _WASM_CXX_SHIM_MANIFOLD_LINK_MUTEX
+#define _WASM_CXX_SHIM_MANIFOLD_LINK_MUTEX
+
+#include <__config>
+
+namespace std { inline namespace __1 {
+
+class mutex {
+public:
+    constexpr mutex() noexcept = default;
+    ~mutex() = default;
+    mutex(const mutex&) = delete;
+    mutex& operator=(const mutex&) = delete;
+    void lock()       {}
+    bool try_lock()   { return true; }
+    void unlock()     {}
+};
+
+class recursive_mutex {
+public:
+    recursive_mutex() = default;
+    ~recursive_mutex() = default;
+    recursive_mutex(const recursive_mutex&) = delete;
+    recursive_mutex& operator=(const recursive_mutex&) = delete;
+    void lock()       {}
+    bool try_lock()   { return true; }
+    void unlock()     {}
+};
+
+template <class _Mutex>
+class lock_guard {
+public:
+    explicit lock_guard(_Mutex&) {}
+    lock_guard(const lock_guard&) = delete;
+    lock_guard& operator=(const lock_guard&) = delete;
+};
+
+template <class... _MArgs>
+class scoped_lock {
+public:
+    explicit scoped_lock(_MArgs&...) {}
+    scoped_lock(const scoped_lock&) = delete;
+    scoped_lock& operator=(const scoped_lock&) = delete;
+};
+
+template <class _Mutex>
+class unique_lock {
+public:
+    unique_lock() = default;
+    explicit unique_lock(_Mutex&) {}
+    unique_lock(const unique_lock&) = delete;
+    unique_lock(unique_lock&&) = default;
+    unique_lock& operator=(unique_lock&&) = default;
+    void lock()       {}
+    bool try_lock()   { return true; }
+    void unlock()     {}
+};
+
+struct defer_lock_t  { explicit defer_lock_t()  = default; };
+struct try_to_lock_t { explicit try_to_lock_t() = default; };
+struct adopt_lock_t  { explicit adopt_lock_t()  = default; };
+inline constexpr defer_lock_t  defer_lock{};
+inline constexpr try_to_lock_t try_to_lock{};
+inline constexpr adopt_lock_t  adopt_lock{};
+
+}}  // namespace std::__1
+
+#endif

--- a/crates/manifold-csg-sys/wasm32-uu/libcxx-extras.cpp
+++ b/crates/manifold-csg-sys/wasm32-uu/libcxx-extras.cpp
@@ -1,0 +1,100 @@
+// test/manifold-link/libcxx-extras.cpp
+//
+// Provides the libc++ source-file symbols that manifold pulls in but
+// the main libcxx component intentionally doesn't ship:
+//   * std::__1::__shared_count / __shared_weak_count out-of-line
+//     methods (from libc++'s src/memory.cpp)
+//   * std::nothrow global, std::__throw_bad_alloc (from libc++'s
+//     src/new_helpers.cpp)
+//   * std::bad_weak_ptr key functions
+//   * std::align helper
+//
+// These are documented in libcxx/README.md as "consumers will surface
+// link errors and need to compile [the upstream libc++ source files]
+// themselves." This file IS that compilation, scoped to the manifold-
+// link smoke. It's NOT part of the main libcxx component because it
+// requires `#include <memory>` / `<new>` which we deliberately keep
+// out of the main libcxx stubs (insulation from libc++ version
+// drift). Including those headers couples this TU to libc++'s
+// `__shared_count` / `__shared_weak_count` class layout — if libc++
+// changes those layouts in a future release, this TU silently breaks
+// (the manifold-tests run will catch it). We accept that coupling
+// because the alternative — redeclaring the classes locally with
+// matching layouts — is fragile in a different way.
+//
+// Runtime semantics: refcount manipulation is non-atomic (correct
+// for our single-threaded wasm), and the destructor + __release_weak
+// dispatch through the vtable to derived-class
+// `__on_zero_shared_weak()` implementations — which DO free the
+// controlled object. Lifetime correctness holds for single-threaded
+// use; do not assume it generalizes to a future threaded build.
+//
+// References (the upstream files we're emulating):
+//   https://github.com/llvm/llvm-project/blob/release/20.x/libcxx/src/memory.cpp
+//   https://github.com/llvm/llvm-project/blob/release/20.x/libcxx/src/new_helpers.cpp
+
+#include <memory>
+#include <new>
+#include <typeinfo>
+
+// ---- std::nothrow + __throw_bad_alloc (from new_helpers.cpp) ----
+
+namespace std {  // intentionally NOT versioned (matches libc++ upstream)
+
+const nothrow_t nothrow{};
+
+[[noreturn]] void __throw_bad_alloc() {
+    __builtin_trap();
+}
+
+}  // namespace std
+
+// ---- bad_weak_ptr key functions + shared_count/__shared_weak_count
+//      out-of-line methods (from memory.cpp) ----
+
+namespace std { inline namespace __1 {
+
+bad_weak_ptr::~bad_weak_ptr() noexcept {}
+const char* bad_weak_ptr::what() const noexcept { return "bad_weak_ptr"; }
+
+__shared_count::~__shared_count() {}
+__shared_weak_count::~__shared_weak_count() {}
+
+void __shared_weak_count::__release_weak() noexcept {
+    if (--__shared_weak_owners_ == -1) {
+        __on_zero_shared_weak();
+    }
+}
+
+__shared_weak_count* __shared_weak_count::lock() noexcept {
+    long object_owners = __shared_owners_;
+    while (object_owners != -1) {
+        // single-threaded: just bump and return
+        __shared_owners_ = object_owners + 1;
+        return this;
+    }
+    return nullptr;
+}
+
+const void* __shared_weak_count::__get_deleter(const type_info&) const noexcept {
+    return nullptr;
+}
+
+// std::align (rare-use helper, vendored from upstream verbatim)
+void* align(size_t alignment, size_t size, void*& ptr, size_t& space) {
+    void* r = nullptr;
+    if (size <= space) {
+        char* p1 = static_cast<char*>(ptr);
+        char* p2 = reinterpret_cast<char*>(
+            reinterpret_cast<__UINTPTR_TYPE__>(p1 + (alignment - 1)) & -alignment);
+        size_t d = static_cast<size_t>(p2 - p1);
+        if (d <= space - size) {
+            r = p2;
+            ptr = r;
+            space -= d;
+        }
+    }
+    return r;
+}
+
+}}  // namespace std::__1

--- a/crates/manifold-csg-sys/wasm32-uu/patches/.gitattributes
+++ b/crates/manifold-csg-sys/wasm32-uu/patches/.gitattributes
@@ -1,0 +1,1 @@
+*.patch eol=lf

--- a/crates/manifold-csg-sys/wasm32-uu/patches/0001-manifold-ifdef-iostream.patch
+++ b/crates/manifold-csg-sys/wasm32-uu/patches/0001-manifold-ifdef-iostream.patch
@@ -1,0 +1,79 @@
+Wrap manifold's iostream-using OBJ I/O paths in `#ifndef MANIFOLD_NO_IOSTREAM` so
+the library compiles when libc++'s localization machinery is disabled (which we
+do for the wasm32-unknown-unknown target via `_LIBCPP_HAS_LOCALIZATION=0` in our
+__config_site override).
+
+Three blocks:
+- src/impl.cpp ~line 64: FromChars template helper using std::istringstream
+- src/impl.cpp ~line 704 to ~870: WriteOBJWithEpsilon, ReadOBJWithEpsilon, ReadOBJ,
+  WriteOBJ, operator<<(ostream, Manifold::Impl) — all use std::istream / ostream /
+  istringstream / stringstream
+- bindings/c/manifoldc.cpp ~lines 1051-1077: the C-API OBJ I/O bindings
+  (manifold_read_obj, manifold_meshgl64_read_obj, manifold_write_obj,
+  manifold_meshgl64_write_obj) — all use std::istringstream / stringstream
+
+Originally documented in pca006132's manifold-on-wasm experiment:
+  https://github.com/elalish/manifold/discussions/1046#discussioncomment-11302257
+
+Generated against manifold @ 65943caaab531ff9e135fe061868fde91760a372 (post-v3.4.1
+master + our existing carry-patches #1687 + #1688). The earlier wasm-cxx-shim
+patch was generated against v3.4.1 directly; line offsets shifted in our pin.
+
+Cleanest upstream form would gate the OBJ I/O bits on a `MANIFOLD_NO_IOSTREAM`
+(or equivalently named) build option. The patch here uses that macro name for
+forward compatibility.
+
+diff --git bindings/c/manifoldc.cpp bindings/c/manifoldc.cpp
+index f411de7b..2f8a6d9d 100644
+--- bindings/c/manifoldc.cpp
++++ bindings/c/manifoldc.cpp
+@@ -1046,6 +1046,7 @@ void manifold_destruct_execution_context(ManifoldExecutionContext* ctx) {
+   from_c(ctx)->~ExecutionContext();
+ }
+ 
++#ifndef MANIFOLD_NO_IOSTREAM
+ // IO
+ 
+ ManifoldManifold* manifold_read_obj(void* mem, char* obj_file) {
+@@ -1075,6 +1076,7 @@ void manifold_meshgl64_write_obj(ManifoldMeshGL64* mesh,
+   WriteOBJ(ss, *m);
+   callback(ss.str().data(), args);
+ }
++#endif  // !MANIFOLD_NO_IOSTREAM
+ 
+ #ifdef __cplusplus
+ }
+diff --git src/impl.cpp src/impl.cpp
+index ce4a2090..6ab507ef 100644
+--- src/impl.cpp
++++ src/impl.cpp
+@@ -61,6 +61,7 @@ int GetLabels(std::vector<int>& components,
+   return uf.connectedComponents(components);
+ }
+ 
++#ifndef MANIFOLD_NO_IOSTREAM
+ template <typename T>
+ double FromChars(T buffer) {
+   double tmp;
+@@ -69,6 +70,7 @@ double FromChars(T buffer) {
+   iss >> tmp;
+   return tmp;
+ }
++#endif  // !MANIFOLD_NO_IOSTREAM
+ }  // namespace
+ 
+ namespace manifold {
+@@ -699,6 +701,7 @@ void Manifold::Impl::IncrementMeshIDs() {
+              UpdateMeshID({meshIDold2new.D()}));
+ }
+ 
++#ifndef MANIFOLD_NO_IOSTREAM
+ static std::ostream& WriteOBJWithEpsilon(std::ostream& stream,
+                                          const MeshGL64& mesh,
+                                          std::optional<double> epsilon) {
+@@ -860,4 +863,5 @@ bool Manifold::WriteOBJ(std::ostream& stream) const {
+   stream << *this->GetCsgLeafNode().GetImpl();
+   return true;
+ }
++#endif  // !MANIFOLD_NO_IOSTREAM
+ }  // namespace manifold

--- a/crates/manifold-csg-sys/wasm32-uu/patches/0002-clipper2-strip-iostream.patch
+++ b/crates/manifold-csg-sys/wasm32-uu/patches/0002-clipper2-strip-iostream.patch
@@ -1,0 +1,243 @@
+From wasm-cxx-shim Phase-7-B1 work-in-progress.
+Strip <iostream> references from Clipper2 headers so the library compiles
+without libc++'s localization machinery (which is disabled via
+_LIBCPP_HAS_LOCALIZATION=0 in the smoke test's __config_site override).
+
+Originally documented in pca006132's manifold-on-wasm experiment:
+  https://github.com/elalish/manifold/discussions/1046#discussioncomment-11302257
+
+Generated against Clipper2 SHA 46f639177fe418f9689e8ddb74f08a870c71f5b4
+(the SHA manifold v3.4.1 pins via FetchContent).
+
+Upstream PR target: AngusJohnson/Clipper2. Cleaner upstream form would
+guard the stream-using bits with `#ifndef CLIPPER2_NO_IOSTREAM`.
+
+diff --git CPP/Clipper2Lib/include/clipper2/clipper.core.h CPP/Clipper2Lib/include/clipper2/clipper.core.h
+index 99a5205..c692f36 100644
+--- CPP/Clipper2Lib/include/clipper2/clipper.core.h
++++ CPP/Clipper2Lib/include/clipper2/clipper.core.h
+@@ -14,7 +14,7 @@
+ #include <cstdint>
+ #include <vector>
+ #include <string>
+-#include <iostream>
++// #include <iostream>
+ #include <algorithm>
+ #include <numeric>
+ #include <cmath>
+@@ -166,11 +166,11 @@ namespace Clipper2Lib
+ 
+     void SetZ(const z_type z_value) { z = z_value; }
+ 
+-    friend std::ostream& operator<<(std::ostream& os, const Point& point)
+-    {
+-      os << point.x << "," << point.y << "," << point.z;
+-      return os;
+-    }
++    // friend std::ostream& operator<<(std::ostream& os, const Point& point)
++    // {
++      // os << point.x << "," << point.y << "," << point.z;
++      // return os;
++    // }
+ 
+ #else
+ 
+@@ -203,11 +203,11 @@ namespace Clipper2Lib
+       return Point(x * scale, y * scale);
+     }
+ 
+-    friend std::ostream& operator<<(std::ostream& os, const Point& point)
+-    {
+-      os << point.x << "," << point.y;
+-      return os;
+-    }
++    // friend std::ostream& operator<<(std::ostream& os, const Point& point)
++    // {
++      // os << point.x << "," << point.y;
++      // return os;
++    // }
+ #endif
+ 
+     friend bool operator==(const Point& a, const Point& b)
+@@ -396,10 +396,10 @@ namespace Clipper2Lib
+       return result;
+     }
+ 
+-    friend std::ostream& operator<<(std::ostream& os, const Rect<T>& rect) {
+-      os << "(" << rect.left << "," << rect.top << "," << rect.right << "," << rect.bottom << ") ";
+-      return os;
+-    }
++    // friend std::ostream& operator<<(std::ostream& os, const Rect<T>& rect) {
++      // os << "(" << rect.left << "," << rect.top << "," << rect.right << "," << rect.bottom << ") ";
++      // return os;
++    // }
+   };
+ 
+   template <typename T1, typename T2>
+@@ -498,26 +498,26 @@ namespace Clipper2Lib
+     return Rect<T>(xmin, ymin, xmax, ymax);
+   }
+ 
+-  template <typename T>
+-  std::ostream& operator << (std::ostream& outstream, const Path<T>& path)
+-  {
+-    if (!path.empty())
+-    {
+-      auto pt = path.cbegin(), last = path.cend() - 1;
+-      while (pt != last)
+-        outstream << *pt++ << ", ";
+-      outstream << *last << std::endl;
+-    }
+-    return outstream;
+-  }
+-
+-  template <typename T>
+-  std::ostream& operator << (std::ostream& outstream, const Paths<T>& paths)
+-  {
+-    for (auto p : paths)
+-      outstream << p;
+-    return outstream;
+-  }
++  // template <typename T>
++  // std::ostream& operator << (std::ostream& outstream, const Path<T>& path)
++  // {
++    // if (!path.empty())
++    // {
++      // auto pt = path.cbegin(), last = path.cend() - 1;
++      // while (pt != last)
++        // outstream << *pt++ << ", ";
++      // outstream << *last << std::endl;
++    // }
++    // return outstream;
++  // }
++
++  // template <typename T>
++  // std::ostream& operator << (std::ostream& outstream, const Paths<T>& paths)
++  // {
++    // for (auto p : paths)
++      // outstream << p;
++    // return outstream;
++  // }
+ 
+ 
+   template <typename T1, typename T2>
+diff --git CPP/Clipper2Lib/include/clipper2/clipper.h CPP/Clipper2Lib/include/clipper2/clipper.h
+index fe1e299..aff9f60 100644
+--- CPP/Clipper2Lib/include/clipper2/clipper.h
++++ CPP/Clipper2Lib/include/clipper2/clipper.h
+@@ -309,35 +309,35 @@ namespace Clipper2Lib {
+       return true;
+     }
+ 
+-    static void OutlinePolyPath(std::ostream& os,
+-      size_t idx, bool isHole, size_t count, const std::string& preamble)
+-    {
+-      std::string plural = (count == 1) ? "." : "s.";
+-      if (isHole)
+-        os << preamble << "+- Hole (" << idx << ") contains " << count <<
+-        " nested polygon" << plural << std::endl;
+-      else
+-        os << preamble << "+- Polygon (" << idx << ") contains " << count <<
+-          " hole" << plural << std::endl;
+-    }
+-
+-    static void OutlinePolyPath64(std::ostream& os, const PolyPath64& pp,
+-      size_t idx, std::string preamble)
+-    {
+-      OutlinePolyPath(os, idx, pp.IsHole(), pp.Count(), preamble);
+-      for (size_t i = 0; i < pp.Count(); ++i)
+-        if (pp.Child(i)->Count())
+-          details::OutlinePolyPath64(os, *pp.Child(i), i, preamble + "  ");
+-    }
+-
+-    static void OutlinePolyPathD(std::ostream& os, const PolyPathD& pp,
+-      size_t idx, std::string preamble)
+-    {
+-      OutlinePolyPath(os, idx, pp.IsHole(), pp.Count(), preamble);
+-      for (size_t i = 0; i < pp.Count(); ++i)
+-        if (pp.Child(i)->Count())
+-          details::OutlinePolyPathD(os, *pp.Child(i), i, preamble + "  ");
+-    }
++    // static void OutlinePolyPath(std::ostream& os,
++      // size_t idx, bool isHole, size_t count, const std::string& preamble)
++    // {
++      // std::string plural = (count == 1) ? "." : "s.";
++      // if (isHole)
++        // os << preamble << "+- Hole (" << idx << ") contains " << count <<
++        // " nested polygon" << plural << std::endl;
++      // else
++        // os << preamble << "+- Polygon (" << idx << ") contains " << count <<
++          // " hole" << plural << std::endl;
++    // }
++
++    // static void OutlinePolyPath64(std::ostream& os, const PolyPath64& pp,
++      // size_t idx, std::string preamble)
++    // {
++      // OutlinePolyPath(os, idx, pp.IsHole(), pp.Count(), preamble);
++      // for (size_t i = 0; i < pp.Count(); ++i)
++        // if (pp.Child(i)->Count())
++          // details::OutlinePolyPath64(os, *pp.Child(i), i, preamble + "  ");
++    // }
++
++    // static void OutlinePolyPathD(std::ostream& os, const PolyPathD& pp,
++      // size_t idx, std::string preamble)
++    // {
++      // OutlinePolyPath(os, idx, pp.IsHole(), pp.Count(), preamble);
++      // for (size_t i = 0; i < pp.Count(); ++i)
++        // if (pp.Child(i)->Count())
++          // details::OutlinePolyPathD(os, *pp.Child(i), i, preamble + "  ");
++    // }
+ 
+     template<typename T, typename U>
+     inline constexpr void MakePathGeneric(const T an_array,
+@@ -377,28 +377,28 @@ namespace Clipper2Lib {
+ 
+   } // end details namespace
+ 
+-  inline std::ostream& operator<< (std::ostream& os, const PolyTree64& pp)
+-  {
+-    std::string plural = (pp.Count() == 1) ? " polygon." : " polygons.";
+-    os << std::endl << "Polytree with " << pp.Count() << plural << std::endl;
+-      for (size_t i = 0; i < pp.Count(); ++i)
+-        if (pp.Child(i)->Count())
+-          details::OutlinePolyPath64(os, *pp.Child(i), i, "  ");
+-    os << std::endl << std::endl;
+-    return os;
+-  }
+-
+-  inline std::ostream& operator<< (std::ostream& os, const PolyTreeD& pp)
+-  {
+-    std::string plural = (pp.Count() == 1) ? " polygon." : " polygons.";
+-    os << std::endl << "Polytree with " << pp.Count() << plural << std::endl;
+-    for (size_t i = 0; i < pp.Count(); ++i)
+-      if (pp.Child(i)->Count())
+-        details::OutlinePolyPathD(os, *pp.Child(i), i, "  ");
+-    os << std::endl << std::endl;
+-    if (!pp.Level()) os << std::endl;
+-    return os;
+-  }
++  // inline std::ostream& operator<< (std::ostream& os, const PolyTree64& pp)
++  // {
++    // std::string plural = (pp.Count() == 1) ? " polygon." : " polygons.";
++    // os << std::endl << "Polytree with " << pp.Count() << plural << std::endl;
++      // for (size_t i = 0; i < pp.Count(); ++i)
++        // if (pp.Child(i)->Count())
++          // details::OutlinePolyPath64(os, *pp.Child(i), i, "  ");
++    // os << std::endl << std::endl;
++    // return os;
++  // }
++
++  // inline std::ostream& operator<< (std::ostream& os, const PolyTreeD& pp)
++  // {
++    // std::string plural = (pp.Count() == 1) ? " polygon." : " polygons.";
++    // os << std::endl << "Polytree with " << pp.Count() << plural << std::endl;
++    // for (size_t i = 0; i < pp.Count(); ++i)
++      // if (pp.Child(i)->Count())
++        // details::OutlinePolyPathD(os, *pp.Child(i), i, "  ");
++    // os << std::endl << std::endl;
++    // if (!pp.Level()) os << std::endl;
++    // return os;
++  // }
+ 
+   inline Paths64 PolyTreeToPaths64(const PolyTree64& polytree)
+   {

--- a/crates/manifold-csg-sys/wasm32-uu/patches/README.md
+++ b/crates/manifold-csg-sys/wasm32-uu/patches/README.md
@@ -1,0 +1,53 @@
+# wasm32-uu patches
+
+Patches applied to manifold and Clipper2 source trees during the
+`wasm32-unknown-unknown` build path. Sibling to (and distinct from) the
+host carry-patches under `../../patches/`, which target the same
+manifold tree but a different build configuration.
+
+## Files
+
+- `0001-manifold-ifdef-iostream.patch` — wraps manifold's iostream-using
+  OBJ I/O paths under `MANIFOLD_NO_IOSTREAM`. Generated against our
+  pinned manifold SHA (post-3.4.1 master). Three blocks across
+  `bindings/c/manifoldc.cpp` and `src/impl.cpp`.
+- `0002-clipper2-strip-iostream.patch` — strips `<iostream>` from
+  Clipper2 headers. Verbatim from
+  [wasm-cxx-shim's reference impl](https://github.com/zmerlynn/wasm-cxx-shim/blob/main/test/manifold-link/patches/0001-clipper2-strip-iostream.patch);
+  applies to the SHA manifold pins (`46f6391...`, see
+  `crates/manifold-csg-sys/build.rs::CLIPPER2_SHA`).
+
+## Patch convention: `-p0`
+
+Both files are generated with `git diff --no-prefix`, which omits the
+standard `a/` and `b/` path prefixes. They must be applied with
+`git apply -p0`, NOT the default `-p1`.
+
+If you regenerate or hand-edit a patch here, **double-check the file
+header**:
+
+```
+diff --git a/src/impl.cpp b/src/impl.cpp     ← -p1 form (DEFAULT git diff)
+diff --git src/impl.cpp src/impl.cpp         ← -p0 form (git diff --no-prefix)
+```
+
+The host `../../patches/` directory uses the `-p1` form (default git
+diff). The two conventions don't mix.
+
+## Updating a patch when the manifold pin moves
+
+`build.rs` has a `git apply --check` style assertion that fails loudly
+when a patch can't apply against the pinned upstream commit. If you
+bump `MANIFOLD_VERSION` in `build.rs` and the wasm32-uu lane fails:
+
+1. Check out `out_dir/manifold-src-wasm32-uu/` after a successful clone
+   (built into `target/wasm32-unknown-unknown/debug/build/manifold-csg-sys-*/out/`).
+2. Apply the host carry-patches first (they're applied before the
+   wasm32-uu ones).
+3. Hand-edit the `MANIFOLD_NO_IOSTREAM` blocks in `bindings/c/manifoldc.cpp`
+   and `src/impl.cpp` to match the new line numbers.
+4. Regenerate: `git diff --no-prefix bindings/c/manifoldc.cpp src/impl.cpp > new.patch`.
+5. Splice the new patch body under the existing header comment in
+   `0001-manifold-ifdef-iostream.patch`.
+
+Same flow for Clipper2 if the upstream pin moves.

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -14,9 +14,12 @@ build = "build.rs"
 default = ["parallel"]
 parallel = ["manifold-csg-sys/parallel"]
 nalgebra = ["dep:nalgebra"]
+# Forwarding of the sys-crate's wasm32-unknown-unknown opt-in. See the
+# "Browser without Emscripten" section of the README.
+unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.104", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.105", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }

--- a/crates/manifold-csg/examples/advanced.rs
+++ b/crates/manifold-csg/examples/advanced.rs
@@ -1,9 +1,20 @@
 //! Advanced operations: SDF, warp, OBJ I/O, properties, and threading.
 //!
 //! Run with: `cargo run -p manifold-csg --example advanced`
+//!
+//! Not buildable on `wasm32-unknown-unknown`: this example uses OBJ I/O
+//! (cfg-gated out on that target) and `std::thread::spawn` (no native
+//! threads). The example is replaced with a stub on that target so
+//! `cargo build --examples` succeeds. See `examples/wasm32_uu_smoke.rs`
+//! for what does work there.
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use manifold_csg::Manifold;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn main() {}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn main() {
     // -- SDF (signed distance function) --------------------------------------
     // Construct geometry from a mathematical function.

--- a/crates/manifold-csg/examples/wasm32_uu_smoke.rs
+++ b/crates/manifold-csg/examples/wasm32_uu_smoke.rs
@@ -1,0 +1,61 @@
+//! Browser-runnable smoke test for the wasm32-unknown-unknown build.
+//!
+//! Builds for wasm32-unknown-unknown via:
+//!
+//! ```sh
+//! cargo build --example wasm32_uu_smoke \
+//!     --target wasm32-unknown-unknown -p manifold-csg \
+//!     --no-default-features --features unstable-wasm-uu
+//! ```
+//!
+//! Then load the resulting `.wasm` from a Node/JS runner and call the
+//! exported `smoke_run` function — see
+//! `crates/manifold-csg/wasm32-uu-runner/run.mjs` for a working example.
+//!
+//! `smoke_run` returns the post-union triangle count (positive integer);
+//! a zero or negative value means something is broken.
+//!
+//! This example only compiles for wasm32-unknown-unknown; on other targets
+//! it's a stub `main` that prints a usage hint.
+
+#![cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), no_main)]
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod wasm32_uu {
+    use manifold_csg::Manifold;
+
+    /// Returns the post-union triangle count for two unit cubes offset by
+    /// (0.5, 0.5, 0.5). Exercises construction, transform, and the boolean
+    /// kernel — enough to pull manifold's actual CSG path through linker
+    /// symbol resolution.
+    ///
+    /// Exported via `#[unsafe(no_mangle)] pub extern "C"` so a JS runner can
+    /// invoke it directly. Build with
+    /// `RUSTFLAGS='-C link-arg=--export=smoke_run' cargo build ...` if the
+    /// linker doesn't auto-export it (rustc on wasm32-unknown-unknown
+    /// usually does, but this is explicit insurance).
+    #[unsafe(no_mangle)]
+    pub extern "C" fn smoke_run() -> i32 {
+        let cube1 = Manifold::cube(1.0, 1.0, 1.0, true);
+        let cube2 = cube1.translate(0.5, 0.5, 0.5);
+        let merged = &cube1 + &cube2;
+        // Cap at i32::MAX rather than returning -1 on overflow — the
+        // runner treats negative as failure, but an overflowed positive
+        // count would still be honestly reportable. For two unit cubes
+        // the value is small (36 today), so this is a documentation
+        // hint more than a real concern.
+        merged.num_tri().min(i32::MAX as usize) as i32
+    }
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn main() {
+    eprintln!(
+        "wasm32_uu_smoke is the wasm32-unknown-unknown smoke test.\n\
+         Build it via:\n  \
+         cargo build --example wasm32_uu_smoke --target wasm32-unknown-unknown \
+         -p manifold-csg --no-default-features --features unstable-wasm-uu\n\
+         Then run via the Node script at \
+         crates/manifold-csg/wasm32-uu-runner/run.mjs."
+    );
+}

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -15,8 +15,9 @@
 //! - **f64 precision**: Uses MeshGL64 to avoid f32 precision loss
 //! - **`Send` + `Sync` safe**: All types can be moved across threads and shared for concurrent reads
 //! - **Memory safe**: All C handles are freed automatically via `Drop`
-//! - **Browser-capable**: Builds for `wasm32-unknown-emscripten` for
-//!   in-browser geometry. See the README's "Browser / WebAssembly" section.
+//! - **Browser-capable**: Builds for `wasm32-unknown-emscripten` and
+//!   `wasm32-unknown-unknown` (the wasm-bindgen-compatible target) for
+//!   in-browser geometry. See the README's "Browser / WebAssembly" sections.
 
 pub mod bounding_box;
 pub mod cross_section;

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -1408,10 +1408,17 @@ impl Manifold {
     }
 
     // ── OBJ I/O ─────────────────────────────────────────────────────
+    //
+    // OBJ I/O is unavailable on `wasm32-unknown-unknown` — manifold's
+    // OBJ paths use `<iostream>` / `<sstream>`, which depend on libc++
+    // localization machinery the freestanding wasm build excludes.
+    // Use the binary `MeshGL64` API to round-trip mesh data on that
+    // target.
 
     /// Parse a Manifold from Wavefront OBJ string content.
     ///
     /// The input should be the content of an .obj file (not a filename).
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn from_obj(obj_content: &str) -> Result<Self, CsgError> {
         let c_str = std::ffi::CString::new(obj_content)
             .map_err(|_| CsgError::InvalidInput("OBJ content contains null byte".into()))?;
@@ -1430,6 +1437,7 @@ impl Manifold {
     }
 
     /// Export this Manifold as a Wavefront OBJ string.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     #[must_use]
     pub fn to_obj(&self) -> String {
         let mut result = String::new();

--- a/crates/manifold-csg/src/mesh.rs
+++ b/crates/manifold-csg/src/mesh.rs
@@ -555,6 +555,10 @@ impl MeshGL64 {
     }
 
     /// Read a MeshGL64 from a Wavefront OBJ string.
+    ///
+    /// Unavailable on `wasm32-unknown-unknown` (manifold's iostream-based
+    /// OBJ paths are excluded from the freestanding wasm build).
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn from_obj(obj_content: &str) -> Result<Self, crate::types::CsgError> {
         let c_str = std::ffi::CString::new(obj_content).map_err(|_| {
             crate::types::CsgError::InvalidInput("OBJ content contains null byte".into())
@@ -567,6 +571,9 @@ impl MeshGL64 {
     }
 
     /// Export this mesh as a Wavefront OBJ string.
+    ///
+    /// Unavailable on `wasm32-unknown-unknown` (see [`from_obj`](Self::from_obj)).
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     #[must_use]
     pub fn to_obj(&self) -> String {
         let mut result = String::new();

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -1035,6 +1035,7 @@ fn from_sdf_creates_manifold() {
 // ── OBJ I/O tests ───────────────────────────────────────────────────
 
 #[test]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn obj_round_trip() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, true);
     let obj_str = cube.to_obj();
@@ -1047,6 +1048,7 @@ fn obj_round_trip() {
 }
 
 #[test]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn from_obj_invalid_returns_error() {
     let result = Manifold::from_obj("not valid obj data");
     // Either parses as empty or returns error — both are acceptable.
@@ -2088,6 +2090,7 @@ fn cross_section_boolean_subtract() {
 // ── MeshGL64 OBJ I/O ──────────────────────────────────────────────────
 
 #[test]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn meshgl64_obj_round_trip() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();

--- a/crates/manifold-csg/wasm32-uu-runner/run.mjs
+++ b/crates/manifold-csg/wasm32-uu-runner/run.mjs
@@ -1,0 +1,42 @@
+// crates/manifold-csg/wasm32-uu-runner/run.mjs
+//
+// Loads the wasm32-unknown-unknown smoke example and invokes its
+// exported `smoke_run`. Asserts a positive triangle count. The exact
+// value isn't load-bearing — what matters is that manifold's CSG kernel
+// actually executes when called from a wasm32-unknown-unknown module
+// linked against wasm-cxx-shim. A zero or negative return means
+// something's broken (allocation failure, dead-stripped function call,
+// etc.).
+//
+// Usage:
+//   cargo build --example wasm32_uu_smoke --target wasm32-unknown-unknown \
+//       -p manifold-csg --no-default-features
+//   node crates/manifold-csg/wasm32-uu-runner/run.mjs \
+//       target/wasm32-unknown-unknown/debug/examples/wasm32_uu_smoke.wasm
+
+import fs from 'node:fs';
+import process from 'node:process';
+
+if (process.argv.length < 3) {
+    console.error('usage: node run.mjs <path-to-wasm32_uu_smoke.wasm>');
+    process.exit(2);
+}
+
+const bytes = fs.readFileSync(process.argv[2]);
+const { instance } = await WebAssembly.instantiate(bytes, {});
+
+if (typeof instance.exports.smoke_run !== 'function') {
+    console.error('wasm32-uu-smoke: wasm has no exported smoke_run');
+    console.error('exports:', Object.keys(instance.exports));
+    process.exit(1);
+}
+
+const got = instance.exports.smoke_run();
+if (!Number.isInteger(got) || got <= 0) {
+    console.error(
+        `wasm32-uu-smoke: smoke_run returned ${got}; expected positive integer (triangle count)`
+    );
+    process.exit(1);
+}
+
+console.log(`wasm32-uu-smoke: smoke_run() = ${got} (triangle count, > 0) ✓`);

--- a/crates/manifold3d-sys/Cargo.toml
+++ b/crates/manifold3d-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold3d-sys"
 description = "Raw FFI bindings to the manifold3d C API (facade crate — re-exports manifold-csg-sys)"
-version = "3.4.104"
+version = "3.4.105"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -12,9 +12,10 @@ categories = ["algorithms", "external-ffi-bindings"]
 [features]
 default = ["parallel"]
 parallel = ["manifold-csg-sys/parallel"]
+unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.4.104", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.4.105", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["parallel"]

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -13,9 +13,10 @@ categories = ["algorithms", "mathematics"]
 default = ["parallel"]
 parallel = ["manifold-csg/parallel"]
 nalgebra = ["manifold-csg/nalgebra"]
+unstable-wasm-uu = ["manifold-csg/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg = { path = "../manifold-csg", version = "=0.1.5", default-features = false }
+manifold-csg = { path = "../manifold-csg", version = "=0.1.6", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]

--- a/docs/plans/wasm-unknown-unknown.md
+++ b/docs/plans/wasm-unknown-unknown.md
@@ -1,0 +1,210 @@
+# Plan: `wasm32-unknown-unknown` target support
+
+Status: **implemented**. Bare-wasm browser target, depending on
+[`wasm-cxx-shim`](https://github.com/zmerlynn/wasm-cxx-shim) for the
+C/C++ runtime layer. Companion to the earlier `wasm32-unknown-emscripten`
+support — same end-goal (browser deployment), different mechanism.
+
+## Why
+
+`wasm32-unknown-unknown` is the canonical wasm target for browser-deployed
+Rust apps because that's what `wasm-bindgen` works with. The previous
+emscripten target was useful but doesn't compose with the wasm-bindgen
+ecosystem (Bevy, Leptos, Yew, etc.). Supporting `wasm32-unknown-unknown`
+directly unblocks those consumers.
+
+The C++ runtime gap (`wasm32-unknown-unknown` ships no libc, no libcxx,
+no libcxxabi) is filled by `wasm-cxx-shim` (pinned to v0.2.0) — a small,
+independently-maintained library providing exactly the C/C++ runtime
+subset that manifold3d (and similar C++-via-Rust crates) need. See the
+shim's `docs/context.md` for the design background.
+
+## Scope
+
+**In:** Build path for `wasm32-unknown-unknown` that produces a wasm
+module with zero unexpected imports. Carry-patches against the pinned
+manifold + Clipper2 to gate iostream-using paths under `MANIFOLD_NO_IOSTREAM`.
+A consumer-side `libcxx-extras.cpp` providing the libc++ source-file
+symbols the shim deliberately doesn't ship. CI lane.
+
+**Out:**
+
+- Threading. `wasm32-unknown-unknown` with `wasm-bindgen` is single-threaded
+  by design (Web Workers + SharedArrayBuffer is the threading story, and
+  it requires consumer-side COOP/COEP HTTP headers — same as the
+  emscripten threading variant we deferred).
+- Exception runtime. Compiled with `-fno-exceptions`; implicit STL throws
+  (`bad_alloc`, etc.) abort. Same as the freestanding pattern in the
+  shim's `libcxx/__cxa_throw` stub.
+- File I/O / OBJ I/O. The carry-patch wraps manifold's iostream-using
+  paths under `MANIFOLD_NO_IOSTREAM`. Consumers can pass meshes via the
+  binary `MeshGL64` API but not via OBJ files on this target.
+- General `wasm-bindgen` interop glue. Out of scope for the kernel crate.
+- Updates to `wasm-cxx-shim` itself (its symbol surface). When a downstream
+  consumer surfaces a missing symbol, file an issue against
+  zmerlynn/wasm-cxx-shim — the shim's maintenance model grows by demand.
+
+## Implementation outline
+
+### `build.rs`
+
+A separate `build_wasm_unknown_unknown()` function dispatched early when
+`CARGO_CFG_TARGET_ARCH=wasm32 && CARGO_CFG_TARGET_OS=unknown && CARGO_CFG_TARGET_ENV=""`.
+Steps:
+
+1. Sanity-check `cmake` and `clang` on PATH.
+2. Clone `wasm-cxx-shim` (pinned to `v0.2.0`) into `OUT_DIR` and build its
+   three components (libc, libm, libcxx) via cmake using the shim's own
+   wasm32 toolchain file.
+3. Clone Clipper2 separately at the SHA manifold pins, apply our
+   `0002-clipper2-strip-iostream.patch`. Manifold's cmake reuses this
+   pre-cloned source via `FETCHCONTENT_SOURCE_DIR_CLIPPER2`.
+4. Clone manifold into a separate tree (`manifold-src-wasm32-uu`) — the
+   host/emscripten path uses its own clone with different patches and
+   build flags. Apply our existing carry-patches (`#1687`, `#1688`) plus
+   the wasm32-uu-specific `0001-manifold-ifdef-iostream.patch`.
+5. cmake-configure + build manifold using the shim's toolchain file +
+   wasm-specific flags (`-fno-exceptions`, `-fno-rtti`, `-nostdlib`,
+   `-nostdinc++`, `-DMANIFOLD_NO_IOSTREAM=1`, `-DCLIPPER2_MAX_DECIMAL_PRECISION=8`,
+   `MANIFOLD_PAR=OFF`).
+6. Compile `wasm32-uu/libcxx-extras.cpp` to a `.o`, archive it as
+   `libcxx_extras.a` via `llvm-ar` (so cargo can emit it as a normal
+   `rustc-link-lib=static` and control link order).
+7. Emit `cargo:rustc-link-search` + `cargo:rustc-link-lib` directives in
+   the validated order: `cxx_extras` → `manifoldc` → `manifold` →
+   `Clipper2` → `wasm-cxx-shim-libcxx` → `wasm-cxx-shim-libc` →
+   `wasm-cxx-shim-libm`.
+
+### LLVM discovery
+
+Mirrors `wasm-cxx-shim`'s `cmake/toolchain-wasm32.cmake` ladder:
+
+1. `WASM_CXX_SHIM_LLVM_BIN_DIR` env override.
+2. Per-platform probe: `/opt/homebrew/opt/llvm@N/bin`, `/usr/lib/llvm-N/bin`,
+   etc. (newest version first).
+3. PATH lookup as last resort (Apple's stock clang lacks libc++ headers
+   in the expected layout, so PATH-discovered clang is unlikely to work
+   on macOS but is correct on most Linux setups).
+
+`WASM_CXX_SHIM_LIBCXX_HEADERS` env separately overrides just the libc++
+header path for unusual installs.
+
+### Troubleshooting / bug reports
+
+The toolchain stack on this target (LLVM ≥ 18 with libc++ headers, plus a
+matching `__config_site`) is precise enough that the most common failure
+mode — system libc++ leaking in instead of LLVM's — is hard to diagnose
+from the build log alone. Two diagnostic surfaces help:
+
+- **`crates/manifold-csg-sys/wasm32-uu/diagnose.sh`** — a standalone bash
+  script that walks the same LLVM probe ladder `build.rs` uses, dumps
+  Rust/cargo/cmake versions, env vars, `~/.cargo/config.toml`, and any
+  cached build state under `target/`. Run from the repo root and attach
+  the output to a bug report:
+
+  ```sh
+  bash crates/manifold-csg-sys/wasm32-uu/diagnose.sh > bugreport.txt 2>&1
+  ```
+
+- **`build.rs` failure hook** — when any wasm32-uu cmake/clang step
+  fails, `build.rs` prints (after cmake's own output) the resolved
+  `clang++` path, libc++ headers path, the candidates probed, key env
+  vars, and tails of `CMakeError.log`/`CMakeOutput.log` from the failing
+  build dir. It also points at `diagnose.sh` for everything outside the
+  build's own scope.
+
+### `wasm32-uu/` directory contents
+
+Vendored from the wasm-cxx-shim reference implementation
+(`test/manifold-link/`, `test/smoke/`):
+
+- `include/__config_site` — libc++ build-knob overrides (no threads, no
+  filesystem, no localization, etc.). Mandatory for the `_LIBCPP_HAS_*=0`
+  knobs that gate the symbols we don't ship.
+- `include/__assertion_handler` — libc++ assertion handler that traps
+  rather than calling into iostream-based abort paths.
+- `include/mutex` — stub `<mutex>` providing no-op `std::mutex` /
+  `std::recursive_mutex` / `lock_guard` / `scoped_lock` / `unique_lock`
+  for builds without pthreads. Manifold references these even though it
+  doesn't actually need them at runtime in our serial config.
+- `libcxx-extras.cpp` — the libc++ source-file symbols (shared_ptr
+  internals, `std::nothrow`, `std::align`, `bad_weak_ptr` key functions,
+  `__throw_bad_alloc`) that the shim's `libcxx` deliberately doesn't
+  ship. Each consumer ships their own.
+- `patches/0001-manifold-ifdef-iostream.patch` — wraps manifold's
+  iostream-using OBJ I/O paths under `MANIFOLD_NO_IOSTREAM`. Generated
+  against our pinned manifold SHA `65943ca`. Three blocks:
+  `bindings/c/manifoldc.cpp` C-API OBJ functions, `src/impl.cpp`
+  `FromChars` template, `src/impl.cpp` `WriteOBJWithEpsilon` /
+  `ReadOBJWithEpsilon` / `ReadOBJ` / `WriteOBJ` / `operator<<`.
+- `patches/0002-clipper2-strip-iostream.patch` — strips `<iostream>` from
+  Clipper2 headers. Verbatim from wasm-cxx-shim, generated against
+  Clipper2 SHA `46f6391...` which is what manifold pins.
+
+### Cargo.toml
+
+A new `unstable-wasm-uu` feature on both `manifold-csg-sys` and
+`manifold-csg` (forwarded through the `manifold3d-sys` / `manifold3d`
+facades). Required to build for this target — `build.rs` panics with an
+instructive error if the target is `wasm32-unknown-unknown` and the
+feature is off. Also emits a `cargo:warning=` on every wasm32-uu build
+even with the feature on, as a build-time reminder of the constraints
+(carry-patches, no exception runtime, OBJ I/O disabled). Future
+graduation to "stable" support is a matter of dropping the warning and
+keeping the feature as a no-op for compatibility.
+
+The `parallel` feature continues to exist; it's silently downgraded for
+`wasm32-unknown-unknown` (TBB / threads aren't available on this target),
+same as for emscripten.
+
+### Tests
+
+The existing 11 thread-using tests are already gated with
+`#[cfg_attr(target_os = "emscripten", ignore)]`. They need an additional
+guard for `wasm32-unknown-unknown`. The two `wasm_smoke_*` tests added
+for emscripten validation (`wasm_smoke_throw_path_returns_error_not_trap`
+and `wasm_smoke_memory_growth_path`) work as-is on this target — the
+points they validate (exception path returns an error, memory growth
+works) apply equally.
+
+### CI
+
+A new `Wasm32 (unknown-unknown)` lane on Ubuntu installing LLVM 20+ via
+apt (`clang-20 lld-20 libc++-20-dev libc++abi-20-dev`), building the
+crate for the new target, running tests under Node via
+`CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=node`.
+
+## Production-readiness
+
+The previous emscripten plan's production-readiness checklist applies
+here too (browser execution vs Node, numerical determinism, long-running
+stability, performance baseline, multi-instance loading). Items marked
+`[x]` for emscripten generally apply to this target too once the smoke
+tests pass.
+
+The most important remaining gap for `wasm32-unknown-unknown` specifically
+is **wasm-bindgen integration end-to-end**: this PR delivers the
+freestanding wasm artifact, but consumers using `wasm-bindgen` in their
+own crate need to verify their integration pulls in our static archives
+correctly (the `DEP_MANIFOLD_LINK_ARGS` pattern from the emscripten work
+also applies here, but for different reasons — emscripten needs runtime
+flags, this target needs the C++ runtime archives propagated). Tracking
+that as a separate stage when a real wasm-bindgen consumer surfaces
+issues.
+
+## Release notes
+
+When `manifold-csg` ships next with this change, the release notes should
+mention:
+
+- New target supported: `wasm32-unknown-unknown` (bare-wasm browser
+  target compatible with `wasm-bindgen`).
+- Build dependency: `wasm-cxx-shim` v0.2.0 (cloned via build.rs into
+  `OUT_DIR`; no Cargo dependency).
+- New required tooling for this target: a wasm-capable LLVM 20+ install
+  (`brew install llvm` on macOS, `apt install clang-20 lld-20 libc++-20-dev`
+  on Debian). docs.rs continues to build only for the host target via
+  the existing `DOCS_RS` guard.
+- Disabled features on this target: TBB / threads (same as emscripten),
+  OBJ I/O via streams (use binary `MeshGL64` API instead), exceptions
+  (implicit STL throws abort).


### PR DESCRIPTION
Closes #30.

## Summary

Lets `manifold-csg` build and run on bare wasm — the same target wasm-bindgen consumers (Bevy, Leptos, Yew, etc.) use. Companion to the earlier `wasm32-unknown-emscripten` support; fundamentally different build path because `wasm32-unknown-unknown` ships no libc, no libc++, no libc++abi.

The C/C++ runtime gap is filled by depending on [`wasm-cxx-shim`](https://github.com/zmerlynn/wasm-cxx-shim) v0.2.0 (cloned + built into `OUT_DIR` by `build.rs`; no Cargo dependency since the shim ships only static archives). Implementation mirrors wasm-cxx-shim's reference `test/manifold-link/CMakeLists.txt`, expressed as `build.rs` steps.

## Highlights

- **`build.rs`** dispatches early on `wasm32-unknown-unknown` to a separate `build_wasm_unknown_unknown()` function. Clones wasm-cxx-shim + Clipper2 (matching SHA manifold pins) + manifold (separate tree from the host build), applies our existing manifold carry-patches plus a wasm32-uu-specific iostream patch, cmake-builds the shim, then cmake-builds manifold using the shim's toolchain + wasm-specific flags.
- **LLVM discovery**: `WASM_CXX_SHIM_LLVM_BIN_DIR` env override; otherwise probes `/opt/homebrew/opt/llvm@N/bin` (newest first), `/usr/lib/llvm-N/bin`, etc. Mirrors wasm-cxx-shim's toolchain file ladder.
- **Hardening against system-libc++ leakage**: `-nostdlibinc` on the manifold/Clipper2 cmake configure, plus a defense-in-depth `_LIBCPP_ASSERTION_SEMANTIC_DEFAULT=0` in `__config_site` for LLVM 21+ compatibility (the libc++ hardening axis was split in LLVM 21; without this, downstream LLVM 21 builds fail with `_LIBCPP_ASSERTION_SEMANTIC_DEFAULT is not defined`).
- **Vendored helpers** under `crates/manifold-csg-sys/wasm32-uu/`: `__config_site` (libc++ build-knob overrides), `__assertion_handler`, `mutex` stub (libc++'s `<mutex>` is gated on threads being on), `libcxx-extras.cpp` (libc++ source-file symbols the shim deliberately doesn't ship), and the two iostream-stripping patches (manifold's `bindings/c/manifoldc.cpp` + `src/impl.cpp`, plus Clipper2's headers).
- **OBJ I/O is `#[cfg]`-elided** on this target — manifold's iostream-using paths are excluded from the freestanding wasm build, so the corresponding FFI declarations + safe wrappers (`Manifold::from_obj`/`to_obj`, `MeshGL64::from_obj`/`to_obj`) and three integration tests are gated. Use the binary `MeshGL64` API to round-trip mesh data.
- **Smoke example + Node runner** at `crates/manifold-csg/examples/wasm32_uu_smoke.rs` + `crates/manifold-csg/wasm32-uu-runner/run.mjs` for validating the link cocktail end-to-end.
- **Diagnostics**: standalone `crates/manifold-csg-sys/wasm32-uu/diagnose.sh` that walks the LLVM probe ladder + dumps env/cargo/cache state for bug reports, plus a `build.rs` failure hook that prints the resolved clang++ path, candidates probed, and tails of `CMakeError.log` / `CMakeOutput.log` on any cmake/clang failure.
- **CI lane** `Wasm32 (unknown-unknown)` on Ubuntu installs LLVM 20 via apt.llvm.org + wabt for `wasm-objdump`, builds + verifies imports + runs the smoke under Node. The cache key includes a `cache-version` bust file (and is referenced from `restore-keys` too) so we can durably invalidate stale caches.
- **Provisional gate**: a new `unstable-wasm-uu` cargo feature on `manifold-csg-sys` (forwarded through `manifold-csg` and the `manifold3d-sys` / `manifold3d` facades) is **required** to build for this target. Without it, `build.rs` panics with an instructive error pointing at the README. With it on, `build.rs` emits a `cargo:warning=` every build as a persistent reminder of the constraints (carry-patches, no exception runtime, no OBJ I/O). Both surfaces disappear when we eventually graduate to stable — the feature can remain as a compat no-op.
- **Documentation**: README "Browser without Emscripten" section; new `docs/plans/wasm-unknown-unknown.md` design doc with what's in/out of scope and production-readiness checklist; CLAUDE.md notes the new `wasm32-uu/` directory.

## Out of scope (deliberate)

- Threading (single-threaded by design; SharedArrayBuffer requires consumer COOP/COEP cooperation).
- Exception runtime (`-fno-exceptions`; implicit STL throws abort).
- File I/O / OBJ I/O via streams (use binary `MeshGL64` API).
- General `wasm-bindgen` interop glue (out of scope for the kernel crate).

## Test plan

- [x] Local: host build + tests clean, fmt/clippy clean
- [x] Local: `cargo build --target wasm32-unknown-unknown -p manifold-csg-sys --features unstable-wasm-uu` builds clean
- [x] Local: `cargo build --target wasm32-unknown-unknown -p manifold-csg --no-default-features --features unstable-wasm-uu --tests --examples` builds clean
- [x] Local: produced wasm has zero unexpected imports (`wasm-objdump -x -j Import` reports "Section not found")
- [x] Local: smoke example runs under Node, returns 36 (correct triangle count for cube + translated cube union)
- [x] Local: build.rs panics with instructive error when feature is omitted, builds with persistent warning when feature is on
- [x] Local: end-to-end interactive validation via the boolean playground demo (separate branch) — exercises real CSG operations + transforms across many frames in the browser
- [ ] CI: `Wasm32 (unknown-unknown)` lane green
- [ ] CI: existing host lanes (Linux/macOS/Windows/MSRV/no-TBB/Sanitizer/Docs/Semver/Deny/Format/Emscripten) all still green