### PR TITLE
Add manifold-csg-playground: interactive browser demo + Node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,14 +163,19 @@ jobs:
           version: 5.0.7
           actions-cache-folder: emsdk-cache
 
+      # The EMSDK path is included in the cache key because cmake bakes it
+      # into target/wasm32-unknown-emscripten/.../CMakeCache.txt. Restoring
+      # a target/ from a run with a different EMSDK install path makes
+      # cmake panic on the now-gone toolchain file. Keying on EMSDK gives
+      # each install path its own cache bucket.
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-emscripten-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
-          restore-keys: ${{ runner.os }}-cargo-emscripten-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
+          key: ${{ runner.os }}-cargo-emscripten-${{ env.EMSDK }}-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-emscripten-${{ env.EMSDK }}-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
 
       # MANIFOLD_PAR is forced off for emscripten regardless of feature flags
       # (TBB needs SharedArrayBuffer + COOP/COEP HTTP headers from the host).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold) geom
 - `crates/manifold-csg-sys/` — Raw C FFI bindings (`links = "manifold"`)
 - `crates/manifold-csg/` — Safe Rust wrapper (the primary public API)
 - `crates/manifold-csg-sys/wasm32-uu/` — Vendored helper files (config_site, mutex stub, libcxx-extras.cpp, iostream-stripping patches) used only when building for `wasm32-unknown-unknown`. See `docs/plans/wasm-unknown-unknown.md`.
+- `crates/manifold-csg-playground/` — Browser-based demo (`publish = false`); also serves as a real-world consumer test for the `wasm32-unknown-unknown` build path. cdylib that exposes a tiny C ABI to a three.js frontend (`web/`) for interactively booleaning two primitives, with Node-side unit tests under `tests/` covering the wasm ABI and the JS/three.js glue.
 - `docs/plans/` — Design docs for in-flight or speculative work (e.g. new target support, large refactors). Lives in the repo so it travels with branches and stays reviewable; preferred over scattered GitHub issue prose for anything bigger than a paragraph.
 
 ## Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/manifold3d-sys",
     "crates/manifold3d",
     "crates/manifold3d-macros",
+    "crates/manifold-csg-playground",
 ]
 resolver = "2"
 

--- a/crates/manifold-csg-playground/.gitignore
+++ b/crates/manifold-csg-playground/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/crates/manifold-csg-playground/Cargo.toml
+++ b/crates/manifold-csg-playground/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "manifold-csg-playground"
+description = "Browser-based interactive demo for manifold-csg booleans (wasm32-unknown-unknown)"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# `unstable-wasm-uu` is required by manifold-csg-sys's build.rs when
+# targeting wasm32-unknown-unknown — opts in to the provisional bare-wasm
+# build path. This crate exists specifically to exercise that path.
+manifold-csg = { path = "../manifold-csg", default-features = false, features = ["unstable-wasm-uu"] }
+
+[lints]
+workspace = true

--- a/crates/manifold-csg-playground/README.md
+++ b/crates/manifold-csg-playground/README.md
@@ -1,0 +1,64 @@
+# manifold-csg-playground
+
+Interactive in-browser demo of `manifold-csg` booleans:
+
+- Pick two primitives (cube / sphere / cylinder) for slots A and B.
+- Move/rotate/scale either slot with three.js `TransformControls` gizmos.
+- Pick the boolean (union / difference / intersection) — the result mesh
+  recomputes live each frame.
+
+Built on top of PR #34's `wasm32-unknown-unknown` target support: no
+Emscripten, no `wasm-bindgen`, just a small C-style FFI shim in
+`src/lib.rs` and a single `.wasm` file that the browser loads directly.
+
+## Quick start
+
+```sh
+# 1. Build (requires rustup target add wasm32-unknown-unknown + LLVM 20+)
+bash crates/manifold-csg-playground/build.sh
+
+# 2. Serve
+bash crates/manifold-csg-playground/serve.sh
+
+# 3. Open http://localhost:8000 in a browser.
+```
+
+If LLVM 20+ is not on `PATH`, point at it via env var:
+
+```sh
+WASM_CXX_SHIM_LLVM_BIN_DIR=/usr/lib/llvm-20/bin bash build.sh
+```
+
+See `../../docs/plans/wasm-unknown-unknown.md` and the workspace `README.md`
+"Browser without Emscripten" section for the full toolchain story.
+
+## Tests
+
+There's a Node-side test suite covering the wasm C ABI and the JS glue
+that uploads the boolean result into a `BufferGeometry`. Run with:
+
+```sh
+bash crates/manifold-csg-playground/test.sh
+```
+
+`test.sh` rebuilds the wasm, runs `npm install` once into a local
+gitignored `node_modules/` (just brings in `three` so the geometry tests
+can use a real `BufferGeometry`), then `node --test tests/*.test.mjs`.
+
+## Layout
+
+- `src/lib.rs` — C ABI exports (`alloc`, `dealloc`, `set_primitive`,
+  `set_transform`, `set_op`, `rebuild`, `positions_ptr`, `positions_len`,
+  `indices_ptr`, `indices_len`).
+- `web/index.html` — UI controls + import map for three.js (loaded from
+  unpkg CDN, no bundler).
+- `web/main.js` — three.js scene + gizmo wiring.
+- `web/rebuild.js` — pure module with the wasm/three.js glue (matrix
+  conversion, geometry rebuild). Extracted so it's testable under Node.
+- `tests/` — Node tests (`wasm.test.mjs`, `rebuild.test.mjs`).
+- `build.sh` / `serve.sh` / `test.sh` — convenience scripts.
+
+## Not for crates.io
+
+`publish = false` in `Cargo.toml` — this crate exists to demo the kernel,
+not to be a library.

--- a/crates/manifold-csg-playground/build.sh
+++ b/crates/manifold-csg-playground/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Build the playground wasm and copy it into web/.
+#
+# Requirements (same as the wasm32-unknown-unknown target):
+#   - rustup target add wasm32-unknown-unknown
+#   - LLVM 20+ on PATH or via WASM_CXX_SHIM_LLVM_BIN_DIR
+#
+# See ../../docs/plans/wasm-unknown-unknown.md and the README.md "Browser
+# without Emscripten" section for the toolchain setup details.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$WORKSPACE_ROOT"
+cargo build --target wasm32-unknown-unknown --release -p manifold-csg-playground
+
+WASM="$WORKSPACE_ROOT/target/wasm32-unknown-unknown/release/manifold_csg_playground.wasm"
+DEST="$SCRIPT_DIR/web/manifold_csg_playground.wasm"
+
+cp "$WASM" "$DEST"
+echo "wrote $DEST ($(wc -c < "$DEST") bytes)"

--- a/crates/manifold-csg-playground/package.json
+++ b/crates/manifold-csg-playground/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "manifold-csg-playground-tests",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Node-side tests for the manifold-csg-playground browser demo. Not published; not consumed by web/ at runtime (browser uses an import map for three.js).",
+  "scripts": {
+    "test": "node --test tests/*.test.mjs"
+  },
+  "devDependencies": {
+    "three": "^0.169.0"
+  }
+}

