### PR TITLE
Hotfix: cfg-gate ray_cast on wasm32-uu + fix Pages cache key

### DIFF
--- a/.claude/skills/deep-review/SKILL.md
+++ b/.claude/skills/deep-review/SKILL.md
@@ -195,6 +195,7 @@ This crate tracks manifold3d upstream. Verify:
 - Pinned version in `build.rs` — what version are we on? What's latest? What changed?
 - ABI compatibility — have any C API function signatures changed in newer manifold3d releases?
 - Deprecated functions — are we binding any C API functions that upstream has deprecated?
+- **wasm32-unknown-unknown cfg-gates may need revisiting.** Grep for `target_os = "unknown"` across the workspace. Each gated FFI declaration / safe wrapper / test is gated because that C API surface postdates the shim's tested manifold pin. When the shim's tested pin moves to (or past) our host pin, those gates can be removed. Currently gated: `manifold_ray_*` (ray casting). The OBJ I/O gates are gated for a different reason (iostream patches strip them) and stay regardless.
 - New capabilities — has upstream added significant new C API surface (new types, new operations) that we're missing?
 - Build system changes — has manifold3d changed its CMake structure, added/removed FetchContent deps, changed library names?
 - Known upstream bugs — check manifold3d issues for bugs affecting functions we bind (especially boolean operations, MeshGL64, CrossSection offset)

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,16 +48,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-20 lld-20 libc++-20-dev libc++abi-20-dev
 
