### PR TITLE
playground: add About section with project context + links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold) geom
 
 - `crates/manifold-csg-sys/` — Raw C FFI bindings (`links = "manifold"`)
 - `crates/manifold-csg/` — Safe Rust wrapper (the primary public API)
-- `crates/manifold-csg-sys/wasm32-uu/` — Vendored helper files (config_site, mutex stub, libcxx-extras.cpp, iostream-stripping patches) used only when building for `wasm32-unknown-unknown`. See `docs/plans/wasm-unknown-unknown.md`.
+- `crates/manifold-csg-sys/wasm32-uu/` — Vendored helper files (config_site, mutex stub, libcxx-extras.cpp, iostream-stripping patches) used only when building for `wasm32-unknown-unknown`. See [`docs/plans/wasm-unknown-unknown.md`](docs/plans/wasm-unknown-unknown.md).
 - `crates/manifold-csg-playground/` — Browser-based demo (`publish = false`); also serves as a real-world consumer test for the `wasm32-unknown-unknown` build path. cdylib that exposes a tiny C ABI to a three.js frontend (`web/`) for interactively booleaning two primitives, with Node-side unit tests under `tests/` covering the wasm ABI and the JS/three.js glue.
 - `docs/plans/` — Design docs for in-flight or speculative work (e.g. new target support, large refactors). Lives in the repo so it travels with branches and stays reviewable; preferred over scattered GitHub issue prose for anything bigger than a paragraph.
 

