### PR TITLE
Add Menger sponge sample + wire into playground; optimize wasm

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,8 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
-          sudo apt-get install -y clang-20 lld-20 libc++-20-dev libc++abi-20-dev
+          # binaryen ships wasm-opt, which build.sh runs post-cargo for ~20% smaller artifacts.
+          sudo apt-get install -y clang-20 lld-20 libc++-20-dev libc++abi-20-dev binaryen
 
       # Separate cache namespace from CI's wasm32-uu lane so they don't fight.
       # Cache key splits the hash into two parts so the restore-keys prefix

--- a/crates/manifold-csg-playground/build.sh
+++ b/crates/manifold-csg-playground/build.sh
@@ -5,6 +5,12 @@
 #   - rustup target add wasm32-unknown-unknown
 #   - LLVM 20+ on PATH or via WASM_CXX_SHIM_LLVM_BIN_DIR
 #
+# Optional:
+#   - wasm-opt (binaryen) for ~20% smaller artifacts. `brew install
+#     binaryen` or `apt install binaryen`. The Pages workflow installs
+#     it; local devs without it get a slightly larger wasm but the
+#     same functionality.
+#
 # See ../../docs/plans/wasm-unknown-unknown.md and the README.md "Browser
 # without Emscripten" section for the toolchain setup details.
 
@@ -19,5 +25,12 @@ cargo build --target wasm32-unknown-unknown --release -p manifold-csg-playground
 WASM="$WORKSPACE_ROOT/target/wasm32-unknown-unknown/release/manifold_csg_playground.wasm"
 DEST="$SCRIPT_DIR/web/manifold_csg_playground.wasm"
 
-cp "$WASM" "$DEST"
-echo "wrote $DEST ($(wc -c < "$DEST") bytes)"
+if command -v wasm-opt >/dev/null 2>&1; then
+    BEFORE=$(wc -c < "$WASM")
+    wasm-opt -Oz "$WASM" -o "$DEST"
+    AFTER=$(wc -c < "$DEST")
+    echo "wrote $DEST ($BEFORE → $AFTER bytes, $(( (BEFORE - AFTER) * 100 / BEFORE ))% smaller via wasm-opt -Oz)"
+else
+    cp "$WASM" "$DEST"
+    echo "wrote $DEST ($(wc -c < "$DEST") bytes — install binaryen for ~20% smaller artifact)"
+fi

--- a/crates/manifold-csg-playground/src/lib.rs
+++ b/crates/manifold-csg-playground/src/lib.rs
@@ -2,7 +2,7 @@
 //! frontend (three.js).
 //!
 //! The state is two primitive "slots" plus a boolean op selector. Each slot
-//! has a kind (cube/sphere/cylinder), shape parameters, and a 4x3 affine
+//! has a kind (cube/sphere/cylinder/menger), shape parameters, and a 4x3 affine
 //! transform pushed in from the JS gizmo. `rebuild()` runs the boolean and
 //! caches the resulting f32 vertex positions + u32 triangle indices in
 //! globally-owned `Vec`s; the frontend reads them via raw pointer + length
@@ -42,6 +42,13 @@ impl Slot {
                 let segs = (self.params[2] as i32).max(8);
                 Manifold::cylinder(self.params[0], self.params[1], self.params[1], segs, true)
             }
+            3 => {
+                // Menger sponge — recursion depth in p0. Clamp to [0, 4]:
+                // upstream warns level 4 already produces ~400k triangles,
+                // and the demo wants to stay interactive.
+                let level = (self.params[0] as i32).clamp(0, 4) as u32;
+                manifold_csg::samples::menger_sponge(level)
+            }
             _ => Manifold::empty(),
         };
         prim.transform(&self.transform)
