### PR TITLE
Add ExecutionContext: cancellation + progress for boolean evaluation

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -90,6 +90,7 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 | `manifold_original_id` | [`Manifold::original_id`](crates/manifold-csg/src/manifold.rs#L934) |
 | `manifold_min_gap` | [`Manifold::min_gap`](crates/manifold-csg/src/manifold.rs#L941) |
 | `manifold_status` | Internal |
+| `manifold_status_with_context` | [`Manifold::status_with_context`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_as_original` | [`Manifold::as_original`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_manifold_size` | Not needed (alloc size) |
 | `manifold_manifold_pair_size` | Not needed (alloc size) |
@@ -330,6 +331,16 @@ Used internally by batch operations, decompose, etc.
 | `manifold_cross_section_vec_set` | Not used |
 | `manifold_cross_section_vec_size` | Not used |
 
+## Execution Context (cancellation + progress)
+
+| C API function | Safe wrapper |
+|---|---|
+| `manifold_execution_context` | [`ExecutionContext::new`](crates/manifold-csg/src/execution.rs) |
+| `manifold_execution_context_cancel` | [`ExecutionContext::cancel`](crates/manifold-csg/src/execution.rs) |
+| `manifold_execution_context_cancelled` | [`ExecutionContext::is_cancelled`](crates/manifold-csg/src/execution.rs) |
+| `manifold_execution_context_progress` | [`ExecutionContext::progress`](crates/manifold-csg/src/execution.rs) |
+| `manifold_execution_context_size` | Not needed (alloc size) |
+
 ## Allocation & Deallocation (Internal)
 
 Every `manifold_alloc_*` and `manifold_delete_*`/`manifold_destruct_*` function
@@ -338,9 +349,9 @@ and `Drop` implementations.
 
 | Function group | Count |
 |---|---|
-| `manifold_alloc_*` | 12 |
-| `manifold_delete_*` | 12 |
-| `manifold_destruct_*` | 12 |
+| `manifold_alloc_*` | 13 |
+| `manifold_delete_*` | 13 |
+| `manifold_destruct_*` | 13 |
 
 ---
 

--- a/crates/manifold-csg-sys/src/lib.rs
+++ b/crates/manifold-csg-sys/src/lib.rs
@@ -55,6 +55,15 @@ pub struct ManifoldRayHitVec {
     _private: [u8; 0],
 }
 
+/// Opaque handle to a manifold3d `ExecutionContext` — observes progress
+/// and allows cooperative cancellation of long-running boolean evaluations.
+/// The C API documents it as safe to read/write from any thread.
+#[repr(C)]
+#[derive(Debug)]
+pub struct ManifoldExecutionContext {
+    _private: [u8; 0],
+}
+
 /// Opaque handle to a manifold3d `Triangulation` result.
 #[repr(C)]
 #[derive(Debug)]
@@ -269,6 +278,7 @@ unsafe extern "C" {
     pub fn manifold_rect_size() -> usize;
     pub fn manifold_triangulation_size() -> usize;
     pub fn manifold_ray_hit_vec_size() -> usize;
+    pub fn manifold_execution_context_size() -> usize;
 
     // ── Allocation ─────────────────────────────────────────────────────
 
@@ -284,6 +294,7 @@ unsafe extern "C" {
     pub fn manifold_alloc_rect() -> *mut ManifoldRect;
     pub fn manifold_alloc_triangulation() -> *mut ManifoldTriangulation;
     pub fn manifold_alloc_ray_hit_vec() -> *mut ManifoldRayHitVec;
+    pub fn manifold_alloc_execution_context() -> *mut ManifoldExecutionContext;
 
     // ── Destruction (destruct only, does not free) ─────────────────────
 
@@ -299,6 +310,7 @@ unsafe extern "C" {
     pub fn manifold_destruct_rect(b: *mut ManifoldRect);
     pub fn manifold_destruct_triangulation(m: *mut ManifoldTriangulation);
     pub fn manifold_destruct_ray_hit_vec(v: *mut ManifoldRayHitVec);
+    pub fn manifold_destruct_execution_context(ctx: *mut ManifoldExecutionContext);
 
     // ── Deletion (destruct + free) ─────────────────────────────────────
 
@@ -314,6 +326,7 @@ unsafe extern "C" {
     pub fn manifold_delete_rect(b: *mut ManifoldRect);
     pub fn manifold_delete_triangulation(m: *mut ManifoldTriangulation);
     pub fn manifold_delete_ray_hit_vec(v: *mut ManifoldRayHitVec);
+    pub fn manifold_delete_execution_context(ctx: *mut ManifoldExecutionContext);
 
     // ── Polygons ───────────────────────────────────────────────────────
 
@@ -1005,6 +1018,12 @@ unsafe extern "C" {
 
     pub fn manifold_is_empty(m: *const ManifoldManifold) -> c_int;
     pub fn manifold_status(m: *const ManifoldManifold) -> ManifoldError;
+    /// Variant of [`manifold_status`] that observes progress and allows
+    /// cancellation via the [`ManifoldExecutionContext`].
+    pub fn manifold_status_with_context(
+        m: *const ManifoldManifold,
+        ctx: *mut ManifoldExecutionContext,
+    ) -> ManifoldError;
     pub fn manifold_num_vert(m: *const ManifoldManifold) -> usize;
     pub fn manifold_num_edge(m: *const ManifoldManifold) -> usize;
     pub fn manifold_num_tri(m: *const ManifoldManifold) -> usize;
@@ -1078,6 +1097,24 @@ unsafe extern "C" {
 
     /// Get a hit by index from a ray hit vector.
     pub fn manifold_ray_hit_vec_get(v: *const ManifoldRayHitVec, idx: usize) -> ManifoldRayHit;
+
+    // ── Execution context (cancel + progress) ───────────────────────────
+
+    /// Construct an `ExecutionContext` in pre-allocated memory. Pass to
+    /// [`manifold_status_with_context`].
+    pub fn manifold_execution_context(
+        mem: *mut ManifoldExecutionContext,
+    ) -> *mut ManifoldExecutionContext;
+
+    /// Request cancellation of any boolean evaluation observing this context.
+    /// Sticky: once cancelled, the context stays cancelled.
+    pub fn manifold_execution_context_cancel(ctx: *mut ManifoldExecutionContext);
+
+    /// Returns nonzero if the context has been cancelled.
+    pub fn manifold_execution_context_cancelled(ctx: *mut ManifoldExecutionContext) -> c_int;
+
+    /// Progress in [0.0, 1.0] for an in-flight evaluation observing this context.
+    pub fn manifold_execution_context_progress(ctx: *mut ManifoldExecutionContext) -> f64;
 
     // ── Bounding box ────────────────────────────────────────────────────
 

--- a/crates/manifold-csg/src/execution.rs
+++ b/crates/manifold-csg/src/execution.rs
@@ -1,0 +1,123 @@
+//! Cooperative cancellation + progress observation for long-running boolean evaluations.
+//!
+//! Manifold operations are lazy: building a CSG tree is cheap, and the
+//! actual evaluation happens when you query results (e.g., via
+//! [`Manifold::status_with_context`](crate::Manifold::status_with_context),
+//! `num_tri`, mesh extraction, etc.). An [`ExecutionContext`] lets you
+//! observe an in-flight evaluation from another thread and ask it to stop
+//! early.
+//!
+//! Cancellation is **sticky** (once cancelled, stays cancelled) and granular
+//! per-boolean (the upstream kernel checks the cancel flag at boolean
+//! boundaries; it doesn't interrupt a single boolean mid-flight). Progress
+//! is reported as a fraction in `[0.0, 1.0]`.
+//!
+//! The C API documents the underlying `ExecutionContext` as safe to read
+//! and write from any thread, so [`ExecutionContext`] is `Send` + `Sync`
+//! and can be wrapped in [`Arc`](std::sync::Arc) to share between the
+//! evaluator thread and a controller/observer thread.
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use std::thread;
+//! use std::time::Duration;
+//! use manifold_csg::{ExecutionContext, Manifold};
+//!
+//! let ctx = Arc::new(ExecutionContext::new());
+//! let cancel = Arc::clone(&ctx);
+//!
+//! // Cancel the evaluation if it takes longer than 100ms.
+//! thread::spawn(move || {
+//!     thread::sleep(Duration::from_millis(100));
+//!     cancel.cancel();
+//! });
+//!
+//! let result = Manifold::cube(1.0, 1.0, 1.0, true);
+//! let status = result.status_with_context(&ctx);
+//! // `status` will be `NoError` for trivial work that finishes before
+//! // cancel fires; for a heavy boolean tree it would surface cancellation.
+//! # let _ = status;
+//! ```
+//!
+//! Available since manifold3d's `5f95a3a` master commit (post-v3.4.1).
+
+use manifold_csg_sys::{
+    ManifoldExecutionContext, manifold_alloc_execution_context, manifold_delete_execution_context,
+    manifold_execution_context, manifold_execution_context_cancel,
+    manifold_execution_context_cancelled, manifold_execution_context_progress,
+};
+
+/// Observes progress and allows cooperative cancellation of long-running
+/// boolean evaluations. See the [module docs](self) for usage.
+pub struct ExecutionContext {
+    ptr: *mut ManifoldExecutionContext,
+}
+
+// SAFETY: The C API explicitly documents `ExecutionContext` as safe to
+// read/write from any thread; the upstream C++ implementation
+// synchronizes the cancel flag and progress counter internally.
+unsafe impl Send for ExecutionContext {}
+// SAFETY: Same justification as `Send` — all accessors (`cancel`,
+// `cancelled`, `progress`) are documented thread-safe at the C boundary.
+unsafe impl Sync for ExecutionContext {}
+
+impl ExecutionContext {
+    /// Create a fresh, un-cancelled context with zero progress.
+    #[must_use]
+    pub fn new() -> Self {
+        // SAFETY: alloc returns a valid handle; the constructor takes that
+        // raw memory and constructs an ExecutionContext into it (returning
+        // the same pointer).
+        let mem = unsafe { manifold_alloc_execution_context() };
+        // SAFETY: mem is a valid, freshly-allocated handle.
+        let ptr = unsafe { manifold_execution_context(mem) };
+        Self { ptr }
+    }
+
+    /// Request cancellation of any in-flight evaluation observing this
+    /// context. Sticky: once called, [`is_cancelled`](Self::is_cancelled)
+    /// returns `true` for the rest of the context's lifetime.
+    pub fn cancel(&self) {
+        // SAFETY: self.ptr is a valid handle for the lifetime of self;
+        // upstream documents thread-safe access.
+        unsafe { manifold_execution_context_cancel(self.ptr) };
+    }
+
+    /// Returns `true` if [`cancel`](Self::cancel) has been called.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        // SAFETY: self.ptr is a valid handle; upstream documents thread-safe access.
+        unsafe { manifold_execution_context_cancelled(self.ptr) != 0 }
+    }
+
+    /// Progress of an in-flight evaluation as a fraction in `[0.0, 1.0]`.
+    /// Reads `0.0` before any evaluation has started and `1.0` after one
+    /// has finished.
+    #[must_use]
+    pub fn progress(&self) -> f64 {
+        // SAFETY: self.ptr is a valid handle; upstream documents thread-safe access.
+        unsafe { manifold_execution_context_progress(self.ptr) }
+    }
+
+    /// Raw pointer for FFI calls that take an `ExecutionContext`. Crate-local
+    /// so the safe wrapper retains exclusive control of the lifetime.
+    pub(crate) fn as_ptr(&self) -> *mut ManifoldExecutionContext {
+        self.ptr
+    }
+}
+
+impl Default for ExecutionContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for ExecutionContext {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            // SAFETY: ptr was returned by alloc + construct; not freed since.
+            unsafe { manifold_delete_execution_context(self.ptr) };
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod bounding_box;
 pub mod cross_section;
+pub mod execution;
 pub mod manifold;
 pub mod mesh;
 pub mod ray;
@@ -30,6 +31,7 @@ pub mod types;
 
 pub use bounding_box::BoundingBox;
 pub use cross_section::{CrossSection, FillRule, JoinType, Rect2};
+pub use execution::ExecutionContext;
 pub use manifold::Manifold;
 pub use manifold::{
     get_circular_segments, reserve_ids, reset_to_circular_defaults, set_circular_segments,

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -1224,6 +1224,36 @@ impl Manifold {
         unsafe { manifold_min_gap(self.ptr, other.ptr, search_length) }
     }
 
+    // ── Cancellable evaluation ──────────────────────────────────────
+
+    /// Force evaluation of this manifold's lazy CSG tree under a cancellable
+    /// [`ExecutionContext`](crate::ExecutionContext), returning the result
+    /// status.
+    ///
+    /// Manifold operations are lazy: building a CSG tree is cheap and
+    /// synchronous; the actual evaluation happens when something queries
+    /// the result. Calling this method triggers that evaluation while
+    /// observing `ctx` — if `ctx` is cancelled (typically from another
+    /// thread), the evaluation aborts at the next boolean boundary and
+    /// returns a cancellation status. See the [`execution`](crate::execution)
+    /// module docs for the full pattern.
+    ///
+    /// Equivalent to upstream's `manifold_status_with_context`.
+    ///
+    /// Concurrent calls on the same `Manifold` with different contexts are
+    /// permitted (`Manifold: Sync`); upstream synchronizes the lazy-eval
+    /// cache. Each context observes its own progress and cancel state.
+    #[must_use]
+    pub fn status_with_context(
+        &self,
+        ctx: &crate::ExecutionContext,
+    ) -> manifold_csg_sys::ManifoldError {
+        // SAFETY: self.ptr is a valid handle; ctx.as_ptr() is valid for
+        // the lifetime of `ctx`. Upstream documents thread-safe access to
+        // the context, so concurrent cancel from another thread is fine.
+        unsafe { manifold_status_with_context(self.ptr, ctx.as_ptr()) }
+    }
+
     // ── Ray casting ─────────────────────────────────────────────────
 
     /// Cast a ray against this manifold, returning all intersection hits.

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -2277,3 +2277,67 @@ fn wasm_smoke_memory_growth_path() {
     // 4/3 * pi * r^3 = 33.51 per sphere, * 30 ≈ 1005, allow some slack.
     assert!(combined.volume() > 800.0);
 }
+
+// ── ExecutionContext tests ──────────────────────────────────────────
+
+#[test]
+fn execution_context_initial_state() {
+    let ctx = manifold_csg::ExecutionContext::new();
+    assert!(!ctx.is_cancelled());
+    assert_eq!(ctx.progress(), 0.0);
+}
+
+#[test]
+fn execution_context_cancel_is_sticky() {
+    let ctx = manifold_csg::ExecutionContext::new();
+    assert!(!ctx.is_cancelled());
+    ctx.cancel();
+    assert!(ctx.is_cancelled());
+    // Sticky: still cancelled on subsequent reads.
+    assert!(ctx.is_cancelled());
+}
+
+#[test]
+#[cfg_attr(
+    target_os = "emscripten",
+    ignore = "default build has no pthreads (-pthread requires SharedArrayBuffer + COOP/COEP from host)"
+)]
+fn execution_context_cross_thread_cancel() {
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    let ctx = Arc::new(manifold_csg::ExecutionContext::new());
+    let cancel = Arc::clone(&ctx);
+
+    let handle = thread::spawn(move || {
+        // Trivially small sleep — we just want to prove cancel from another
+        // thread becomes visible to the original via shared upstream state.
+        thread::sleep(Duration::from_millis(5));
+        cancel.cancel();
+    });
+
+    handle.join().unwrap();
+    assert!(ctx.is_cancelled());
+}
+
+#[test]
+fn manifold_status_with_context_no_cancel() {
+    use manifold_csg_sys::ManifoldError;
+    let cube = Manifold::cube(1.0, 1.0, 1.0, true);
+    let ctx = manifold_csg::ExecutionContext::new();
+    // Trivial Manifold; evaluation finishes immediately.
+    assert_eq!(cube.status_with_context(&ctx), ManifoldError::NoError);
+}
+
+#[test]
+fn manifold_status_with_context_already_cancelled() {
+    let cube = Manifold::cube(1.0, 1.0, 1.0, true);
+    let ctx = manifold_csg::ExecutionContext::new();
+    ctx.cancel();
+    // We don't assert on the specific status code — upstream may surface
+    // cancellation as NoError for trivial work that doesn't poll the flag,
+    // or as a specific cancellation status. We just want to prove the call
+    // is well-formed and doesn't panic / leak / crash.
+    let _ = cube.status_with_context(&ctx);
+}


### PR DESCRIPTION
Binds upstream's \`ManifoldExecutionContext\` (added post-v3.4.1, available on wasm-uu since shim v0.4.0-alpha.1 in #40). Lets another thread cancel a long-running boolean evaluation or observe its progress.

**Surface** (manifold-csg): \`ExecutionContext::{new, cancel, is_cancelled, progress}\` (\`Send + Sync\` per upstream's "safe to read/write from any thread" guarantee) + \`Manifold::status_with_context(&ExecutionContext)\` to trigger cancellable evaluation. \`API_COVERAGE.md\` updated.

Re upstream #1674 (within-phase cancel refactor): zero \`bindings/c/\` files touched, so our bindings stay accurate.

Versions stay at 0.1.8 / 3.4.107 (additive on top of #40's pre-bump).

## Test plan

- [x] 219 host tests pass (was 214; +5 new)
- [x] wasm-uu build clean, produced wasm has zero unexpected imports
- [x] fmt + clippy clean
- [ ] CI green