--- a/crates/manifold-csg-playground/serve.sh
+++ b/crates/manifold-csg-playground/serve.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Serve web/ on http://localhost:8000 so the browser can fetch the .wasm
+# (file:// URLs can't run WebAssembly.instantiateStreaming in most browsers).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORT="${PORT:-8000}"
+
+cd "$SCRIPT_DIR/web"
+echo "serving $SCRIPT_DIR/web on http://localhost:$PORT"
+exec python3 -m http.server "$PORT"

--- a/crates/manifold-csg-playground/src/lib.rs
+++ b/crates/manifold-csg-playground/src/lib.rs
@@ -1,0 +1,243 @@
+//! Boolean playground — minimal C ABI bridging `manifold-csg` to a browser
+//! frontend (three.js).
+//!
+//! The state is two primitive "slots" plus a boolean op selector. Each slot
+//! has a kind (cube/sphere/cylinder), shape parameters, and a 4x3 affine
+//! transform pushed in from the JS gizmo. `rebuild()` runs the boolean and
+//! caches the resulting f32 vertex positions + u32 triangle indices in
+//! globally-owned `Vec`s; the frontend reads them via raw pointer + length
+//! getters and copies into a `THREE.BufferGeometry`.
+//!
+//! Designed for `wasm32-unknown-unknown` (no wasm-bindgen — see PR #34's
+//! `docs/plans/wasm-unknown-unknown.md` for why), but the same C ABI works
+//! on host so `cargo test` / `cargo check` on the workspace stay green.
+
+use std::sync::{Mutex, OnceLock};
+
+use manifold_csg::Manifold;
+
+#[derive(Clone)]
+struct Slot {
+    kind: i32,
+    params: [f64; 4],
+    transform: [f64; 12],
+}
+
+const IDENTITY_4X3: [f64; 12] = [
+    1.0, 0.0, 0.0, // col0 (X basis)
+    0.0, 1.0, 0.0, // col1 (Y basis)
+    0.0, 0.0, 1.0, // col2 (Z basis)
+    0.0, 0.0, 0.0, // col3 (translation)
+];
+
+impl Slot {
+    fn build(&self) -> Manifold {
+        let prim = match self.kind {
+            0 => Manifold::cube(self.params[0], self.params[1], self.params[2], true),
+            1 => {
+                let segs = (self.params[1] as i32).max(8);
+                Manifold::sphere(self.params[0], segs)
+            }
+            2 => {
+                let segs = (self.params[2] as i32).max(8);
+                Manifold::cylinder(self.params[0], self.params[1], self.params[1], segs, true)
+            }
+            _ => Manifold::empty(),
+        };
+        prim.transform(&self.transform)
+    }
+}
+
+struct State {
+    a: Slot,
+    b: Slot,
+    op: i32,
+    last_positions: Vec<f32>,
+    last_indices: Vec<u32>,
+}
+
+fn state() -> &'static Mutex<State> {
+    static STATE: OnceLock<Mutex<State>> = OnceLock::new();
+    STATE.get_or_init(|| {
+        let mut b_xform = IDENTITY_4X3;
+        b_xform[9] = 0.7; // translate B by +0.7 on X so default scene is non-empty
+
+        Mutex::new(State {
+            a: Slot {
+                kind: 0,
+                params: [1.0, 1.0, 1.0, 0.0],
+                transform: IDENTITY_4X3,
+            },
+            b: Slot {
+                kind: 0,
+                params: [1.0, 1.0, 1.0, 0.0],
+                transform: b_xform,
+            },
+            op: 0,
+            last_positions: Vec::new(),
+            last_indices: Vec::new(),
+        })
+    })
+}
+
+// ── JS-facing memory helpers ────────────────────────────────────────────
+
+/// Allocate `n` zero-initialised bytes in wasm linear memory and return a
+/// raw pointer. Caller (JS) is expected to release with [`dealloc`] when
+/// done.
+#[unsafe(no_mangle)]
+pub extern "C" fn alloc(n: usize) -> *mut u8 {
+    let mut v = vec![0u8; n];
+    let p = v.as_mut_ptr();
+    std::mem::forget(v);
+    p
+}
+
+/// Free a buffer previously returned by [`alloc`].
+///
+/// # Safety
+///
+/// `ptr` must have been returned by `alloc(n)` and not freed since. `n`
+/// must equal the original allocation size.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dealloc(ptr: *mut u8, n: usize) {
+    if ptr.is_null() || n == 0 {
+        return;
+    }
+    // SAFETY: per function contract, ptr came from alloc(n) (a Vec<u8> with
+    // capacity == length == n) and has not been freed; reconstruction with
+    // matching len/cap restores the original Vec for drop.
+    let v = unsafe { Vec::from_raw_parts(ptr, n, n) };
+    drop(v);
+}
+
+// ── Slot configuration ──────────────────────────────────────────────────
+
+fn slot_mut(s: &mut State, slot: i32) -> &mut Slot {
+    match slot {
+        0 => &mut s.a,
+        1 => &mut s.b,
+        n => panic!("invalid slot {n}: expected 0 (A) or 1 (B)"),
+    }
+}
+
+/// Set primitive kind + parameters for a slot. `slot` is 0 (A) or 1 (B).
+/// `kind` is 0=cube, 1=sphere, 2=cylinder. The four `p*` parameters are
+/// shape-specific:
+///
+/// - cube: `(x, y, z, _)`
+/// - sphere: `(radius, segments, _, _)`
+/// - cylinder: `(height, radius, segments, _)`
+///
+/// Panics if `slot` is not 0 or 1. (Panics in this crate abort the wasm
+/// instance; the JS frontend is expected to pass valid values.)
+#[unsafe(no_mangle)]
+pub extern "C" fn set_primitive(slot: i32, kind: i32, p0: f64, p1: f64, p2: f64, p3: f64) {
+    let mut s = state().lock().expect("playground state lock poisoned");
+    let target = slot_mut(&mut s, slot);
+    target.kind = kind;
+    target.params = [p0, p1, p2, p3];
+}
+
+/// Update the 4x3 column-major affine transform for a slot.
+///
+/// Panics if `slot` is not 0 or 1.
+///
+/// # Safety
+///
+/// `m_ptr` must point to 12 contiguous, well-aligned `f64`s.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn set_transform(slot: i32, m_ptr: *const f64) {
+    // SAFETY: per function contract, m_ptr is valid for 12 f64 reads.
+    let m = unsafe { std::slice::from_raw_parts(m_ptr, 12) };
+    let mut s = state().lock().expect("playground state lock poisoned");
+    let target = slot_mut(&mut s, slot);
+    target.transform.copy_from_slice(m);
+}
+
+/// Set the boolean operation: 0=union, 1=difference (A − B), 2=intersection.
+/// Panics on any other value.
+#[unsafe(no_mangle)]
+pub extern "C" fn set_op(op: i32) {
+    if !(0..=2).contains(&op) {
+        panic!("invalid op {op}: expected 0 (union), 1 (difference), or 2 (intersection)");
+    }
+    state().lock().expect("playground state lock poisoned").op = op;
+}
+
+// ── Recompute + result accessors ───────────────────────────────────────
+
+/// Recompute the boolean. Returns the resulting triangle count, or 0 if
+/// the result is empty. The returned positions and indices are valid until
+/// the next call to `rebuild`.
+#[unsafe(no_mangle)]
+pub extern "C" fn rebuild() -> i32 {
+    let mut s = state().lock().expect("playground state lock poisoned");
+    let a = s.a.build();
+    let b = s.b.build();
+    // `op` is validated at set_op time, so any value here is one of {0,1,2}.
+    let result = match s.op {
+        0 => &a + &b,
+        1 => &a - &b,
+        2 => &a ^ &b,
+        n => unreachable!("op {n} should have been rejected by set_op"),
+    };
+    let (verts, n_props, indices) = result.to_mesh_f32();
+
+    // Strip down to xyz only if the manifold carried extra properties
+    // (it shouldn't for our use case, but defensive).
+    let positions = if n_props == 3 || verts.is_empty() {
+        verts
+    } else {
+        let n_verts = verts.len() / n_props;
+        let mut p = Vec::with_capacity(n_verts * 3);
+        for i in 0..n_verts {
+            let base = i * n_props;
+            p.push(verts[base]);
+            p.push(verts[base + 1]);
+            p.push(verts[base + 2]);
+        }
+        p
+    };
+
+    let n_tris = indices.len() / 3;
+    s.last_positions = positions;
+    s.last_indices = indices;
+    n_tris.min(i32::MAX as usize) as i32
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn positions_ptr() -> *const f32 {
+    state()
+        .lock()
+        .expect("playground state lock poisoned")
+        .last_positions
+        .as_ptr()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn positions_len() -> usize {
+    state()
+        .lock()
+        .expect("playground state lock poisoned")
+        .last_positions
+        .len()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn indices_ptr() -> *const u32 {
+    state()
+        .lock()
+        .expect("playground state lock poisoned")
+        .last_indices
+        .as_ptr()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn indices_len() -> usize {
+    state()
+        .lock()
+        .expect("playground state lock poisoned")
+        .last_indices
+        .len()
+}

--- a/crates/manifold-csg-playground/test.sh
+++ b/crates/manifold-csg-playground/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Build the playground wasm + run the Node-side tests.
+#
+# The wasm tests load web/manifold_csg_playground.wasm directly, so the
+# build must run first. The rebuild tests need real three.js, installed
+# via npm into ./node_modules (gitignored).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "$SCRIPT_DIR/build.sh"
+
+cd "$SCRIPT_DIR"
+if [ ! -d node_modules ]; then
+    echo "→ installing test deps (one-time)..."
+    npm install --no-audit --no-fund
+fi
+
+node --test tests/*.test.mjs

--- a/crates/manifold-csg-playground/tests/load_wasm.mjs
+++ b/crates/manifold-csg-playground/tests/load_wasm.mjs
@@ -1,0 +1,13 @@
+// Shared wasm loader for Node-side tests.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export async function loadWasm() {
+    const wasmPath = join(__dirname, '..', 'web', 'manifold_csg_playground.wasm');
+    const bytes = readFileSync(wasmPath);
+    const { instance } = await WebAssembly.instantiate(bytes, {});
+    return instance.exports;
+}

--- a/crates/manifold-csg-playground/tests/rebuild.test.mjs
+++ b/crates/manifold-csg-playground/tests/rebuild.test.mjs
@@ -1,0 +1,184 @@
+// Geometry-rebuild flow tests — verify the JS glue between wasm and three.js
+// (rebuildIntoMesh) keeps the BufferGeometry in a state WebGL would accept,
+// across sequences of rebuilds whose vertex count fluctuates.
+//
+// This test would have caught the original bug where `computeVertexNormals()`
+// reused a too-small 'normal' attribute when vertex count grew between
+// rebuilds, producing the WebGL "vertex buffer not big enough" error.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+
+import { loadWasm } from './load_wasm.mjs';
+import {
+    KIND_CUBE, OP_UNION, OP_INTERSECTION,
+    pushTransform, setPrimitive, rebuildIntoMesh,
+} from '../web/rebuild.js';
+
+// The invariant WebGL would check at draw time: every attribute's count
+// (= array.length / itemSize) must be ≥ max value in the index buffer + 1.
+// Anything less and gl.drawElements rejects with "vertex buffer not big
+// enough for the draw call".
+function assertGeometryWebGLConsistent(geom, label) {
+    const index = geom.index;
+    if (!index || index.count === 0) {
+        // Empty geometry is OK — three.js just skips the draw.
+        return;
+    }
+    let maxIdx = -1;
+    for (let i = 0; i < index.count; i++) {
+        const v = index.getX(i);
+        if (v > maxIdx) maxIdx = v;
+    }
+    const minVerts = maxIdx + 1;
+    for (const [name, attr] of Object.entries(geom.attributes)) {
+        assert.ok(
+            attr.count >= minVerts,
+            `${label}: attribute '${name}' has count ${attr.count}, ` +
+            `but index buffer references vertex ${maxIdx} (need >= ${minVerts}). ` +
+            `WebGL would reject this draw.`,
+        );
+    }
+}
+
+function makeMesh() {
+    return new THREE.Mesh(new THREE.BufferGeometry());
+}
+
+function makeSetup(wasm) {
+    const scratchPtr = wasm.alloc(96);
+    wasm.set_op(OP_UNION);
+    setPrimitive(wasm, 0, KIND_CUBE);
+    setPrimitive(wasm, 1, KIND_CUBE);
+    return { scratchPtr };
+}
+
+function translate(x) {
+    const m = new THREE.Matrix4();
+    m.makeTranslation(x, 0, 0);
+    return m;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test('rebuildIntoMesh on default scene populates geometry consistently', async () => {
+    const wasm = await loadWasm();
+    const { scratchPtr } = makeSetup(wasm);
+    pushTransform(wasm, scratchPtr, 0, new THREE.Matrix4());
+    pushTransform(wasm, scratchPtr, 1, translate(0.7));
+    const mesh = makeMesh();
+    const tri = rebuildIntoMesh(THREE, wasm, mesh);
+    assert.ok(tri > 0, `default union should be non-empty, got ${tri}`);
+    assert.ok(mesh.geometry.attributes.position, 'position attribute set');
+    assert.ok(mesh.geometry.attributes.normal, 'normal attribute set');
+    assert.ok(mesh.geometry.index, 'index set');
+    assertGeometryWebGLConsistent(mesh.geometry, 'default-scene');
+});
+
+test('rebuildIntoMesh stays WebGL-consistent across vertex-count fluctuations', async () => {
+    // Regression test for the computeVertexNormals reuse bug: when vertex
+    // count grows between rebuilds, the stale 'normal' attribute caused
+    // WebGL "vertex buffer not big enough". We deliberately mix primitives,
+    // ops, and translations to guarantee vertex count varies; then assert
+    // every frame's geometry would be accepted by WebGL.
+    const wasm = await loadWasm();
+    const KIND_SPHERE = 1;
+    const KIND_CYLINDER = 2;
+    const OP_DIFFERENCE = 1;
+    const { scratchPtr } = makeSetup(wasm);
+    const mesh = makeMesh();
+
+    const frames = [
+        { aKind: KIND_CUBE,     bKind: KIND_CUBE,     bx: 0.7, op: OP_UNION },
+        { aKind: KIND_SPHERE,   bKind: KIND_CUBE,     bx: 0.5, op: OP_UNION },
+        { aKind: KIND_CYLINDER, bKind: KIND_SPHERE,   bx: 0.3, op: OP_DIFFERENCE },
+        { aKind: KIND_CUBE,     bKind: KIND_SPHERE,   bx: 0.6, op: OP_INTERSECTION },
+        { aKind: KIND_SPHERE,   bKind: KIND_CYLINDER, bx: 0.4, op: OP_UNION },
+        { aKind: KIND_CYLINDER, bKind: KIND_CYLINDER, bx: 0.2, op: OP_DIFFERENCE },
+    ];
+
+    pushTransform(wasm, scratchPtr, 0, new THREE.Matrix4());
+    const seenVertCounts = new Set();
+    for (const f of frames) {
+        setPrimitive(wasm, 0, f.aKind);
+        setPrimitive(wasm, 1, f.bKind);
+        wasm.set_op(f.op);
+        pushTransform(wasm, scratchPtr, 1, translate(f.bx));
+        rebuildIntoMesh(THREE, wasm, mesh);
+        const label = `aKind=${f.aKind} bKind=${f.bKind} op=${f.op} bx=${f.bx}`;
+        assertGeometryWebGLConsistent(mesh.geometry, label);
+        seenVertCounts.add(mesh.geometry.attributes.position.count);
+    }
+    assert.ok(seenVertCounts.size >= 3,
+        `sweep must hit at least 3 distinct vertex counts to exercise the bug; got ${seenVertCounts.size}: ${[...seenVertCounts].sort((a,b)=>a-b)}`);
+});
+
+test('rebuildIntoMesh handles empty result without leaving stale attributes', async () => {
+    const wasm = await loadWasm();
+    const { scratchPtr } = makeSetup(wasm);
+    pushTransform(wasm, scratchPtr, 0, new THREE.Matrix4());
+    pushTransform(wasm, scratchPtr, 1, translate(0.7));
+    const mesh = makeMesh();
+
+    // Populate with a non-empty result first so an old normal attribute exists.
+    rebuildIntoMesh(THREE, wasm, mesh);
+    assert.ok(mesh.geometry.attributes.position.count > 0);
+
+    // Now move B far away and ask for the intersection — empty.
+    pushTransform(wasm, scratchPtr, 1, translate(10.0));
+    wasm.set_op(OP_INTERSECTION);
+    const tri = rebuildIntoMesh(THREE, wasm, mesh);
+    assert.equal(tri, 0, 'disjoint intersection should be empty');
+    // After the empty rebuild, the geometry should still be drawable
+    // (i.e., not reference indices into a stale larger position buffer).
+    assertGeometryWebGLConsistent(mesh.geometry, 'empty-result');
+    assert.equal(mesh.geometry.attributes.position.count, 0,
+        'empty result should produce zero-vertex position attribute');
+});
+
+test('previous geometry is disposed when replaced', async () => {
+    const wasm = await loadWasm();
+    const { scratchPtr } = makeSetup(wasm);
+    pushTransform(wasm, scratchPtr, 0, new THREE.Matrix4());
+    pushTransform(wasm, scratchPtr, 1, translate(0.7));
+    const mesh = makeMesh();
+
+    rebuildIntoMesh(THREE, wasm, mesh);
+    const firstGeom = mesh.geometry;
+    let disposed = false;
+    firstGeom.addEventListener('dispose', () => { disposed = true; });
+
+    rebuildIntoMesh(THREE, wasm, mesh);
+    assert.ok(disposed, 'previous BufferGeometry should be disposed on rebuild');
+    assert.notEqual(mesh.geometry, firstGeom, 'rebuild should swap to a fresh geometry');
+});
+
+test('pushTransform writes column-major 4x3 layout into wasm scratch', async () => {
+    const wasm = await loadWasm();
+    const scratchPtr = wasm.alloc(96);
+    const m = new THREE.Matrix4();
+    // 90° about Y, then translate (5, 6, 7).
+    m.makeRotationY(Math.PI / 2);
+    m.setPosition(5, 6, 7);
+
+    pushTransform(wasm, scratchPtr, 0, m);
+
+    const view = new Float64Array(wasm.memory.buffer, scratchPtr, 12);
+    // Column 0 = rotated X basis = (cos90, 0, -sin90) = (0, 0, -1)
+    assert.ok(Math.abs(view[0] - 0) < 1e-9);
+    assert.ok(Math.abs(view[1] - 0) < 1e-9);
+    assert.ok(Math.abs(view[2] - -1) < 1e-9);
+    // Column 1 = Y basis = (0, 1, 0)
+    assert.ok(Math.abs(view[3] - 0) < 1e-9);
+    assert.ok(Math.abs(view[4] - 1) < 1e-9);
+    assert.ok(Math.abs(view[5] - 0) < 1e-9);
+    // Column 2 = rotated Z basis = (sin90, 0, cos90) = (1, 0, 0)
+    assert.ok(Math.abs(view[6] - 1) < 1e-9);
+    assert.ok(Math.abs(view[7] - 0) < 1e-9);
+    assert.ok(Math.abs(view[8] - 0) < 1e-9);
+    // Column 3 = translation
+    assert.equal(view[9], 5);
+    assert.equal(view[10], 6);
+    assert.equal(view[11], 7);
+});

--- a/crates/manifold-csg-playground/tests/wasm.test.mjs
+++ b/crates/manifold-csg-playground/tests/wasm.test.mjs
@@ -1,0 +1,167 @@
+// Wasm C ABI tests.
+//
+// Drives the same exported functions the browser frontend calls
+// (set_primitive / set_transform / set_op / rebuild + position/index
+// accessors) and verifies internal consistency: triangle counts make sense,
+// indices stay in-bounds of the position buffer, no NaNs, distinct ops
+// produce distinct results.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { loadWasm } from './load_wasm.mjs';
+
+const KIND_CUBE = 0;
+const KIND_SPHERE = 1;
+const KIND_CYLINDER = 2;
+
+const OP_UNION = 0;
+const OP_DIFFERENCE = 1;
+const OP_INTERSECTION = 2;
+
+const IDENTITY_4X3 = [1, 0, 0,  0, 1, 0,  0, 0, 1,  0, 0, 0];
+const TRANSLATE_X = (x) => [1, 0, 0,  0, 1, 0,  0, 0, 1,  x, 0, 0];
+
+function readPositions(wasm) {
+    return new Float32Array(
+        wasm.memory.buffer, wasm.positions_ptr(), wasm.positions_len(),
+    ).slice();
+}
+function readIndices(wasm) {
+    return new Uint32Array(
+        wasm.memory.buffer, wasm.indices_ptr(), wasm.indices_len(),
+    ).slice();
+}
+
+function pushTransform(wasm, scratchPtr, slot, m12) {
+    const view = new Float64Array(wasm.memory.buffer, scratchPtr, 12);
+    for (let i = 0; i < 12; i++) view[i] = m12[i];
+    wasm.set_transform(slot, scratchPtr);
+}
+
+// Set up a fresh wasm instance with two unit cubes (B translated +0.7 X)
+// and union op. Returns { wasm, scratchPtr } that match the browser's
+// initial scene.
+async function defaultScene() {
+    const wasm = await loadWasm();
+    const scratchPtr = wasm.alloc(96);
+    wasm.set_op(OP_UNION);
+    wasm.set_primitive(0, KIND_CUBE, 1.0, 1.0, 1.0, 0.0);
+    wasm.set_primitive(1, KIND_CUBE, 1.0, 1.0, 1.0, 0.0);
+    pushTransform(wasm, scratchPtr, 0, IDENTITY_4X3);
+    pushTransform(wasm, scratchPtr, 1, TRANSLATE_X(0.7));
+    return { wasm, scratchPtr };
+}
+
+// ── Property assertions ───────────────────────────────────────────────
+
+function assertResultConsistent(wasm, triCount, label) {
+    const positions = readPositions(wasm);
+    const indices = readIndices(wasm);
+
+    assert.equal(indices.length, triCount * 3,
+        `${label}: indices.length should equal triCount*3`);
+    assert.equal(positions.length % 3, 0,
+        `${label}: positions.length should be a multiple of 3 (xyz)`);
+
+    if (triCount === 0) {
+        assert.equal(positions.length, 0, `${label}: empty result has no positions`);
+        return;
+    }
+
+    const vertCount = positions.length / 3;
+    let maxIdx = -1;
+    for (const i of indices) if (i > maxIdx) maxIdx = i;
+    assert.ok(maxIdx < vertCount,
+        `${label}: max index ${maxIdx} must be < vertex count ${vertCount}`);
+
+    for (const v of positions) {
+        assert.ok(Number.isFinite(v), `${label}: position contains non-finite ${v}`);
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test('alloc/dealloc returns non-null aligned pointer', async () => {
+    const wasm = await loadWasm();
+    const p = wasm.alloc(96);
+    assert.notEqual(p, 0);
+    assert.equal(p % 8, 0, 'alloc(96) result should be 8-byte aligned');
+    wasm.dealloc(p, 96);
+});
+
+test('default scene: two unit cubes overlapping → union has > 0 triangles', async () => {
+    const { wasm } = await defaultScene();
+    const triCount = wasm.rebuild();
+    assert.ok(triCount > 0, `expected non-empty union, got ${triCount}`);
+    assertResultConsistent(wasm, triCount, 'default-union');
+});
+
+test('union vs intersection vs difference produce different triangle counts', async () => {
+    const { wasm } = await defaultScene();
+    wasm.set_op(OP_UNION);
+    const u = wasm.rebuild();
+    wasm.set_op(OP_INTERSECTION);
+    const i = wasm.rebuild();
+    wasm.set_op(OP_DIFFERENCE);
+    const d = wasm.rebuild();
+    assert.ok(u > 0 && i > 0 && d > 0, `all ops should be non-empty: u=${u} i=${i} d=${d}`);
+    // A ∪ B is strictly larger than A ∩ B for two overlapping cubes.
+    assert.ok(u > i, `union (${u}) should have more tris than intersection (${i})`);
+});
+
+test('disjoint operands: intersection is empty, union is non-empty', async () => {
+    const { wasm, scratchPtr } = await defaultScene();
+    pushTransform(wasm, scratchPtr, 1, TRANSLATE_X(10.0)); // far apart
+    wasm.set_op(OP_INTERSECTION);
+    assert.equal(wasm.rebuild(), 0, 'disjoint cubes have empty intersection');
+    assertResultConsistent(wasm, 0, 'disjoint-intersection');
+    wasm.set_op(OP_UNION);
+    const u = wasm.rebuild();
+    assert.ok(u > 0, 'disjoint cubes have non-empty union');
+    assertResultConsistent(wasm, u, 'disjoint-union');
+});
+
+test('rebuild result is internally consistent across primitive switches', async () => {
+    const { wasm } = await defaultScene();
+    const cases = [
+        { a: KIND_CUBE,     b: KIND_SPHERE,   ap: [1, 1, 1, 0],     bp: [0.7, 32, 0, 0] },
+        { a: KIND_SPHERE,   b: KIND_CYLINDER, ap: [0.7, 32, 0, 0],  bp: [1, 0.5, 32, 0] },
+        { a: KIND_CYLINDER, b: KIND_CUBE,     ap: [1, 0.5, 32, 0],  bp: [1, 1, 1, 0] },
+    ];
+    for (const { a, b, ap, bp } of cases) {
+        wasm.set_primitive(0, a, ...ap);
+        wasm.set_primitive(1, b, ...bp);
+        wasm.set_op(OP_UNION);
+        const triCount = wasm.rebuild();
+        assertResultConsistent(wasm, triCount, `union(kind=${a},kind=${b})`);
+    }
+});
+
+test('repeated rebuilds with growing/shrinking results stay consistent', async () => {
+    // Reproduces the "dragging the gizmo" pattern that surfaced the
+    // computeVertexNormals reuse bug in main.js — vertex count fluctuates
+    // across rebuilds. The wasm side's job is to keep its own outputs
+    // self-consistent; the JS test (rebuild.test.mjs) covers the JS bug.
+    const { wasm, scratchPtr } = await defaultScene();
+    for (const x of [0.1, 0.4, 0.7, 1.2, 0.3, 0.9, 0.05, 0.6]) {
+        pushTransform(wasm, scratchPtr, 1, TRANSLATE_X(x));
+        const triCount = wasm.rebuild();
+        assertResultConsistent(wasm, triCount, `union with B at x=${x}`);
+    }
+});
+
+test('result pointers are stable across reads but invalidated by next rebuild', async () => {
+    const { wasm } = await defaultScene();
+    wasm.rebuild();
+    const p1 = wasm.positions_ptr();
+    const p2 = wasm.positions_ptr();
+    assert.equal(p1, p2, 'consecutive positions_ptr() reads return the same pointer');
+
+    // After another rebuild with a different op (which produces different
+    // result sizes), the pointer may legitimately change.
+    wasm.set_op(OP_INTERSECTION);
+    wasm.rebuild();
+    // We don't assert p1 vs new — both reuse-and-different are legal — but
+    // the new read must be internally consistent.
+    assertResultConsistent(wasm, wasm.indices_len() / 3, 'after-op-switch');
+});

--- a/crates/manifold-csg-playground/web/.gitignore
+++ b/crates/manifold-csg-playground/web/.gitignore
@@ -1,0 +1,1 @@
+manifold_csg_playground.wasm

--- a/crates/manifold-csg-playground/web/index.html
+++ b/crates/manifold-csg-playground/web/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>manifold-csg boolean playground</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --panel-bg: rgba(20, 22, 28, 0.85);
+            --panel-fg: #e6e8ee;
+            --panel-border: rgba(255, 255, 255, 0.08);
+            --accent: #7aa2ff;
+        }
+        html, body { height: 100%; margin: 0; }
+        body {
+            background: #0b0d12;
+            color: var(--panel-fg);
+            font: 13px/1.4 system-ui, -apple-system, "Segoe UI", sans-serif;
+            overflow: hidden;
+        }
+        canvas { display: block; }
+        #ui {
+            position: absolute;
+            top: 16px;
+            left: 16px;
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            border-radius: 10px;
+            padding: 14px 16px;
+            backdrop-filter: blur(10px);
+            min-width: 220px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+        }
+        #ui h1 {
+            font-size: 13px;
+            font-weight: 600;
+            margin: 0 0 10px;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: #a0a8b8;
+        }
+        #ui label {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin: 6px 0;
+            font-size: 12px;
+        }
+        #ui select {
+            background: #1a1d25;
+            color: var(--panel-fg);
+            border: 1px solid var(--panel-border);
+            border-radius: 5px;
+            padding: 4px 6px;
+            font: inherit;
+            min-width: 110px;
+        }
+        #ui hr {
+            border: none;
+            border-top: 1px solid var(--panel-border);
+            margin: 10px 0;
+        }
+        #ui .row {
+            display: flex;
+            gap: 4px;
+            margin: 6px 0;
+        }
+        #ui .row button {
+            flex: 1;
+            background: #1a1d25;
+            color: var(--panel-fg);
+            border: 1px solid var(--panel-border);
+            border-radius: 5px;
+            padding: 4px 6px;
+            font: inherit;
+            cursor: pointer;
+        }
+        #ui .row button.active {
+            background: var(--accent);
+            color: #0b0d12;
+            border-color: var(--accent);
+        }
+        #status {
+            font-size: 11px;
+            color: #7a8090;
+            margin-top: 10px;
+        }
+        #status.error { color: #ff6b6b; }
+    </style>
+</head>
+<body>
+    <div id="ui">
+        <h1>boolean playground</h1>
+
+        <label>Primitive A
+            <select id="kind-a">
+                <option value="0">Cube</option>
+                <option value="1">Sphere</option>
+                <option value="2">Cylinder</option>
+            </select>
+        </label>
+
+        <label>Primitive B
+            <select id="kind-b">
+                <option value="0">Cube</option>
+                <option value="1">Sphere</option>
+                <option value="2">Cylinder</option>
+            </select>
+        </label>
+
+        <label>Operation
+            <select id="op">
+                <option value="0">Union (A + B)</option>
+                <option value="1">Difference (A − B)</option>
+                <option value="2">Intersection (A ∩ B)</option>
+            </select>
+        </label>
+
+        <hr>
+
+        <div style="font-size: 11px; color: #a0a8b8; margin-bottom: 4px;">Gizmo target</div>
+        <div class="row">
+            <button data-target="0" class="target-btn active">A</button>
+            <button data-target="1" class="target-btn">B</button>
+        </div>
+
+        <div style="font-size: 11px; color: #a0a8b8; margin: 8px 0 4px;">Gizmo mode</div>
+        <div class="row">
+            <button data-mode="translate" class="mode-btn active">Translate</button>
+            <button data-mode="rotate"    class="mode-btn">Rotate</button>
+            <button data-mode="scale"     class="mode-btn">Scale</button>
+        </div>
+
+        <div id="status">loading wasm…</div>
+    </div>
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://unpkg.com/three@0.169.0/build/three.module.js",
+            "three/addons/": "https://unpkg.com/three@0.169.0/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/crates/manifold-csg-playground/web/main.js
+++ b/crates/manifold-csg-playground/web/main.js
@@ -1,0 +1,262 @@
+// manifold-csg-playground — three.js frontend
+//
+// Loads the wasm32-unknown-unknown build of `manifold-csg-playground`, wires
+// two TransformControls gizmos to push 4×3 affine matrices into wasm, and
+// reads the boolean-result mesh back as `BufferGeometry` attributes from
+// raw linear memory.
+//
+// Zero npm dependencies — three.js is pulled from a CDN via the import map
+// in index.html. PR #34 (wasm32-unknown-unknown support) deliberately
+// punts wasm-bindgen, so this uses the raw C-style ABI exported by lib.rs.
+//
+// The pure-data parts (matrix conversion, geometry rebuild) live in
+// rebuild.js so they can be unit-tested under Node.
+
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { TransformControls } from 'three/addons/controls/TransformControls.js';
+
+import {
+    KIND_CUBE, KIND_SPHERE, KIND_CYLINDER,
+    OP_UNION,
+    pushTransform as pushTransformImpl,
+    setPrimitive as setPrimitiveImpl,
+    rebuildIntoMesh,
+} from './rebuild.js';
+
+// ── Status helper ──────────────────────────────────────────────────────
+
+const statusEl = document.getElementById('status');
+function setStatus(text, isError = false) {
+    statusEl.textContent = text;
+    statusEl.classList.toggle('error', isError);
+}
+
+// ── wasm load ──────────────────────────────────────────────────────────
+
+let wasm;
+try {
+    const { instance } = await WebAssembly.instantiateStreaming(
+        fetch('./manifold_csg_playground.wasm'),
+        {},
+    );
+    wasm = instance.exports;
+} catch (e) {
+    setStatus(`wasm load failed: ${e.message}`, true);
+    throw e;
+}
+
+// 96-byte scratch (12 × f64) for matrix uploads.
+const transformScratchPtr = wasm.alloc(96);
+
+const pushTransform = (slot, matrix4) =>
+    pushTransformImpl(wasm, transformScratchPtr, slot, matrix4);
+const setPrimitive = (slot, kind) => setPrimitiveImpl(wasm, slot, kind);
+
+// ── three.js scene ────────────────────────────────────────────────────
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x0b0d12);
+
+const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.01, 100);
+camera.position.set(2.4, 1.8, 3.2);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+scene.add(new THREE.AmbientLight(0xffffff, 0.5));
+const keyLight = new THREE.DirectionalLight(0xffffff, 1.2);
+keyLight.position.set(3, 5, 2);
+scene.add(keyLight);
+const rimLight = new THREE.DirectionalLight(0x7aa2ff, 0.6);
+rimLight.position.set(-3, -2, -2);
+scene.add(rimLight);
+
+const grid = new THREE.GridHelper(10, 20, 0x303642, 0x1f242d);
+grid.rotation.x = Math.PI / 2; // grid in XY plane (Z up matches manifold's convention)
+scene.add(grid);
+
+const orbit = new OrbitControls(camera, renderer.domElement);
+orbit.enableDamping = true;
+orbit.target.set(0, 0, 0);
+
+// ── Slot proxies (carry the gizmos) ───────────────────────────────────
+
+function makeProxyGeometry(kind) {
+    switch (kind) {
+        case KIND_CUBE:     return new THREE.BoxGeometry(1.0, 1.0, 1.0);
+        case KIND_SPHERE:   return new THREE.SphereGeometry(0.7, 24, 16);
+        case KIND_CYLINDER: {
+            // manifold's cylinder is along Z; three's CylinderGeometry is
+            // along Y, so rotate. Wrap in a group so the gizmo target is
+            // a single Object3D.
+            const g = new THREE.CylinderGeometry(0.5, 0.5, 1.0, 24);
+            g.rotateX(Math.PI / 2);
+            return g;
+        }
+    }
+    return new THREE.BoxGeometry(1, 1, 1);
+}
+
+const proxyMaterial = new THREE.MeshBasicMaterial({
+    color: 0x7aa2ff,
+    transparent: true,
+    opacity: 0.0,           // invisible by default; shows on hover via wire helper
+    depthWrite: false,
+});
+
+function makeSlot(slotIdx, initialKind, initialPos) {
+    const proxy = new THREE.Mesh(makeProxyGeometry(initialKind), proxyMaterial);
+    proxy.userData.slot = slotIdx;
+    proxy.userData.kind = initialKind;
+    proxy.position.copy(initialPos);
+    scene.add(proxy);
+
+    // Wireframe child to visualise the input shape (so the user can see
+    // what they're dragging even though the proxy itself is invisible).
+    const wire = new THREE.LineSegments(
+        new THREE.EdgesGeometry(proxy.geometry),
+        new THREE.LineBasicMaterial({
+            color: slotIdx === 0 ? 0x7aa2ff : 0xff8a65,
+            transparent: true,
+            opacity: 0.35,
+        }),
+    );
+    proxy.add(wire);
+    proxy.userData.wire = wire;
+
+    return proxy;
+}
+
+const slotA = makeSlot(0, KIND_CUBE, new THREE.Vector3(0, 0, 0));
+const slotB = makeSlot(1, KIND_CUBE, new THREE.Vector3(0.7, 0, 0));
+const slots = [slotA, slotB];
+
+// ── Result mesh ───────────────────────────────────────────────────────
+
+const resultMaterial = new THREE.MeshStandardMaterial({
+    color: 0xeef0f4,
+    roughness: 0.4,
+    metalness: 0.05,
+    flatShading: true,
+    side: THREE.DoubleSide,
+});
+
+const resultMesh = new THREE.Mesh(new THREE.BufferGeometry(), resultMaterial);
+scene.add(resultMesh);
+
+function rebuildAndUpload() {
+    const triCount = rebuildIntoMesh(THREE, wasm, resultMesh);
+    setStatus(triCount > 0
+        ? `boolean result: ${triCount} triangles`
+        : 'boolean result: empty');
+}
+
+// Coalesce many gizmo events into a single rebuild per animation frame.
+let rebuildPending = false;
+function scheduleRebuild() {
+    if (rebuildPending) return;
+    rebuildPending = true;
+    requestAnimationFrame(() => {
+        rebuildPending = false;
+        rebuildAndUpload();
+    });
+}
+
+// ── Transform gizmo ────────────────────────────────────────────────────
+
+let activeSlot = 0;
+const gizmo = new TransformControls(camera, renderer.domElement);
+gizmo.size = 0.8;
+const gizmoHelper = gizmo.getHelper ? gizmo.getHelper() : gizmo;
+scene.add(gizmoHelper);
+gizmo.attach(slots[activeSlot]);
+
+gizmo.addEventListener('dragging-changed', (event) => {
+    orbit.enabled = !event.value;
+});
+gizmo.addEventListener('objectChange', () => {
+    const obj = gizmo.object;
+    if (!obj) return;
+    obj.updateMatrix();
+    pushTransform(obj.userData.slot, obj.matrix);
+    scheduleRebuild();
+});
+
+function setActiveSlot(idx) {
+    activeSlot = idx;
+    gizmo.attach(slots[idx]);
+    document.querySelectorAll('.target-btn').forEach((b) => {
+        b.classList.toggle('active', Number(b.dataset.target) === idx);
+    });
+}
+
+function setGizmoMode(mode) {
+    gizmo.setMode(mode);
+    document.querySelectorAll('.mode-btn').forEach((b) => {
+        b.classList.toggle('active', b.dataset.mode === mode);
+    });
+}
+
+document.querySelectorAll('.target-btn').forEach((b) => {
+    b.addEventListener('click', () => setActiveSlot(Number(b.dataset.target)));
+});
+document.querySelectorAll('.mode-btn').forEach((b) => {
+    b.addEventListener('click', () => setGizmoMode(b.dataset.mode));
+});
+
+// ── Primitive + op pickers ─────────────────────────────────────────────
+
+function swapProxyShape(slotIdx, kind) {
+    const proxy = slots[slotIdx];
+    proxy.userData.kind = kind;
+    proxy.geometry.dispose();
+    proxy.geometry = makeProxyGeometry(kind);
+    proxy.userData.wire.geometry.dispose();
+    proxy.userData.wire.geometry = new THREE.EdgesGeometry(proxy.geometry);
+}
+
+function onPrimitiveChange(slotIdx, kind) {
+    setPrimitive(slotIdx, kind);
+    swapProxyShape(slotIdx, kind);
+    scheduleRebuild();
+}
+
+document.getElementById('kind-a').addEventListener('change', (e) => {
+    onPrimitiveChange(0, Number(e.target.value));
+});
+document.getElementById('kind-b').addEventListener('change', (e) => {
+    onPrimitiveChange(1, Number(e.target.value));
+});
+document.getElementById('op').addEventListener('change', (e) => {
+    wasm.set_op(Number(e.target.value));
+    scheduleRebuild();
+});
+
+// ── Initial sync (wasm has its own defaults; mirror them) ─────────────
+
+wasm.set_op(OP_UNION);
+setPrimitive(0, KIND_CUBE);
+setPrimitive(1, KIND_CUBE);
+slots[0].updateMatrix();
+slots[1].updateMatrix();
+pushTransform(0, slots[0].matrix);
+pushTransform(1, slots[1].matrix);
+rebuildAndUpload();
+
+// ── Render loop ────────────────────────────────────────────────────────
+
+window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+});
+
+function animate() {
+    requestAnimationFrame(animate);
+    orbit.update();
+    renderer.render(scene, camera);
+}
+animate();

--- a/crates/manifold-csg-playground/web/rebuild.js
+++ b/crates/manifold-csg-playground/web/rebuild.js
@@ -1,0 +1,71 @@
+// Pure-data interface from the wasm module to a three.js BufferGeometry.
+// Extracted from main.js so it can be unit-tested under Node without a
+// browser/WebGL context.
+//
+// Both `THREE` and `wasm` are passed in by the caller — the module has no
+// import-time dependencies of its own.
+
+export const KIND_CUBE = 0;
+export const KIND_SPHERE = 1;
+export const KIND_CYLINDER = 2;
+
+export const OP_UNION = 0;
+export const OP_DIFFERENCE = 1;
+export const OP_INTERSECTION = 2;
+
+export const DEFAULT_PARAMS = {
+    [KIND_CUBE]:     [1.0, 1.0, 1.0, 0.0],
+    [KIND_SPHERE]:   [0.7, 32.0, 0.0, 0.0],
+    [KIND_CYLINDER]: [1.0, 0.5, 32.0, 0.0],
+};
+
+// Copy a THREE.Matrix4 (column-major, length 16) into the wasm scratch
+// buffer as a 12-element column-major 4x3 affine (manifold's convention:
+// the implicit fourth row is [0,0,0,1]).
+export function pushTransform(wasm, scratchPtr, slot, matrix4) {
+    const e = matrix4.elements;
+    const view = new Float64Array(wasm.memory.buffer, scratchPtr, 12);
+    view[0]  = e[0];  view[1]  = e[1];  view[2]  = e[2];   // col0 (X basis)
+    view[3]  = e[4];  view[4]  = e[5];  view[5]  = e[6];   // col1 (Y basis)
+    view[6]  = e[8];  view[7]  = e[9];  view[8]  = e[10];  // col2 (Z basis)
+    view[9]  = e[12]; view[10] = e[13]; view[11] = e[14];  // col3 (translation)
+    wasm.set_transform(slot, scratchPtr);
+}
+
+export function setPrimitive(wasm, slot, kind, params = DEFAULT_PARAMS[kind]) {
+    const [p0, p1, p2, p3] = params;
+    wasm.set_primitive(slot, kind, p0, p1, p2, p3);
+}
+
+// Run the boolean and replace `mesh.geometry` with a fresh BufferGeometry
+// holding the result. Returns the triangle count.
+//
+// We replace the BufferGeometry wholesale rather than mutating in place:
+// `computeVertexNormals()` reuses an existing 'normal' attribute even when
+// the new position attribute has a different vertex count, which then
+// triggers WebGL "vertex buffer not big enough" once the rebuild grows
+// vertex count.
+export function rebuildIntoMesh(THREE, wasm, mesh) {
+    const triCount = wasm.rebuild();
+
+    const posPtr = wasm.positions_ptr();
+    const posLen = wasm.positions_len();
+    const idxPtr = wasm.indices_ptr();
+    const idxLen = wasm.indices_len();
+
+    // Slice copies — the wasm Vecs are reallocated on the next rebuild.
+    const positions = new Float32Array(wasm.memory.buffer, posPtr, posLen).slice();
+    const indices = new Uint32Array(wasm.memory.buffer, idxPtr, idxLen).slice();
+
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geom.setIndex(new THREE.BufferAttribute(indices, 1));
+    if (positions.length > 0) {
+        geom.computeVertexNormals();
+        geom.computeBoundingSphere();
+    }
+    mesh.geometry.dispose();
+    mesh.geometry = geom;
+
+    return triCount;
+}


### PR DESCRIPTION
A browser-based interactive demo of the boolean kernel (cube/sphere/cylinder × union/difference/intersection), riding on the recently-landed `wasm32-unknown-unknown` target (#34). Doubles as a real-world consumer test for that build path — exercises real CSG operations with live transforms, well beyond what the synthetic smoke example covers.

The crate is `publish = false` and lives in the workspace so it gets exercised by \`cargo build\` / \`cargo check\`. It opts in to the new \`unstable-wasm-uu\` feature on its \`manifold-csg\` dependency.

## Layout

- \`src/lib.rs\` — minimal C ABI (\`alloc\`/\`dealloc\`, \`set_primitive\`, \`set_transform\`, \`set_op\`, \`rebuild\`, positions/indices accessors). Global state under \`OnceLock<Mutex<State>>\`. Slot indices and op values are validated; out-of-range inputs panic with an instructive message.
- \`web/index.html\` + \`web/main.js\` — three.js 0.169 (loaded from unpkg via import map, no bundler) + \`TransformControls\` gizmos that push 4×3 affine matrices into wasm. Result mesh is rebuilt as a fresh \`BufferGeometry\` each frame from raw linear memory.
- \`web/rebuild.js\` — pure module containing the wasm/three.js glue (matrix conversion, geometry rebuild). Extracted from \`main.js\` so it's unit-testable under Node.
- \`tests/wasm.test.mjs\` — drives the C ABI (alloc alignment, default scene, op variants, disjoint operands, primitive switches, repeated rebuilds, pointer stability). Loads the \`.wasm\` with \`WebAssembly.instantiate\`; verifies indices stay in-bounds, no NaNs.
- \`tests/rebuild.test.mjs\` — drives \`rebuildIntoMesh\` against real three.js. Includes a regression test for a \`computeVertexNormals\` reuse bug: when vertex count grew between rebuilds, the stale 'normal' attribute caused WebGL "vertex buffer not big enough". Fixed by replacing the \`BufferGeometry\` wholesale rather than mutating in place.
- \`build.sh\` / \`serve.sh\` / \`test.sh\` — convenience scripts.

## Why a separate crate

It exercises the wasm32-uu API end-to-end (well beyond what the freestanding smoke example covers) and gives downstream readers a runnable example of "small C ABI + three.js" — a pattern likely to recur for other Rust-via-wasm geometry consumers.

## Drive-by: Emscripten CI cache fix

Includes \`EMSDK\` in the Emscripten lane's cache key. cmake bakes the absolute toolchain file path into \`CMakeCache.txt\`, so restoring a \`target/\` from a run with a different \`EMSDK\` install path makes cmake panic on the now-gone toolchain file. Keying on \`EMSDK\` gives each install path its own cache bucket. Surfaced because the lane started failing on this PR; unrelated to the playground itself.

## Test plan

- [x] Local: \`bash crates/manifold-csg-playground/build.sh\` builds the wasm clean (391 KB, zero unexpected imports)
- [x] Local: \`bash crates/manifold-csg-playground/test.sh\` — all 12 Node tests pass
- [x] Local: interactive browser test — drag gizmos, switch primitives/ops, observe live boolean updates without WebGL errors
- [x] Local: \`cargo fmt --all --check\` and \`cargo clippy -p manifold-csg-playground --all-targets -- -D warnings\` clean
- [x] Local: regression test for the vertex-count fluctuation bug verified to catch the original symptom (off-by-N normal attribute mismatch)
- [ ] CI: workspace lanes (host + wasm32-uu + Emscripten) all green with the new crate added to \`members = [...]\`