@@ -59,21 +66,25 @@ struct State {
 fn state() -> &'static Mutex<State> {
     static STATE: OnceLock<Mutex<State>> = OnceLock::new();
     STATE.get_or_init(|| {
+        // Default scene: Menger sponge ∩ sphere, halfway overlapping. Picks
+        // a fast-evaluating boolean that obviously isn't either input shape,
+        // so visitors landing on the demo immediately see "this is doing CSG"
+        // rather than "this is just a cube".
         let mut b_xform = IDENTITY_4X3;
-        b_xform[9] = 0.7; // translate B by +0.7 on X so default scene is non-empty
+        b_xform[9] = 0.5; // sphere center on the menger's +X face
 
         Mutex::new(State {
             a: Slot {
-                kind: 0,
-                params: [1.0, 1.0, 1.0, 0.0],
+                kind: 3,                      // menger sponge
+                params: [2.0, 0.0, 0.0, 0.0], // recursion depth 2
                 transform: IDENTITY_4X3,
             },
             b: Slot {
-                kind: 0,
-                params: [1.0, 1.0, 1.0, 0.0],
+                kind: 1,                       // sphere
+                params: [0.7, 32.0, 0.0, 0.0], // radius, segments
                 transform: b_xform,
             },
-            op: 0,
+            op: 2, // intersection
             last_positions: Vec::new(),
             last_indices: Vec::new(),
         })
@@ -122,12 +133,13 @@ fn slot_mut(s: &mut State, slot: i32) -> &mut Slot {
 }
 
 /// Set primitive kind + parameters for a slot. `slot` is 0 (A) or 1 (B).
-/// `kind` is 0=cube, 1=sphere, 2=cylinder. The four `p*` parameters are
-/// shape-specific:
+/// `kind` is 0=cube, 1=sphere, 2=cylinder, 3=menger. The four `p*`
+/// parameters are shape-specific:
 ///
 /// - cube: `(x, y, z, _)`
 /// - sphere: `(radius, segments, _, _)`
 /// - cylinder: `(height, radius, segments, _)`
+/// - menger: `(level, _, _, _)` — recursion depth, clamped to [0, 4]
 ///
 /// Panics if `slot` is not 0 or 1. (Panics in this crate abort the wasm
 /// instance; the JS frontend is expected to pass valid values.)

--- a/crates/manifold-csg-playground/tests/wasm.test.mjs
+++ b/crates/manifold-csg-playground/tests/wasm.test.mjs
@@ -13,6 +13,7 @@ import { loadWasm } from './load_wasm.mjs';
 const KIND_CUBE = 0;
 const KIND_SPHERE = 1;
 const KIND_CYLINDER = 2;
+const KIND_MENGER = 3;
 
 const OP_UNION = 0;
 const OP_DIFFERENCE = 1;
@@ -39,9 +40,10 @@ function pushTransform(wasm, scratchPtr, slot, m12) {
 }
 
 // Set up a fresh wasm instance with two unit cubes (B translated +0.7 X)
-// and union op. Returns { wasm, scratchPtr } that match the browser's
-// initial scene.
-async function defaultScene() {
+// and union op. This is the tests' canonical "known-non-empty" baseline,
+// NOT the wasm-side initial state (which the demo's first impression sets
+// to Menger ∩ Sphere — see `wasm_default_scene_menger_intersect_sphere`).
+async function twoUnitCubesScene() {
     const wasm = await loadWasm();
     const scratchPtr = wasm.alloc(96);
     wasm.set_op(OP_UNION);
@@ -89,15 +91,25 @@ test('alloc/dealloc returns non-null aligned pointer', async () => {
     wasm.dealloc(p, 96);
 });
 
-test('default scene: two unit cubes overlapping → union has > 0 triangles', async () => {
-    const { wasm } = await defaultScene();
+test('two unit cubes overlapping → union has > 0 triangles', async () => {
+    const { wasm } = await twoUnitCubesScene();
     const triCount = wasm.rebuild();
     assert.ok(triCount > 0, `expected non-empty union, got ${triCount}`);
     assertResultConsistent(wasm, triCount, 'default-union');
 });
 
+test('wasm default scene (Menger ∩ Sphere) produces a non-empty result', async () => {
+    // The wasm crate's State::default sets up Menger ∩ Sphere at half-overlap.
+    // No setup calls — just load and rebuild straight from the initial state.
+    // This is what a fresh page load runs before any JS interaction.
+    const wasm = await loadWasm();
+    const triCount = wasm.rebuild();
+    assert.ok(triCount > 0, `expected non-empty Menger ∩ Sphere, got ${triCount}`);
+    assertResultConsistent(wasm, triCount, 'menger-intersect-sphere-default');
+});
+
 test('union vs intersection vs difference produce different triangle counts', async () => {
-    const { wasm } = await defaultScene();
+    const { wasm } = await twoUnitCubesScene();
     wasm.set_op(OP_UNION);
     const u = wasm.rebuild();
     wasm.set_op(OP_INTERSECTION);
@@ -110,7 +122,7 @@ test('union vs intersection vs difference produce different triangle counts', as
 });
 
 test('disjoint operands: intersection is empty, union is non-empty', async () => {
-    const { wasm, scratchPtr } = await defaultScene();
+    const { wasm, scratchPtr } = await twoUnitCubesScene();
     pushTransform(wasm, scratchPtr, 1, TRANSLATE_X(10.0)); // far apart
     wasm.set_op(OP_INTERSECTION);
     assert.equal(wasm.rebuild(), 0, 'disjoint cubes have empty intersection');
@@ -122,11 +134,15 @@ test('disjoint operands: intersection is empty, union is non-empty', async () =>
 });
 
 test('rebuild result is internally consistent across primitive switches', async () => {
-    const { wasm } = await defaultScene();
+    const { wasm } = await twoUnitCubesScene();
     const cases = [
         { a: KIND_CUBE,     b: KIND_SPHERE,   ap: [1, 1, 1, 0],     bp: [0.7, 32, 0, 0] },
         { a: KIND_SPHERE,   b: KIND_CYLINDER, ap: [0.7, 32, 0, 0],  bp: [1, 0.5, 32, 0] },
         { a: KIND_CYLINDER, b: KIND_CUBE,     ap: [1, 0.5, 32, 0],  bp: [1, 1, 1, 0] },
+        // Menger sponge level 1 (small): exercises samples::menger_sponge
+        // through the C ABI so we'd notice an integration regression even
+        // without driving the JS frontend.
+        { a: KIND_MENGER,   b: KIND_CUBE,     ap: [1, 0, 0, 0],     bp: [0.5, 0.5, 0.5, 0] },
     ];
     for (const { a, b, ap, bp } of cases) {
         wasm.set_primitive(0, a, ...ap);
@@ -142,7 +158,7 @@ test('repeated rebuilds with growing/shrinking results stay consistent', async (
     // computeVertexNormals reuse bug in main.js — vertex count fluctuates
     // across rebuilds. The wasm side's job is to keep its own outputs
     // self-consistent; the JS test (rebuild.test.mjs) covers the JS bug.
-    const { wasm, scratchPtr } = await defaultScene();
+    const { wasm, scratchPtr } = await twoUnitCubesScene();
     for (const x of [0.1, 0.4, 0.7, 1.2, 0.3, 0.9, 0.05, 0.6]) {
         pushTransform(wasm, scratchPtr, 1, TRANSLATE_X(x));
         const triCount = wasm.rebuild();
@@ -151,7 +167,7 @@ test('repeated rebuilds with growing/shrinking results stay consistent', async (
 });
 
 test('result pointers are stable across reads but invalidated by next rebuild', async () => {
-    const { wasm } = await defaultScene();
+    const { wasm } = await twoUnitCubesScene();
     wasm.rebuild();
     const p1 = wasm.positions_ptr();
     const p2 = wasm.positions_ptr();

--- a/crates/manifold-csg-playground/web/index.html
+++ b/crates/manifold-csg-playground/web/index.html
@@ -110,14 +110,16 @@
                 <option value="0">Cube</option>
                 <option value="1">Sphere</option>
                 <option value="2">Cylinder</option>
+                <option value="3" selected>Menger Sponge</option>
             </select>
         </label>
 
         <label>Primitive B
             <select id="kind-b">
                 <option value="0">Cube</option>
-                <option value="1">Sphere</option>
+                <option value="1" selected>Sphere</option>
                 <option value="2">Cylinder</option>
+                <option value="3">Menger Sponge</option>
             </select>
         </label>
 
@@ -125,7 +127,7 @@
             <select id="op">
                 <option value="0">Union (A + B)</option>
                 <option value="1">Difference (A − B)</option>
-                <option value="2">Intersection (A ∩ B)</option>
+                <option value="2" selected>Intersection (A ∩ B)</option>
             </select>
         </label>
 

--- a/crates/manifold-csg-playground/web/main.js
+++ b/crates/manifold-csg-playground/web/main.js
@@ -17,8 +17,8 @@ import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
 import {
-    KIND_CUBE, KIND_SPHERE, KIND_CYLINDER,
-    OP_UNION,
+    KIND_CUBE, KIND_SPHERE, KIND_CYLINDER, KIND_MENGER,
+    OP_INTERSECTION,
     pushTransform as pushTransformImpl,
     setPrimitive as setPrimitiveImpl,
     rebuildIntoMesh,
@@ -96,6 +96,10 @@ function makeProxyGeometry(kind) {
             g.rotateX(Math.PI / 2);
             return g;
         }
+        // Menger sponge occupies the same unit-cube bounding box as a cube;
+        // a wireframe box is sufficient for gizmo manipulation. The actual
+        // fractal is rendered from the wasm-side rebuild() output.
+        case KIND_MENGER:   return new THREE.BoxGeometry(1.0, 1.0, 1.0);
     }
     return new THREE.BoxGeometry(1, 1, 1);
 }
@@ -130,8 +134,8 @@ function makeSlot(slotIdx, initialKind, initialPos) {
     return proxy;
 }
 
-const slotA = makeSlot(0, KIND_CUBE, new THREE.Vector3(0, 0, 0));
-const slotB = makeSlot(1, KIND_CUBE, new THREE.Vector3(0.7, 0, 0));
+const slotA = makeSlot(0, KIND_MENGER, new THREE.Vector3(0, 0, 0));
+const slotB = makeSlot(1, KIND_SPHERE, new THREE.Vector3(0.5, 0, 0));
 const slots = [slotA, slotB];
 
 // ── Result mesh ───────────────────────────────────────────────────────
@@ -237,9 +241,9 @@ document.getElementById('op').addEventListener('change', (e) => {
 
 // ── Initial sync (wasm has its own defaults; mirror them) ─────────────
 
-wasm.set_op(OP_UNION);
-setPrimitive(0, KIND_CUBE);
-setPrimitive(1, KIND_CUBE);
+wasm.set_op(OP_INTERSECTION);
+setPrimitive(0, KIND_MENGER);
+setPrimitive(1, KIND_SPHERE);
 slots[0].updateMatrix();
 slots[1].updateMatrix();
 pushTransform(0, slots[0].matrix);

--- a/crates/manifold-csg-playground/web/rebuild.js
+++ b/crates/manifold-csg-playground/web/rebuild.js
@@ -8,6 +8,7 @@
 export const KIND_CUBE = 0;
 export const KIND_SPHERE = 1;
 export const KIND_CYLINDER = 2;
+export const KIND_MENGER = 3;
 
 export const OP_UNION = 0;
 export const OP_DIFFERENCE = 1;
@@ -17,6 +18,10 @@ export const DEFAULT_PARAMS = {
     [KIND_CUBE]:     [1.0, 1.0, 1.0, 0.0],
     [KIND_SPHERE]:   [0.7, 32.0, 0.0, 0.0],
     [KIND_CYLINDER]: [1.0, 0.5, 32.0, 0.0],
+    // Menger sponge: p0 = recursion depth (clamped 0..=4 by the wasm side).
+    // Level 2 = ~2k tris (instant); level 3 = ~30k (still snappy);
+    // level 4 = ~400k (wasm-uu single-threaded gets sluggish). Default to 2.
+    [KIND_MENGER]:   [2.0, 0.0, 0.0, 0.0],
 };
 
 // Copy a THREE.Matrix4 (column-major, length 16) into the wasm scratch

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -26,6 +26,7 @@ pub mod manifold;
 pub mod mesh;
 pub mod ray;
 pub mod rect;
+pub mod samples;
 pub mod triangulation;
 pub mod types;
 

--- a/crates/manifold-csg/src/samples.rs
+++ b/crates/manifold-csg/src/samples.rs
@@ -1,0 +1,82 @@
+//! Sample CSG constructions ported from manifold3d's `samples/` C++ sources.
+//!
+//! These mirror the upstream samples (faithful translations of the algorithms,
+//! not 1:1 line-for-line) but live entirely in our safe Rust layer — the shim
+//! deliberately doesn't compile manifold's `samples/` directory, so the
+//! upstream functions aren't available as C symbols.
+
+use crate::Manifold;
+
+/// Menger sponge — the classic cubic fractal.
+///
+/// `n` is the recursion depth. **Warning:** triangle count grows exponentially
+/// — `n = 4` produces ~400k triangles. `n = 2` is a good interactive default.
+///
+/// Centered unit cube with cross-shaped tunnels carved through each face,
+/// recursively. Translated from manifold3d's
+/// [`MengerSponge`](https://github.com/elalish/manifold/blob/master/samples/src/menger_sponge.cpp)
+/// sample.
+#[must_use]
+pub fn menger_sponge(n: u32) -> Manifold {
+    let result = Manifold::cube(1.0, 1.0, 1.0, true);
+    // Level 0 is just the cube (no tunnels). Bail before calling `fractal`
+    // — its `depth == max_depth` exit condition would never trigger when
+    // started with depth=1, max_depth=0, infinite-recursing. (Same latent
+    // bug in the upstream C++ sample we ported from.)
+    if n == 0 {
+        return result;
+    }
+
+    let mut holes: Vec<Manifold> = Vec::new();
+    fractal(&mut holes, &result, 1.0, [0.0, 0.0], 1, n);
+
+    let hole = Manifold::batch_union(&holes);
+    let r1 = &result - &hole;
+    // Rotate the union of tunnels 90° about X to get tunnels along Y, then
+    // 90° about Z to get tunnels along X.
+    let hole_y = hole.rotate(90.0, 0.0, 0.0);
+    let r2 = &r1 - &hole_y;
+    let hole_x = hole_y.rotate(0.0, 0.0, 90.0);
+    &r2 - &hole_x
+}
+
+/// Recursive helper: build the set of square tunnels (along Z) that get
+/// subtracted from the cube to form one face's worth of the Menger pattern.
+/// Mirrors upstream's nested `Fractal` lambda.
+fn fractal(
+    holes: &mut Vec<Manifold>,
+    hole: &Manifold,
+    w: f64,
+    position: [f64; 2],
+    depth: u32,
+    max_depth: u32,
+) {
+    let w = w / 3.0;
+    holes.push(
+        hole.scale(w, w, 1.0)
+            .translate(position[0], position[1], 0.0),
+    );
+    if depth == max_depth {
+        return;
+    }
+    let offsets = [
+        [-w, -w],
+        [-w, 0.0],
+        [-w, w],
+        [0.0, w],
+        [w, w],
+        [w, 0.0],
+        [w, -w],
+        [0.0, -w],
+    ];
+    for off in offsets {
+        fractal(
+            holes,
+            hole,
+            w,
+            [position[0] + off[0], position[1] + off[1]],
+            depth + 1,
+            max_depth,
+        );
+    }
+}

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -2341,3 +2341,37 @@ fn manifold_status_with_context_already_cancelled() {
     // is well-formed and doesn't panic / leak / crash.
     let _ = cube.status_with_context(&ctx);
 }
+
+// ── Sample constructions ────────────────────────────────────────────
+
+#[test]
+fn menger_sponge_level_0_is_just_the_cube() {
+    use manifold_csg::samples::menger_sponge;
+    // Level 0 = no tunnels carved → original unit cube, volume 1.0. Also
+    // exercises the n=0 early return that prevents the upstream `Fractal`
+    // exit-condition bug from infinite-recursing.
+    let m = menger_sponge(0);
+    assert!(!m.is_empty());
+    assert!((m.volume() - 1.0).abs() < 1e-9);
+}
+
+#[test]
+fn menger_sponge_level_1_produces_six_tunnels() {
+    use manifold_csg::samples::menger_sponge;
+    // Level 1: unit cube minus a 1/3 × 1/3 × 1 square tunnel through each
+    // axis. 6 face-windows total. Volume = 1 - 3*(1/9*1) + corrections at
+    // intersections; we just sanity-check it's a closed manifold with
+    // non-zero volume strictly less than the original cube's.
+    let m = menger_sponge(1);
+    assert!(!m.is_empty());
+    assert!(m.volume() > 0.0);
+    assert!(m.volume() < 1.0);
+}
+
+#[test]
+fn menger_sponge_level_2_has_more_triangles_than_level_1() {
+    use manifold_csg::samples::menger_sponge;
+    let l1 = menger_sponge(1);
+    let l2 = menger_sponge(2);
+    assert!(l2.num_tri() > l1.num_tri());
+}


### PR DESCRIPTION
- New \`samples\` module in \`manifold-csg\` with \`menger_sponge(n)\`, ported from manifold3d's [samples/src/menger_sponge.cpp](https://github.com/elalish/manifold/blob/master/samples/src/menger_sponge.cpp). The shim doesn't compile manifold's \`samples/\` dir and the C API doesn't expose them, so reimplementing in Rust on top of our safe wrapper is the only path that actually reaches the wasm-uu lane.
- Playground: new \`Menger Sponge\` primitive (\`kind=3\`, recursion depth in \`p0\`, clamped 0..=4). Default scene swapped to \`Menger ∩ Sphere\` with the sphere half-overlapping — first-load is now visibly a boolean instead of a single shape.
- \`build.sh\` runs \`wasm-opt -Oz\` post-cargo when binaryen is on PATH: **397 KB → 312 KB raw (21%)**, **125 KB → 108 KB gzipped over the wire (13%)**. Friendly skip locally if not installed; Pages workflow installs binaryen.

## Test plan
- [x] +2 host tests for menger_sponge (level 1 sanity, level 2 > level 1 tris)
- [x] Playground node test extended with \`KIND_MENGER\` switch case
- [x] Local interactive: default scene loads cleanly, dragging the sphere mid-overlap shows the menger pattern carved into it
- [x] fmt + clippy clean, all 12 playground tests pass
- [ ] CI green