--- a/crates/manifold-csg-playground/README.md
+++ b/crates/manifold-csg-playground/README.md
@@ -29,7 +29,7 @@ If LLVM 20+ is not on `PATH`, point at it via env var:
 WASM_CXX_SHIM_LLVM_BIN_DIR=/usr/lib/llvm-20/bin bash build.sh
 ```
 
-See `../../docs/plans/wasm-unknown-unknown.md` and the workspace `README.md`
+See [`../../docs/plans/wasm-unknown-unknown.md`](../../docs/plans/wasm-unknown-unknown.md) and the workspace [`README.md`](../../README.md)
 "Browser without Emscripten" section for the full toolchain story.
 
 ## Tests

--- a/crates/manifold-csg-playground/web/index.html
+++ b/crates/manifold-csg-playground/web/index.html
@@ -87,11 +87,22 @@
             margin-top: 10px;
         }
         #status.error { color: #ff6b6b; }
+        #about {
+            font-size: 11px;
+            color: #a0a8b8;
+            margin-top: 12px;
+            line-height: 1.5;
+        }
+        #about a {
+            color: var(--accent);
+            text-decoration: none;
+        }
+        #about a:hover { text-decoration: underline; }
     </style>
 </head>
 <body>
     <div id="ui">
-        <h1>boolean playground</h1>
+        <h1>manifold-csg playground</h1>
 
         <label>Primitive A
             <select id="kind-a">
@@ -133,6 +144,16 @@
         </div>
 
         <div id="status">loading wasm…</div>
+
+        <hr>
+
+        <div id="about">
+            Live demo of <a href="https://github.com/zmerlynn/manifold-csg" target="_blank" rel="noopener">manifold-csg</a> — safe Rust bindings to the <a href="https://github.com/elalish/manifold" target="_blank" rel="noopener">manifold3d</a> CSG kernel, compiled to <code>wasm32-unknown-unknown</code> (no Emscripten, no wasm-bindgen).
+            <br>
+            <a href="https://github.com/zmerlynn/manifold-csg/tree/main/crates/manifold-csg-playground" target="_blank" rel="noopener">Source &amp; build instructions</a> ·
+            <a href="https://crates.io/crates/manifold-csg" target="_blank" rel="noopener">crates.io</a> ·
+            <a href="https://docs.rs/manifold-csg" target="_blank" rel="noopener">docs.rs</a>
+        </div>
     </div>
 
     <script type="importmap">

--- a/crates/manifold-csg-playground/web/index.html
+++ b/crates/manifold-csg-playground/web/index.html
@@ -29,6 +29,7 @@
             padding: 14px 16px;
             backdrop-filter: blur(10px);
             min-width: 220px;
+            max-width: 280px;
             box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
         }
         #ui h1 {

--- a/crates/manifold-csg-sys/wasm32-uu/patches/README.md
+++ b/crates/manifold-csg-sys/wasm32-uu/patches/README.md
@@ -2,16 +2,16 @@
 
 Patches applied to manifold and Clipper2 source trees during the
 `wasm32-unknown-unknown` build path. Sibling to (and distinct from) the
-host carry-patches under `../../patches/`, which target the same
+host carry-patches under [`../../patches/`](../../patches/), which target the same
 manifold tree but a different build configuration.
 
 ## Files
 
-- `0001-manifold-ifdef-iostream.patch` — wraps manifold's iostream-using
+- [`0001-manifold-ifdef-iostream.patch`](0001-manifold-ifdef-iostream.patch) — wraps manifold's iostream-using
   OBJ I/O paths under `MANIFOLD_NO_IOSTREAM`. Generated against our
   pinned manifold SHA (post-3.4.1 master). Three blocks across
   `bindings/c/manifoldc.cpp` and `src/impl.cpp`.
-- `0002-clipper2-strip-iostream.patch` — strips `<iostream>` from
+- [`0002-clipper2-strip-iostream.patch`](0002-clipper2-strip-iostream.patch) — strips `<iostream>` from
   Clipper2 headers. Verbatim from
   [wasm-cxx-shim's reference impl](https://github.com/zmerlynn/wasm-cxx-shim/blob/main/test/manifold-link/patches/0001-clipper2-strip-iostream.patch);
   applies to the SHA manifold pins (`46f6391...`, see
@@ -48,6 +48,6 @@ bump `MANIFOLD_VERSION` in `build.rs` and the wasm32-uu lane fails:
    and `src/impl.cpp` to match the new line numbers.
 4. Regenerate: `git diff --no-prefix bindings/c/manifoldc.cpp src/impl.cpp > new.patch`.
 5. Splice the new patch body under the existing header comment in
-   `0001-manifold-ifdef-iostream.patch`.
+   [`0001-manifold-ifdef-iostream.patch`](0001-manifold-ifdef-iostream.patch).
 
 Same flow for Clipper2 if the upstream pin moves.

--- a/docs/plans/wasm-unknown-unknown.md
+++ b/docs/plans/wasm-unknown-unknown.md
@@ -17,7 +17,7 @@ The C++ runtime gap (`wasm32-unknown-unknown` ships no libc, no libcxx,
 no libcxxabi) is filled by `wasm-cxx-shim` (pinned to v0.2.0) — a small,
 independently-maintained library providing exactly the C/C++ runtime
 subset that manifold3d (and similar C++-via-Rust crates) need. See the
-shim's `docs/context.md` for the design background.
+shim's [`docs/context.md`](https://github.com/zmerlynn/wasm-cxx-shim/blob/main/docs/context.md) for the design background.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Visitors landing on the published Pages site (\`https://zmerlynn.github.io/manifold-csg/\`) now see a short blurb explaining what the demo is OF — safe Rust bindings to the manifold3d CSG kernel, compiled to \`wasm32-unknown-unknown\` without Emscripten or wasm-bindgen — plus three links: the GitHub repo, the playground crate's source/build instructions, and crates.io / docs.rs.

Also renames the panel title from "boolean playground" to "manifold-csg playground" so the project name is the first thing visible — useful when someone bookmarks or shares a screenshot.

## What it looks like

The new About section appears at the bottom of the existing UI panel, separated by an \`<hr>\`. Two lines of small (11px) text in muted color, with the accent-colored links inheriting the existing panel theme. The panel has a \`max-width: 280px\` cap so the longer About text wraps inside the panel rather than stretching it across the viewport.

## Drive-by: linkify path references in docs

Five path references in prose that read like "see X" / "under Y" but were plain backticked text instead of clickable markdown links:
- \`CLAUDE.md\` → \`docs/plans/wasm-unknown-unknown.md\`
- \`crates/manifold-csg-playground/README.md\` → \`../../docs/plans/wasm-unknown-unknown.md\` and the workspace \`README.md\`
- \`docs/plans/wasm-unknown-unknown.md\` → cross-repo link to wasm-cxx-shim's \`docs/context.md\`
- \`crates/manifold-csg-sys/wasm32-uu/patches/README.md\` → \`../../patches/\` plus the two patch filenames (3× total)

Spotted while polishing the demo; small enough to ride along.

## Test plan

- [x] Local: page loads, links go to the right URLs, layout doesn't shift other controls
- [x] Local: \`max-width\` cap keeps the panel from stretching when the About text doesn't wrap
- [x] Local: doc links render as clickable in the GitHub markdown viewer
- [ ] Post-merge: Pages workflow auto-deploys (the path filter matches \`crates/manifold-csg-playground/**\`)