### PR TITLE
Bump wasm-cxx-shim to v0.4.0 + manifold pin to 3ce9622b

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ The sys crate clones manifold3d (pinned to a specific commit on master, post-v3.
 
 Things to revisit whenever the manifold pin moves OR `wasm-cxx-shim` cuts a new release:
 
-- **Re-evaluate wasm32-unknown-unknown cfg-gates.** Any FFI declaration / safe wrapper / test gated on `not(all(target_arch = "wasm32", target_os = "unknown"))` exists because that surface postdates the shim's tested manifold pin. When the shim's tested pin moves up to (or past) our host pin, those gates can be dropped and the surface unified across targets. Current gated surface: `manifold_*_obj` (OBJ I/O — gated for a different reason: iostream patches strip it; this stays regardless). Ray casting is **no longer gated** as of shim v0.4.0-alpha.1, whose tested pin matches our host pin. Grep for `target_os = "unknown"` to enumerate.
+- **Re-evaluate wasm32-unknown-unknown cfg-gates.** Any FFI declaration / safe wrapper / test gated on `not(all(target_arch = "wasm32", target_os = "unknown"))` exists because that surface postdates the shim's tested manifold pin. When the shim's tested pin moves up to (or past) our host pin, those gates can be dropped and the surface unified across targets. Current gated surface: `manifold_*_obj` (OBJ I/O — gated for a different reason: iostream patches strip it; this stays regardless). The shim's tested pin currently matches our host pin (no extra gating needed). Grep for `target_os = "unknown"` to enumerate.
 - **Re-evaluate carry-patches.** For each patch in `crates/manifold-csg-sys/patches/` (if any), check whether it's merged upstream and included in the new pin; if so, delete it.
 
 ## Carry-patches

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -25,7 +25,7 @@ fn find_lib_recursive(dir: &Path, name: &str) -> Option<PathBuf> {
 }
 
 /// Pinned upstream version — can be a tag (e.g., "v3.4.1"), branch, or commit SHA.
-const MANIFOLD_VERSION: &str = "5f95a3ac0e906f596bb2d27a52d005ef60de58f3";
+const MANIFOLD_VERSION: &str = "3ce9622b851f3d459566bf5ab55adacd93708b5d";
 
 fn main() {
     // docs.rs builds with --network=none, so we can't clone manifold3d.
@@ -404,11 +404,12 @@ fn main() {
 // build.rs instead of a cmake file).
 
 const WASM_CXX_SHIM_GIT: &str = "https://github.com/zmerlynn/wasm-cxx-shim.git";
-// v0.4.0-alpha.1 pins manifold to the same commit as our host build
-// (`5f95a3ac`), so the wasm-uu lane sees the same C API surface (including
-// ray_cast). Will move to non-alpha v0.4.0 once upstream manifold#1690
-// (the iostream gating PR the alpha vendors as a carry-patch) merges.
-const WASM_CXX_SHIM_TAG: &str = "v0.4.0-alpha.1+5f95a3ac";
+// v0.4.0 dropped the iostream carry-patch (upstream manifold#1690 merged)
+// and pins manifold to `3ce9622b`, currently matching our host pin. The
+// wasm-uu lane sees the same C API surface as the host, no cfg-gating
+// needed. If the host pin moves past the shim's tested pin in a future
+// bump, see CLAUDE.md "Versioning" for the override-or-cfg-gate playbook.
+const WASM_CXX_SHIM_TAG: &str = "v0.4.0";
 
 fn build_wasm_unknown_unknown() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/manifold-csg-sys/wasm32-uu/CMakeLists.txt
+++ b/crates/manifold-csg-sys/wasm32-uu/CMakeLists.txt
@@ -65,13 +65,13 @@ add_compile_options(
     -nostdlibinc
 )
 
-# FetchContent + patches + manifold/Clipper2 options + base compile flags.
-# Uses the helper's tested-pin default. As of shim v0.4.0-alpha.1 the
-# helper's default pin matches our host pin (`5f95a3ac`), so the wasm-uu
-# lane sees the same C API surface as the host build (including ray_cast).
-# When the host pin moves past the helper's tested pin again, either
-# override via `MANIFOLD_GIT_TAG` here or cfg-gate the new surface on
-# this target — see the "Pin / shim follow-ups" section in CLAUDE.md.
+# FetchContent + manifold/Clipper2 options + base compile flags.
+# Uses the helper's tested-pin default. As of shim v0.4.0 the helper's
+# default pin matches our host pin (`3ce9622b`), so the wasm-uu lane sees
+# the same C API surface as the host build. When the host pin moves past
+# the helper's tested pin again, either override via `MANIFOLD_GIT_TAG`
+# here or cfg-gate the new surface on this target — see the "Pin / shim
+# follow-ups" section in CLAUDE.md.
 wasm_cxx_shim_add_manifold()
 
 # Force the manifold + Clipper2 archives to build by default. Without

--- a/crates/manifold-csg/src/execution.rs
+++ b/crates/manifold-csg/src/execution.rs
@@ -39,7 +39,7 @@
 //! # let _ = status;
 //! ```
 //!
-//! Available since manifold3d's `5f95a3a` master commit (post-v3.4.1).
+//! Available since manifold3d's post-v3.4.1 master.
 
 use manifold_csg_sys::{
     ManifoldExecutionContext, manifold_alloc_execution_context, manifold_delete_execution_context,

--- a/docs/plans/wasm-unknown-unknown.md
+++ b/docs/plans/wasm-unknown-unknown.md
@@ -14,12 +14,12 @@ ecosystem (Bevy, Leptos, Yew, etc.). Supporting `wasm32-unknown-unknown`
 directly unblocks those consumers.
 
 The C++ runtime gap (`wasm32-unknown-unknown` ships no libc, no libcxx,
-no libcxxabi) is filled by `wasm-cxx-shim` (pinned to v0.4.0-alpha.1) — a small,
+no libcxxabi) is filled by `wasm-cxx-shim` (pinned to v0.4.0) — a small,
 independently-maintained library providing exactly the C/C++ runtime
 subset that manifold3d (and similar C++-via-Rust crates) need. See the
 shim's [`docs/context.md`](https://github.com/zmerlynn/wasm-cxx-shim/blob/main/docs/context.md) for the design background.
 
-Since v0.4.0-alpha.1 the shim ships a `wasm_cxx_shim_add_manifold()` CMake helper
+Since v0.4.0 the shim ships a `wasm_cxx_shim_add_manifold()` CMake helper
 that owns the high-change-rate parts of the integration cocktail
 (FetchContent of manifold + Clipper2 with tested-pin defaults, the three
 carry-patches, and manifold/Clipper2 CMake options). We invoke it from a
@@ -59,7 +59,7 @@ A separate `build_wasm_unknown_unknown()` function dispatched early when
 Steps:
 
 1. Sanity-check `cmake` and `clang` on PATH.
-2. Clone `wasm-cxx-shim` (pinned to `v0.4.0-alpha.1`) into `OUT_DIR` and build its
+2. Clone `wasm-cxx-shim` (pinned to `v0.4.0`) into `OUT_DIR` and build its
    three components (libc, libm, libcxx) via cmake using the shim's own
    wasm32 toolchain file.
 3. cmake-configure + build manifold + Clipper2 via our wrapper at
@@ -210,7 +210,7 @@ mention:
 
 - New target supported: `wasm32-unknown-unknown` (bare-wasm browser
   target compatible with `wasm-bindgen`).
-- Build dependency: `wasm-cxx-shim` v0.4.0-alpha.1 (cloned via build.rs into
+- Build dependency: `wasm-cxx-shim` v0.4.0 (cloned via build.rs into
   `OUT_DIR`; no Cargo dependency). The integration uses the shim's
   `wasm_cxx_shim_add_manifold()` CMake helper, so manifold/Clipper2
   pins, patches, and CMake options live upstream now.


### PR DESCRIPTION
Shim's [v0.4.0](https://github.com/zmerlynn/wasm-cxx-shim/releases/tag/v0.4.0) dropped the iostream carry-patch ([manifold#1690](https://github.com/elalish/manifold/pull/1690) merged upstream) and moved its tested pin to \`3ce9622b\`. Pinning host to the same commit keeps the wasm-uu lane and host build aligned.

No version bump — staying at 3.4.107 / 0.1.8 per request to defer the next release.

## Test plan

- [x] All 222 host integration tests pass against the new manifold pin
- [x] wasm-uu CI-equivalent build clean; produced wasm has zero unexpected imports
- [x] 13 playground node tests pass
- [x] fmt + clippy clean
- [ ] CI green