-      # Separate cache namespace from CI's wasm32-uu lane so they don't fight,
-      # but key on the same files so they invalidate at the same times.
+      # Separate cache namespace from CI's wasm32-uu lane so they don't fight.
+      # Cache key splits the hash into two parts so the restore-keys prefix
+      # can include the "stable" inputs (build.rs + wasm32-uu/**). Those are
+      # the inputs that determine cmake's source-dir layout — if either
+      # changes, a restored target/ would have a CMakeCache.txt pointing at
+      # the old source dir and cmake refuses to reuse it. Same shape as the
+      # CI wasm32-uu lane's key. See ci.yml for the long-form explanation.
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-pages-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/wasm32-uu/**', 'crates/manifold-csg/build.rs') }}
-          restore-keys: ${{ runner.os }}-pages-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
+          key: ${{ runner.os }}-pages-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/wasm32-uu/**') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-pages-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/wasm32-uu/**') }}-
 
       - name: Build playground wasm
         run: bash crates/manifold-csg-playground/build.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,13 @@ The sys crate clones manifold3d (pinned to a specific commit on master, post-v3.
 - `Sync` is implemented for `Manifold` and `CrossSection` (upstream synchronizes lazy evaluation with a mutex). `MeshGL`/`MeshGL64` are also `Sync` (pure data, no lazy state)
 - `manifold_meshgl_merge` / `manifold_meshgl64_merge` had an upstream ownership bug (returning the input pointer on failure, causing double-free). This was fixed upstream in #1632 (included in our pinned commit).
 
+## Pin / shim follow-ups
+
+Things to revisit whenever the manifold pin moves OR `wasm-cxx-shim` cuts a new release:
+
+- **Re-evaluate wasm32-unknown-unknown cfg-gates.** Any FFI declaration / safe wrapper / test gated on `not(all(target_arch = "wasm32", target_os = "unknown"))` exists because that surface postdates the shim's tested manifold pin. When the shim's tested pin moves up to (or past) our host pin, those gates can be dropped and the surface unified across targets. Current gated surface: `manifold_ray_*` (ray casting), `manifold_*_obj` (OBJ I/O — gated for a different reason: iostream patches strip it). Grep for `target_os = "unknown"` to enumerate.
+- **Re-evaluate carry-patches.** For each patch in `crates/manifold-csg-sys/patches/` (if any), check whether it's merged upstream and included in the new pin; if so, delete it.
+
 ## Carry-patches
 
 `crates/manifold-csg-sys/patches/` (when present) holds patches applied to the cloned manifold3d source at build time via `git apply`. These fix upstream bugs or add features not yet in a tagged release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.4.105"
+version = "3.4.106"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/manifold-csg-sys/src/lib.rs
+++ b/crates/manifold-csg-sys/src/lib.rs
@@ -49,6 +49,10 @@ pub struct ManifoldSimplePolygon {
 }
 
 /// Opaque handle to a manifold3d `RayHitVec` (vector of ray hit results).
+///
+/// Unavailable on `wasm32-unknown-unknown` — that lane builds against the
+/// shim's tested manifold pin (v3.4.1), which predates ray casting.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[repr(C)]
 #[derive(Debug)]
 pub struct ManifoldRayHitVec {
@@ -159,6 +163,10 @@ pub struct ManifoldProperties {
 }
 
 /// Result of a ray-manifold intersection test.
+///
+/// Unavailable on `wasm32-unknown-unknown` — see [`ManifoldRayHitVec`] for
+/// the rationale.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct ManifoldRayHit {
@@ -268,6 +276,7 @@ unsafe extern "C" {
     pub fn manifold_box_size() -> usize;
     pub fn manifold_rect_size() -> usize;
     pub fn manifold_triangulation_size() -> usize;
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_ray_hit_vec_size() -> usize;
 
     // ── Allocation ─────────────────────────────────────────────────────
@@ -283,6 +292,7 @@ unsafe extern "C" {
     pub fn manifold_alloc_box() -> *mut ManifoldBox;
     pub fn manifold_alloc_rect() -> *mut ManifoldRect;
     pub fn manifold_alloc_triangulation() -> *mut ManifoldTriangulation;
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_alloc_ray_hit_vec() -> *mut ManifoldRayHitVec;
 
     // ── Destruction (destruct only, does not free) ─────────────────────
@@ -298,6 +308,7 @@ unsafe extern "C" {
     pub fn manifold_destruct_box(b: *mut ManifoldBox);
     pub fn manifold_destruct_rect(b: *mut ManifoldRect);
     pub fn manifold_destruct_triangulation(m: *mut ManifoldTriangulation);
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_destruct_ray_hit_vec(v: *mut ManifoldRayHitVec);
 
     // ── Deletion (destruct + free) ─────────────────────────────────────
@@ -313,6 +324,7 @@ unsafe extern "C" {
     pub fn manifold_delete_box(b: *mut ManifoldBox);
     pub fn manifold_delete_rect(b: *mut ManifoldRect);
     pub fn manifold_delete_triangulation(m: *mut ManifoldTriangulation);
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_delete_ray_hit_vec(v: *mut ManifoldRayHitVec);
 
     // ── Polygons ───────────────────────────────────────────────────────
@@ -1060,8 +1072,12 @@ unsafe extern "C" {
     ) -> *mut ManifoldManifold;
 
     // ── Ray casting ─────────────────────────────────────────────────────
+    //
+    // Postdates the manifold v3.4.1 pin the wasm32-uu lane builds against,
+    // so the whole ray-cast surface is cfg-elided on that target.
 
     /// Cast a ray from `origin` to `end` against a manifold, returning all hits.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_ray_cast(
         mem: *mut ManifoldRayHitVec,
         m: *const ManifoldManifold,
@@ -1074,9 +1090,11 @@ unsafe extern "C" {
     ) -> *mut ManifoldRayHitVec;
 
     /// Number of hits in a ray hit vector.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_ray_hit_vec_length(v: *const ManifoldRayHitVec) -> usize;
 
     /// Get a hit by index from a ray hit vector.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub fn manifold_ray_hit_vec_get(v: *const ManifoldRayHitVec, idx: usize) -> ManifoldRayHit;
 
     // ── Bounding box ────────────────────────────────────────────────────

--- a/crates/manifold-csg-sys/wasm32-uu/CMakeLists.txt
+++ b/crates/manifold-csg-sys/wasm32-uu/CMakeLists.txt
@@ -66,7 +66,11 @@ add_compile_options(
 )
 
 # FetchContent + patches + manifold/Clipper2 options + base compile flags.
-# Uses the helper's tested-pin defaults (manifold v3.4.1, Clipper2 matching SHA).
+# Uses the helper's tested-pin defaults (manifold v3.4.1, Clipper2 matching
+# SHA). The host build pins newer SHAs to pick up post-3.4.1 fixes; FFI
+# declarations and safe wrappers for any C API surface that postdates v3.4.1
+# (e.g., manifold_ray_cast) are cfg-gated off on this target so the wasm
+# produced here has no unresolved imports against the helper's pin.
 wasm_cxx_shim_add_manifold()
 
 # Force the manifold + Clipper2 archives to build by default. Without

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -19,7 +19,7 @@ nalgebra = ["dep:nalgebra"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.105", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.4.106", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -23,6 +23,7 @@ pub mod bounding_box;
 pub mod cross_section;
 pub mod manifold;
 pub mod mesh;
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub mod ray;
 pub mod rect;
 pub mod triangulation;
@@ -37,6 +38,7 @@ pub use manifold::{
 };
 pub use manifold_csg_sys::ManifoldOpType as OpType;
 pub use mesh::{MeshGL, MeshGL64};
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub use ray::RayHit;
 pub use rect::Rect;
 pub use triangulation::triangulate_polygons;

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -1231,6 +1231,10 @@ impl Manifold {
     /// The ray goes from `origin` to `end`. Returns a list of [`RayHit`](crate::RayHit)
     /// results, each containing the face ID, distance, hit position, and
     /// surface normal.
+    ///
+    /// Unavailable on `wasm32-unknown-unknown` — that lane builds against the
+    /// shim's tested manifold pin (v3.4.1), which predates ray casting.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     #[must_use]
     pub fn ray_cast(&self, origin: [f64; 3], end: [f64; 3]) -> Vec<crate::RayHit> {
         // SAFETY: manifold_alloc_ray_hit_vec returns a valid handle.

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -799,7 +799,11 @@ fn min_gap_between_separated_cubes() {
 }
 
 // ── Ray casting tests ──────────────────────────────────────────────
+//
+// `Manifold::ray_cast` is unavailable on `wasm32-unknown-unknown` (the shim's
+// tested manifold pin predates ray casting), so these tests are gated off.
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[test]
 fn ray_cast_through_cube() {
     // Cube from [0,0,0] to [10,10,10].
@@ -815,6 +819,7 @@ fn ray_cast_through_cube() {
     assert_relative_eq!(distances[1], 10.0, epsilon = 0.1);
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[test]
 fn ray_cast_miss() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, true);
@@ -823,6 +828,7 @@ fn ray_cast_miss() {
     assert!(hits.is_empty());
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 #[test]
 fn ray_cast_hit_has_normal() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);

--- a/crates/manifold3d-sys/Cargo.toml
+++ b/crates/manifold3d-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold3d-sys"
 description = "Raw FFI bindings to the manifold3d C API (facade crate — re-exports manifold-csg-sys)"
-version = "3.4.105"
+version = "3.4.106"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ parallel = ["manifold-csg-sys/parallel"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.4.105", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.4.106", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["parallel"]

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -16,7 +16,7 @@ nalgebra = ["manifold-csg/nalgebra"]
 unstable-wasm-uu = ["manifold-csg/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg = { path = "../manifold-csg", version = "=0.1.6", default-features = false }
+manifold-csg = { path = "../manifold-csg", version = "=0.1.7", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]


### PR DESCRIPTION
## Summary

Two regressions surfaced after #38 landed and 0.1.6 / 3.4.105 was published. This is the hotfix release (0.1.7 / 3.4.106).

### 1. wasm32-unknown-unknown wasm has unresolved imports

The shim's helper defaults to its tested manifold pin (v3.4.1). Our host pin moved past v3.4.1 to upstream main HEAD (\`5f95a3a\`) in #38, which added the ray_cast C API. Our FFI declarations matched the host pin, so the wasm-uu link emitted unresolved imports for \`manifold_ray_cast\`, \`manifold_alloc_ray_hit_vec\`, \`manifold_ray_hit_vec_length\`, \`manifold_ray_hit_vec_get\`, \`manifold_delete_ray_hit_vec\`. The "Verify zero imports" CI check correctly flagged this on the post-merge main run, but the same check passed on #38 itself because a stale cached library archive (from before the helper switch) was masking the divergence.

**Fix**: cfg-gate the entire ray-cast surface on \`all(target_arch = "wasm32", target_os = "unknown")\`. Same pattern as the existing OBJ I/O gating.
- Sys-side: the two FFI types (\`ManifoldRayHitVec\`, \`ManifoldRayHit\`) and the seven \`manifold_ray_*\` extern fn declarations.
- Safe-side: the \`ray_cast\` method on \`Manifold\`.
- Tests: the three \`ray_cast_*\` integration tests.

Result: wasm-uu lane now produces a wasm with no Import section (verified locally with \`wasm-objdump\`).

**Why not bump the wasm-uu pin to match host?** Tried it. The helper's iostream patch is generated against v3.4.1 and doesn't apply against the host's newer SHA. Restoring our own carry-patches against the newer pin would undo the simplification just done in #38. Cfg-gating is the right tradeoff: small surface impact, no new patches to carry. We can drop the gate when the shim's tested pin moves past the new APIs.

### 2. Pages workflow cache key has the same footgun the CI wasm32-uu lane just got fixed for

#38 fixed the CI lane's \`restore-keys\` prefix to include the layout-affecting inputs (\`build.rs\` + \`wasm32-uu/**\`), but the Pages workflow has its own separate cache stanza that didn't get the same fix. Mirroring the fix into \`pages.yml\`.

## Versions (hotfix release)

| Crate | From (broken) | To |
|---|---|---|
| \`manifold-csg-sys\` | 3.4.105 | 3.4.106 |
| \`manifold-csg\` | 0.1.6 | 0.1.7 |
| \`manifold3d-sys\` (lockstep \`=\` pin) | 3.4.105 | 3.4.106 |
| \`manifold3d\` (lockstep \`=\` pin) | 0.1.6 | 0.1.7 |

## Note on the broken release

0.1.6 / 3.4.105 is technically broken on \`wasm32-unknown-unknown\` (anyone who built with \`--features unstable-wasm-uu\` would hit the unresolved-imports issue). Not yanking — the host build is fine, and the wasm-uu surface is provisional / opt-in / new. 0.1.7 ships the fix.

## Test plan

- [x] Local: 214 host integration tests pass (3 \`ray_cast_*\` tests still run since they're only gated on wasm-uu)
- [x] Local: \`cargo build --target wasm32-unknown-unknown -p manifold-csg --no-default-features --features unstable-wasm-uu --tests --examples\` clean
- [x] Local: \`wasm-objdump -x -j Import\` on the produced wasm reports "Section not found" — no unresolved imports
- [x] Local: \`cargo fmt --all --check\` and \`cargo clippy --all-targets --features nalgebra -- -D warnings\` clean
- [ ] CI: all 11 required lanes green (newly enforced via branch protection)
- [ ] CI: \`cargo-semver-checks\` confirms 0.1.6 → 0.1.7 (additive — ray_cast already public on host) and 3.4.105 → 3.4.106
- [ ] CI: Pages workflow republishes the demo with no cmake cache failure