### PR TITLE
Prepare manifold-csg 0.3.0 API cleanup

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -1,8 +1,7 @@
 # API Coverage
 
-This document maps every function in the manifold3d C API (pinned to master
-post-v3.4.1) to its status in `manifold-csg-sys` (raw FFI) and `manifold-csg`
-(safe wrapper).
+This document maps every function in the bundled manifold3d 3.5.x C API to its
+status in `manifold-csg-sys` (raw FFI) and `manifold-csg` (safe wrapper).
 
 All C API functions are bound in `manifold-csg-sys`. The safe crate wraps the
 most commonly needed operations; infrastructure functions (allocation, vectors,
@@ -19,19 +18,19 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_cube` | [`Manifold::cube`](crates/manifold-csg/src/manifold.rs#L276) |
-| `manifold_cylinder` | [`Manifold::cylinder`](crates/manifold-csg/src/manifold.rs#L289) |
-| `manifold_sphere` | [`Manifold::sphere`](crates/manifold-csg/src/manifold.rs#L305) |
-| `manifold_tetrahedron` | [`Manifold::tetrahedron`](crates/manifold-csg/src/manifold.rs#L786) |
-| `manifold_empty` | [`Manifold::empty`](crates/manifold-csg/src/manifold.rs#L315) |
-| `manifold_of_meshgl` | [`Manifold::from_mesh_f32`](crates/manifold-csg/src/manifold.rs#L147) |
-| `manifold_of_meshgl64` | [`Manifold::from_mesh_f64`](crates/manifold-csg/src/manifold.rs#L97) |
-| `manifold_extrude` | [`Manifold::extrude`](crates/manifold-csg/src/manifold.rs#L467), [`extrude_with_options`](crates/manifold-csg/src/manifold.rs#L812) |
-| `manifold_revolve` | [`Manifold::revolve`](crates/manifold-csg/src/manifold.rs#L796) |
-| `manifold_compose` | [`Manifold::compose`](crates/manifold-csg/src/manifold.rs#L835) |
-| `manifold_copy` | [`Clone` impl](crates/manifold-csg/src/manifold.rs#L56) |
-| `manifold_level_set` | [`Manifold::from_sdf`](crates/manifold-csg/src/manifold.rs#L1114) |
-| `manifold_read_obj` | [`Manifold::from_obj`](crates/manifold-csg/src/manifold.rs#L1063) |
+| `manifold_cube` | [`Manifold::cube`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_cylinder` | [`Manifold::cylinder`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_sphere` | [`Manifold::sphere`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_tetrahedron` | [`Manifold::tetrahedron`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_empty` | [`Manifold::empty`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_of_meshgl` | [`Manifold::from_meshgl`](crates/manifold-csg/src/manifold.rs), [`from_mesh_f32`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_of_meshgl64` | [`Manifold::from_meshgl64`](crates/manifold-csg/src/manifold.rs), [`from_mesh_f64`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_extrude` | [`Manifold::extrude`](crates/manifold-csg/src/manifold.rs), [`extrude_with_options`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_revolve` | [`Manifold::revolve`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_compose` | [`Manifold::compose`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_copy` | [`Clone` impl](crates/manifold-csg/src/manifold.rs) |
+| `manifold_level_set` | [`Manifold::from_sdf`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_read_obj` | [`Manifold::from_obj`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_smooth` | [`Manifold::smooth_f32`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_smooth64` | [`Manifold::smooth_f64`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_level_set_seq` | [`Manifold::from_sdf_seq`](crates/manifold-csg/src/manifold.rs) |
@@ -40,55 +39,55 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_union` | [`Manifold::union`](crates/manifold-csg/src/manifold.rs#L607), `&a + &b` |
-| `manifold_difference` | [`Manifold::difference`](crates/manifold-csg/src/manifold.rs#L592), `&a - &b` |
-| `manifold_intersection` | [`Manifold::intersection`](crates/manifold-csg/src/manifold.rs#L622), `&a ^ &b` |
+| `manifold_union` | [`Manifold::union`](crates/manifold-csg/src/manifold.rs), `&a + &b` |
+| `manifold_difference` | [`Manifold::difference`](crates/manifold-csg/src/manifold.rs), `&a - &b` |
+| `manifold_intersection` | [`Manifold::intersection`](crates/manifold-csg/src/manifold.rs), `&a ^ &b` |
 | `manifold_boolean` | [`Manifold::boolean`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_batch_boolean` | [`Manifold::batch_union`](crates/manifold-csg/src/manifold.rs#L489), [`batch_difference`](crates/manifold-csg/src/manifold.rs#L495) |
-| `manifold_batch_hull` | [`Manifold::batch_hull`](crates/manifold-csg/src/manifold.rs#L673) |
-| `manifold_split` | [`Manifold::split`](crates/manifold-csg/src/manifold.rs#L859) |
-| `manifold_split_by_plane` | [`Manifold::split_by_plane`](crates/manifold-csg/src/manifold.rs#L389) |
+| `manifold_batch_boolean` | [`Manifold::batch_union`](crates/manifold-csg/src/manifold.rs), [`batch_difference`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_batch_hull` | [`Manifold::batch_hull`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_split` | [`Manifold::split`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_split_by_plane` | [`Manifold::split_by_plane`](crates/manifold-csg/src/manifold.rs) |
 
 ## Manifold — Transforms
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_translate` | [`Manifold::translate`](crates/manifold-csg/src/manifold.rs#L327) |
-| `manifold_rotate` | [`Manifold::rotate`](crates/manifold-csg/src/manifold.rs#L348) |
-| `manifold_scale` | [`Manifold::scale`](crates/manifold-csg/src/manifold.rs#L337) |
-| `manifold_transform` | [`Manifold::transform`](crates/manifold-csg/src/manifold.rs#L366) |
-| `manifold_mirror` | [`Manifold::mirror`](crates/manifold-csg/src/manifold.rs#L716) |
-| `manifold_warp` | [`Manifold::warp`](crates/manifold-csg/src/manifold.rs#L974) |
-| `manifold_refine` | [`Manifold::refine`](crates/manifold-csg/src/manifold.rs#L728) |
-| `manifold_refine_to_length` | [`Manifold::refine_to_length`](crates/manifold-csg/src/manifold.rs#L738) |
-| `manifold_refine_to_tolerance` | [`Manifold::refine_to_tolerance`](crates/manifold-csg/src/manifold.rs#L748) |
+| `manifold_translate` | [`Manifold::translate`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_rotate` | [`Manifold::rotate`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_scale` | [`Manifold::scale`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_transform` | [`Manifold::transform`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_mirror` | [`Manifold::mirror`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_warp` | [`Manifold::warp`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_refine` | [`Manifold::refine`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_refine_to_length` | [`Manifold::refine_to_length`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_refine_to_tolerance` | [`Manifold::refine_to_tolerance`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_set_tolerance` | [`Manifold::set_tolerance`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_simplify` | [`Manifold::simplify`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_smooth_by_normals` | [`Manifold::smooth_by_normals`](crates/manifold-csg/src/manifold.rs#L761) |
-| `manifold_smooth_out` | [`Manifold::smooth_out`](crates/manifold-csg/src/manifold.rs#L774) |
-| `manifold_calculate_normals` | [`Manifold::calculate_normals`](crates/manifold-csg/src/manifold.rs#L950) |
-| `manifold_calculate_curvature` | [`Manifold::calculate_curvature`](crates/manifold-csg/src/manifold.rs#L960) |
-| `manifold_set_properties` | [`Manifold::set_properties`](crates/manifold-csg/src/manifold.rs#L1011) |
-| `manifold_trim_by_plane` | [`Manifold::trim_by_plane`](crates/manifold-csg/src/manifold.rs#L409) |
+| `manifold_smooth_by_normals` | [`Manifold::smooth_by_normals`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_smooth_out` | [`Manifold::smooth_out`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_calculate_normals` | [`Manifold::calculate_normals`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_calculate_curvature` | [`Manifold::calculate_curvature`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_set_properties` | [`Manifold::set_properties`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_trim_by_plane` | [`Manifold::trim_by_plane`](crates/manifold-csg/src/manifold.rs) |
 
 ## Manifold — Queries
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_is_empty` | [`Manifold::is_empty`](crates/manifold-csg/src/manifold.rs#L534) |
-| `manifold_volume` | [`Manifold::volume`](crates/manifold-csg/src/manifold.rs#L541) |
-| `manifold_surface_area` | [`Manifold::surface_area`](crates/manifold-csg/src/manifold.rs#L548) |
-| `manifold_num_vert` | [`Manifold::num_vert`](crates/manifold-csg/src/manifold.rs#L555) |
-| `manifold_num_tri` | [`Manifold::num_tri`](crates/manifold-csg/src/manifold.rs#L562) |
-| `manifold_num_edge` | [`Manifold::num_edge`](crates/manifold-csg/src/manifold.rs#L906) |
-| `manifold_num_prop` | [`Manifold::num_prop`](crates/manifold-csg/src/manifold.rs#L912) |
-| `manifold_epsilon` | [`Manifold::epsilon`](crates/manifold-csg/src/manifold.rs#L920) |
+| `manifold_is_empty` | [`Manifold::is_empty`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_volume` | [`Manifold::volume`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_surface_area` | [`Manifold::surface_area`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_num_vert` | [`Manifold::num_vert`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_num_tri` | [`Manifold::num_tri`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_num_edge` | [`Manifold::num_edge`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_num_prop` | [`Manifold::num_prop`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_epsilon` | [`Manifold::epsilon`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_get_tolerance` | [`Manifold::get_tolerance`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_num_prop_vert` | [`Manifold::num_prop_vert`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_genus` | [`Manifold::genus`](crates/manifold-csg/src/manifold.rs#L927) |
-| `manifold_bounding_box` | [`Manifold::bounding_box`](crates/manifold-csg/src/manifold.rs#L571) |
-| `manifold_original_id` | [`Manifold::original_id`](crates/manifold-csg/src/manifold.rs#L934) |
-| `manifold_min_gap` | [`Manifold::min_gap`](crates/manifold-csg/src/manifold.rs#L941) |
+| `manifold_genus` | [`Manifold::genus`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_bounding_box` | [`Manifold::bounding_box`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_original_id` | [`Manifold::original_id`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_min_gap` | [`Manifold::min_gap`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_status` | [`Manifold::status`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_with_context` | [`Manifold::with_context`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_as_original` | [`Manifold::as_original`](crates/manifold-csg/src/manifold.rs) |
@@ -99,36 +98,36 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_hull` | [`Manifold::hull`](crates/manifold-csg/src/manifold.rs#L663) |
-| `manifold_hull_pts` | [`Manifold::hull_pts`](crates/manifold-csg/src/manifold.rs#L700) |
-| `manifold_decompose` | [`Manifold::decompose`](crates/manifold-csg/src/manifold.rs#L637) |
-| `manifold_slice` | [`Manifold::slice_at_z`](crates/manifold-csg/src/manifold.rs#L428), [`slice_to_cross_section`](crates/manifold-csg/src/manifold.rs#L445) |
-| `manifold_project` | [`Manifold::project`](crates/manifold-csg/src/manifold.rs#L891) |
-| `manifold_minkowski_sum` | [`Manifold::minkowski_sum`](crates/manifold-csg/src/manifold.rs#L871) |
-| `manifold_minkowski_difference` | [`Manifold::minkowski_difference`](crates/manifold-csg/src/manifold.rs#L881) |
-| `manifold_get_meshgl` | [`Manifold::to_mesh_f32`](crates/manifold-csg/src/manifold.rs#L235) |
-| `manifold_get_meshgl64` | [`Manifold::to_mesh_f64`](crates/manifold-csg/src/manifold.rs#L197) |
-| `manifold_write_obj` | [`Manifold::to_obj`](crates/manifold-csg/src/manifold.rs#L1082) |
-| `manifold_get_meshgl_w_normals` | [`Manifold::to_mesh_f32_with_normals`](crates/manifold-csg/src/manifold.rs) |
-| `manifold_get_meshgl64_w_normals` | [`Manifold::to_mesh_f64_with_normals`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_hull` | [`Manifold::hull`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_hull_pts` | [`Manifold::hull_pts`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_decompose` | [`Manifold::decompose`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_slice` | [`Manifold::slice_at_z`](crates/manifold-csg/src/manifold.rs), [`slice_to_cross_section`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_project` | [`Manifold::project`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_minkowski_sum` | [`Manifold::minkowski_sum`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_minkowski_difference` | [`Manifold::minkowski_difference`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_get_meshgl` | [`Manifold::to_meshgl`](crates/manifold-csg/src/manifold.rs), [`to_mesh_f32`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_get_meshgl64` | [`Manifold::to_meshgl64`](crates/manifold-csg/src/manifold.rs), [`to_mesh_f64`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_write_obj` | [`Manifold::to_obj`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_get_meshgl_w_normals` | [`Manifold::to_meshgl_with_normals`](crates/manifold-csg/src/manifold.rs), [`to_mesh_f32_with_normals`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_get_meshgl64_w_normals` | [`Manifold::to_meshgl64_with_normals`](crates/manifold-csg/src/manifold.rs), [`to_mesh_f64_with_normals`](crates/manifold-csg/src/manifold.rs) |
 
 ## CrossSection — Construction & Booleans
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_cross_section_empty` | [`CrossSection::empty`](crates/manifold-csg/src/cross_section.rs#L104) |
-| `manifold_cross_section_square` | [`CrossSection::square`](crates/manifold-csg/src/cross_section.rs#L114) |
-| `manifold_cross_section_circle` | [`CrossSection::circle`](crates/manifold-csg/src/cross_section.rs#L124) |
-| `manifold_cross_section_of_polygons` | [`CrossSection::from_polygons`](crates/manifold-csg/src/cross_section.rs#L137) |
-| `manifold_cross_section_copy` | [`Clone` impl](crates/manifold-csg/src/cross_section.rs#L79) |
-| `manifold_cross_section_union` | [`CrossSection::union`](crates/manifold-csg/src/cross_section.rs#L166), `&a + &b` |
-| `manifold_cross_section_difference` | [`CrossSection::difference`](crates/manifold-csg/src/cross_section.rs#L176), `&a - &b` |
-| `manifold_cross_section_intersection` | [`CrossSection::intersection`](crates/manifold-csg/src/cross_section.rs#L186), `&a ^ &b` |
+| `manifold_cross_section_empty` | [`CrossSection::empty`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_square` | [`CrossSection::square`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_circle` | [`CrossSection::circle`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_of_polygons` | [`CrossSection::from_polygons`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_copy` | [`Clone` impl](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_union` | [`CrossSection::union`](crates/manifold-csg/src/cross_section.rs), `&a + &b` |
+| `manifold_cross_section_difference` | [`CrossSection::difference`](crates/manifold-csg/src/cross_section.rs), `&a - &b` |
+| `manifold_cross_section_intersection` | [`CrossSection::intersection`](crates/manifold-csg/src/cross_section.rs), `&a ^ &b` |
 | `manifold_cross_section_boolean` | [`CrossSection::boolean`](crates/manifold-csg/src/cross_section.rs) |
-| `manifold_cross_section_batch_boolean` | [`CrossSection::batch_boolean`](crates/manifold-csg/src/cross_section.rs#L349), [`batch_union`](crates/manifold-csg/src/cross_section.rs#L376) |
-| `manifold_cross_section_batch_hull` | [`CrossSection::batch_hull`](crates/manifold-csg/src/cross_section.rs#L382) |
-| `manifold_cross_section_hull` | [`CrossSection::hull`](crates/manifold-csg/src/cross_section.rs#L234) |
-| `manifold_cross_section_compose` | [`CrossSection::compose`](crates/manifold-csg/src/cross_section.rs#L409) |
+| `manifold_cross_section_batch_boolean` | [`CrossSection::batch_boolean`](crates/manifold-csg/src/cross_section.rs), [`batch_union`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_batch_hull` | [`CrossSection::batch_hull`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_hull` | [`CrossSection::hull`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_compose` | [`CrossSection::compose`](crates/manifold-csg/src/cross_section.rs) |
 | `manifold_cross_section_of_simple_polygon` | [`CrossSection::from_simple_polygon`](crates/manifold-csg/src/cross_section.rs) |
 | `manifold_cross_section_hull_polygons` | [`CrossSection::hull_polygons`](crates/manifold-csg/src/cross_section.rs) |
 | `manifold_cross_section_hull_simple_polygon` | [`CrossSection::hull_simple_polygon`](crates/manifold-csg/src/cross_section.rs) |
@@ -138,19 +137,19 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_cross_section_translate` | [`CrossSection::translate`](crates/manifold-csg/src/cross_section.rs#L246) |
-| `manifold_cross_section_rotate` | [`CrossSection::rotate`](crates/manifold-csg/src/cross_section.rs#L256) |
-| `manifold_cross_section_scale` | [`CrossSection::scale`](crates/manifold-csg/src/cross_section.rs#L266) |
-| `manifold_cross_section_mirror` | [`CrossSection::mirror`](crates/manifold-csg/src/cross_section.rs#L276) |
-| `manifold_cross_section_offset` | [`CrossSection::offset`](crates/manifold-csg/src/cross_section.rs#L207) |
-| `manifold_cross_section_simplify` | [`CrossSection::simplify`](crates/manifold-csg/src/cross_section.rs#L339) |
-| `manifold_cross_section_warp_context` | [`CrossSection::warp`](crates/manifold-csg/src/cross_section.rs#L447) |
-| `manifold_cross_section_area` | [`CrossSection::area`](crates/manifold-csg/src/cross_section.rs#L288) |
-| `manifold_cross_section_num_vert` | [`CrossSection::num_vert`](crates/manifold-csg/src/cross_section.rs#L295) |
-| `manifold_cross_section_num_contour` | [`CrossSection::num_contour`](crates/manifold-csg/src/cross_section.rs#L302) |
-| `manifold_cross_section_is_empty` | [`CrossSection::is_empty`](crates/manifold-csg/src/cross_section.rs#L309) |
-| `manifold_cross_section_bounds` | [`CrossSection::bounds`](crates/manifold-csg/src/cross_section.rs#L316) |
-| `manifold_cross_section_to_polygons` | [`CrossSection::to_polygons`](crates/manifold-csg/src/cross_section.rs#L479) |
+| `manifold_cross_section_translate` | [`CrossSection::translate`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_rotate` | [`CrossSection::rotate`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_scale` | [`CrossSection::scale`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_mirror` | [`CrossSection::mirror`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_offset` | [`CrossSection::offset`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_simplify` | [`CrossSection::simplify`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_warp_context` | [`CrossSection::warp`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_area` | [`CrossSection::area`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_num_vert` | [`CrossSection::num_vert`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_num_contour` | [`CrossSection::num_contour`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_is_empty` | [`CrossSection::is_empty`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_bounds` | [`CrossSection::bounds`](crates/manifold-csg/src/cross_section.rs) |
+| `manifold_cross_section_to_polygons` | [`CrossSection::to_polygons`](crates/manifold-csg/src/cross_section.rs) |
 | `manifold_cross_section_transform` | [`CrossSection::transform`](crates/manifold-csg/src/cross_section.rs) |
 | `manifold_cross_section_size` | Not needed (alloc size) |
 
@@ -158,26 +157,26 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_meshgl` | [`MeshGL::new`](crates/manifold-csg/src/mesh.rs#L35) |
-| `manifold_meshgl_num_vert` | [`MeshGL::num_vert`](crates/manifold-csg/src/mesh.rs#L51) |
-| `manifold_meshgl_num_tri` | [`MeshGL::num_tri`](crates/manifold-csg/src/mesh.rs#L58) |
-| `manifold_meshgl_num_prop` | [`MeshGL::num_prop`](crates/manifold-csg/src/mesh.rs#L65) |
-| `manifold_meshgl_vert_properties` | [`MeshGL::vert_properties`](crates/manifold-csg/src/mesh.rs#L72) |
-| `manifold_meshgl_tri_verts` | [`MeshGL::tri_verts`](crates/manifold-csg/src/mesh.rs#L83) |
-| `manifold_meshgl64` | [`MeshGL64::new`](crates/manifold-csg/src/mesh.rs#L120) |
-| `manifold_meshgl64_num_vert` | [`MeshGL64::num_vert`](crates/manifold-csg/src/mesh.rs#L136) |
-| `manifold_meshgl64_num_tri` | [`MeshGL64::num_tri`](crates/manifold-csg/src/mesh.rs#L143) |
-| `manifold_meshgl64_num_prop` | [`MeshGL64::num_prop`](crates/manifold-csg/src/mesh.rs#L150) |
-| `manifold_meshgl64_vert_properties` | [`MeshGL64::vert_properties`](crates/manifold-csg/src/mesh.rs#L157) |
-| `manifold_meshgl64_tri_verts` | [`MeshGL64::tri_verts`](crates/manifold-csg/src/mesh.rs#L168) |
+| `manifold_meshgl` | [`MeshGL::new`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_num_vert` | [`MeshGL::num_vert`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_num_tri` | [`MeshGL::num_tri`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_num_prop` | [`MeshGL::num_prop`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_vert_properties` | [`MeshGL::vert_properties`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl_tri_verts` | [`MeshGL::tri_verts`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64` | [`MeshGL64::new`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_num_vert` | [`MeshGL64::num_vert`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_num_tri` | [`MeshGL64::num_tri`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_num_prop` | [`MeshGL64::num_prop`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_vert_properties` | [`MeshGL64::vert_properties`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_tri_verts` | [`MeshGL64::tri_verts`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_vert_properties_length` | Internal |
 | `manifold_meshgl_tri_length` | Internal |
 | `manifold_meshgl64_vert_properties_length` | Internal |
 | `manifold_meshgl64_tri_length` | Internal |
 | `manifold_meshgl_copy` | Internal (Clone impl) |
 | `manifold_meshgl64_copy` | Internal (Clone impl) |
-| `manifold_meshgl_w_options` | Not wrapped |
-| `manifold_meshgl64_w_options` | Not wrapped |
+| `manifold_meshgl_w_options` | [`MeshGL::new_with_options`](crates/manifold-csg/src/mesh.rs) |
+| `manifold_meshgl64_w_options` | [`MeshGL64::new_with_options`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_w_tangents` | [`MeshGL::new_with_tangents`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl64_w_tangents` | [`MeshGL64::new_with_tangents`](crates/manifold-csg/src/mesh.rs) |
 | `manifold_meshgl_halfedge_tangent` | [`MeshGL::halfedge_tangent`](crates/manifold-csg/src/mesh.rs) |
@@ -225,7 +224,7 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_triangulate` | [`triangulate_polygons`](crates/manifold-csg/src/triangulation.rs#L22) |
+| `manifold_triangulate` | [`triangulate_polygons`](crates/manifold-csg/src/triangulation.rs) |
 | `manifold_triangulation_num_tri` | Internal |
 | `manifold_triangulation_tri_verts` | Internal |
 | `manifold_triangulation_size` | Not used |
@@ -234,12 +233,12 @@ polygon helpers) are used internally and don't need direct safe wrappers.
 
 | C API function | Safe wrapper |
 |---|---|
-| `manifold_set_min_circular_angle` | [`set_min_circular_angle`](crates/manifold-csg/src/manifold.rs#L1288) |
-| `manifold_set_min_circular_edge_length` | [`set_min_circular_edge_length`](crates/manifold-csg/src/manifold.rs#L1296) |
-| `manifold_set_circular_segments` | [`set_circular_segments`](crates/manifold-csg/src/manifold.rs#L1304) |
-| `manifold_reset_to_circular_defaults` | [`reset_to_circular_defaults`](crates/manifold-csg/src/manifold.rs#L1312) |
-| `manifold_get_circular_segments` | [`get_circular_segments`](crates/manifold-csg/src/manifold.rs#L1319) |
-| `manifold_reserve_ids` | [`reserve_ids`](crates/manifold-csg/src/manifold.rs#L1326) |
+| `manifold_set_min_circular_angle` | [`set_min_circular_angle`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_set_min_circular_edge_length` | [`set_min_circular_edge_length`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_set_circular_segments` | [`set_circular_segments`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_reset_to_circular_defaults` | [`reset_to_circular_defaults`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_get_circular_segments` | [`get_circular_segments`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_reserve_ids` | [`reserve_ids`](crates/manifold-csg/src/manifold.rs) |
 
 ## Box3D Operations (`BoundingBox`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,14 @@ Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold) geom
 
 ## Build
 
-The sys crate clones manifold3d (pinned to a specific commit on master, post-v3.4.1) via git and builds with cmake. Requires:
+The sys crate clones manifold3d (currently pinned to v3.5.0) via git and builds with cmake. Requires:
 - git, cmake, a C++ compiler
 - First build is slow (clones + compiles manifold3d); subsequent builds are cached
 
 ## Versioning
 
 - **`manifold-csg-sys`** uses version `{major}.{minor}.{patch}` where major.minor tracks the upstream manifold3d version and patch >= 100 is our release number. For example, `3.4.100` tracks manifold3d v3.4.1, and `3.4.101` would be our next release against the same upstream. Patch bumps (e.g., `3.4.101` → `3.4.102`) must be semver-compatible: no removed or changed function signatures, only additions.
+- Exception: `3.5.101` completes `ManifoldError` to match bundled manifold3d 3.5.0 status codes (`InvalidTangents`, `Cancelled`), marks `ManifoldError` `#[non_exhaustive]`, and tightens the public `ManifoldMeshGLOptions` / `ManifoldMeshGL64Options` input pointers from `*mut` to `*const`. These are documented patch-level binding corrections: the previous incomplete enum could construct invalid Rust enum values from safe status queries, the non-exhaustive marker prevents recurring downstream match breaks when upstream adds status codes, and the option pointers are input-only fields that should not require safe wrappers to cast shared slices to mutable pointers.
 - **`manifold-csg`** uses standard semver (`0.1.0`, etc.) independent of the upstream version. Its `Cargo.toml` pins the sys crate version it depends on.
 - When bumping the manifold3d pin in `build.rs`, the sys crate version must be updated to match (e.g., manifold3d v3.5.0 -> sys crate `3.5.100`).
 - **Before bumping `MANIFOLD_VERSION`, check that `wasm-cxx-shim` supports the new pin.** The shim's helper (`wasm_cxx_shim_add_manifold()`) ships carry-patches generated against a specific manifold commit; pins past that point may not patch cleanly, and FFI declarations for any C API added in the gap will produce wasm-uu link failures. Two paths if the shim hasn't caught up: (1) wait for a shim release that pins past your target SHA, or (2) cfg-gate the new FFI surface on `not(all(target_arch = "wasm32", target_os = "unknown"))` so the wasm-uu lane stays on the shim's tested pin. The "Pin / shim follow-ups" section below covers the post-bump cleanups for path (2).
@@ -41,6 +42,7 @@ The sys crate clones manifold3d (pinned to a specific commit on master, post-v3.
 - Every `manifold_alloc_*` must be paired with `manifold_delete_*` on all code paths
 - All `Drop` impls must null-check before freeing
 - All FFI callback trampolines must use `catch_unwind` to prevent panic-across-FFI UB
+- `FnMut` callback trampolines are valid only for upstream callbacks that are sequential in the pinned source. In v3.5.0, `Warp` and non-null `SetProperties` callbacks use sequential execution; parallel callbacks must use `Sync`/shared-state-safe bounds like `from_sdf`.
 - `unsafe impl Send` requires documented justification on each type
 - `Sync` is implemented for `Manifold` and `CrossSection` (upstream synchronizes lazy evaluation with a mutex). `MeshGL`/`MeshGL64` are also `Sync` (pure data, no lazy state)
 - `manifold_meshgl_merge` / `manifold_meshgl64_merge` had an upstream ownership bug (returning the input pointer on failure, causing double-free). This was fixed upstream in #1632 (included in our pinned commit).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/MIGRATION_0.2.0_TO_0.3.0.md
+++ b/MIGRATION_0.2.0_TO_0.3.0.md
@@ -1,0 +1,258 @@
+# Migration guide: `manifold-csg` 0.2.0 -> 0.3.0
+
+This release tightens the safe Rust API around status handling, mesh
+construction, and upstream enum/default behavior.
+
+Breaking changes:
+
+1. `Manifold::status()` now returns `Result<(), CsgError>`.
+2. `MeshGL::new`, `MeshGL64::new`, and their tangent constructors now return
+   `Result<_, CsgError>`.
+3. Empty mesh input is valid. `CsgError::EmptyMesh` was removed.
+4. `CrossSection::from_polygons()` now uses upstream's default
+   `FillRule::Positive` instead of `FillRule::EvenOdd`.
+5. `CrossSection::from_simple_polygon()` now uses `FillRule::Positive`; the
+   fill-rule-taking form was renamed to `from_simple_polygon_with_fill_rule()`.
+6. `manifold_csg::OpType` is now a safe crate enum instead of a re-export of
+   `manifold_csg_sys::ManifoldOpType`.
+7. Safe public enums intended to follow upstream growth are now
+   `#[non_exhaustive]`; raw `ManifoldError` is also non-exhaustive.
+8. Panics in user callbacks now propagate after the FFI call returns safely,
+   instead of being swallowed by the Rust trampoline.
+
+Additions:
+
+1. `Manifold::raw_status()` returns the raw upstream `ManifoldError`.
+2. `Manifold::to_meshgl()` and `Manifold::to_meshgl64()` return the full mesh
+   containers, including metadata.
+3. `Manifold::to_meshgl_with_normals()` and `to_meshgl64_with_normals()` return
+   full mesh containers with normals baked into vertex properties.
+4. `MeshGL::new_with_options()` and `MeshGL64::new_with_options()` construct
+   meshes with run, original-ID, merge, and tangent metadata.
+5. `Manifold::from_meshgl()` and `from_meshgl64()` construct manifolds from
+   mesh containers, including containers built with metadata options.
+6. `Default` for `Manifold` and `CrossSection` returns empty geometry.
+7. `manifold-csg-sys` / `manifold3d-sys` move to `3.5.101`, tracking the same
+   upstream `3.5.x` source plus binding fixes.
+
+If you do not construct meshes directly, call `status()`, match public enums
+exhaustively, depend on `from_polygons()` using EvenOdd semantics, or call
+`from_simple_polygon()` with a fill rule, most code only needs a dependency
+bump.
+
+**This guide is structured so an AI coding assistant can read it and migrate
+code automatically.** If you have a Claude/Copilot/Cursor-style tool, point it
+at this file and at your code. AI prompt at the end.
+
+## Cargo.toml
+
+```diff
+ [dependencies]
+-manifold-csg = "0.2.0"
++manifold-csg = "0.3.0"
+```
+
+Or for the facade:
+
+```diff
+ [dependencies]
+-manifold3d = "0.2.0"
++manifold3d = "0.3.0"
+```
+
+## `Manifold::status()` returns `Result`
+
+Use `?`, `is_ok()`, or match on `Result`.
+
+```diff
+-use manifold_csg_sys::ManifoldError;
+-
+ let result = manifold.with_context(&ctx).status();
+-assert_eq!(result, ManifoldError::NoError);
++assert!(result.is_ok());
+```
+
+If you need the raw upstream status enum:
+
+```diff
+-let status = manifold.status();
++let status = manifold.raw_status();
+```
+
+## Mesh constructors return `Result`
+
+`MeshGL` constructors now validate buffer shape before calling the C API.
+
+```diff
+-let mesh = MeshGL64::new(&verts, n_props, &indices);
++let mesh = MeshGL64::new(&verts, n_props, &indices)?;
+```
+
+Empty meshes are valid:
+
+```rust
+let mesh = MeshGL64::new(&[], 3, &[])?;
+let manifold = Manifold::from_mesh_f64(&[], 3, &[])?;
+assert!(manifold.is_empty());
+```
+
+Shape errors are now reported as `CsgError::InvalidInput`, for example
+`n_props < 3`, vertex-property length not divisible by `n_props`, triangle
+index length not divisible by 3, or tangent length not equal to
+`num_tri * 3 * 4`.
+
+## `from_polygons()` uses `FillRule::Positive`
+
+This matches upstream C++/Python defaults. If you relied on EvenOdd behavior,
+call the explicit constructor. This also affects
+`Manifold::slice_to_cross_section()`, which reconstructs a cross-section from
+sliced polygons using the same upstream default.
+
+```diff
+-let cs = CrossSection::from_polygons(&polygons);
++let cs = CrossSection::from_polygons_with_fill_rule(&polygons, FillRule::EvenOdd);
+```
+
+`FillRule::Positive` treats positively oriented contours as filled regions and
+negatively oriented contours as holes.
+
+## `from_simple_polygon()` uses `FillRule::Positive`
+
+The old `from_simple_polygon(points, fill_rule)` spelling moved to
+`from_simple_polygon_with_fill_rule(points, fill_rule)`.
+
+```diff
+-let cs = CrossSection::from_simple_polygon(&points, FillRule::EvenOdd);
++let cs = CrossSection::from_simple_polygon_with_fill_rule(&points, FillRule::EvenOdd);
+```
+
+For upstream default behavior:
+
+```diff
+-let cs = CrossSection::from_simple_polygon(&points, FillRule::Positive);
++let cs = CrossSection::from_simple_polygon(&points);
+```
+
+## `OpType` is now a safe enum
+
+Most code that imports `manifold_csg::OpType` keeps the same variant names. Code
+that explicitly names the raw sys type should use the safe type for safe API
+calls:
+
+```diff
+-let op = manifold_csg_sys::ManifoldOpType::Add;
++let op = manifold_csg::OpType::Add;
+ let result = a.boolean(&b, op);
+```
+
+## Public enums are non-exhaustive
+
+Downstream exhaustive matches need a wildcard arm.
+
+```diff
+ match fill_rule {
+     FillRule::EvenOdd => { /* ... */ }
+     FillRule::NonZero => { /* ... */ }
+     FillRule::Positive => { /* ... */ }
+     FillRule::Negative => { /* ... */ }
++    _ => { /* future upstream variant */ }
+ }
+```
+
+This applies to `FillRule`, `JoinType`, `OpType`, `CsgError`, and raw
+`manifold_csg_sys::ManifoldError`. Other raw `manifold-csg-sys` enums remain
+exhaustive for the bundled upstream source.
+
+## Raw sys changes
+
+`manifold-csg-sys` / `manifold3d-sys` `3.5.101` add the upstream
+`ManifoldError::InvalidTangents` and `ManifoldError::Cancelled` variants and
+mark `ManifoldError` as `#[non_exhaustive]`. Downstream matches over
+`ManifoldError` must add a wildcard arm.
+
+This is a deliberate binding-correction exception to the usual sys patch-bump
+rule: bundled manifold3d 3.5.0 can already return these status codes, so the
+old incomplete enum could construct invalid Rust enum values through safe
+status queries. Making `ManifoldError` non-exhaustive means this release has
+one explicit sys compatibility break, but future upstream status additions can
+be represented without breaking downstream exhaustive matches again.
+
+The same sys patch release also changes the public
+`ManifoldMeshGLOptions` / `ManifoldMeshGL64Options` input pointer fields from
+`*mut` to `*const`. The upstream C header spells these input-only pointers as
+mutable, but the Rust binding uses const pointers for the same ABI so safe
+wrappers can pass shared slices without casting away constness.
+
+## Callback panics now propagate
+
+`Manifold::warp()`, `Manifold::set_properties()`, `Manifold::from_sdf()`,
+`Manifold::from_sdf_seq()`, and `CrossSection::warp()` now catch user callback
+panics before they cross the C stack, clean up any partially created handle,
+then resume the original panic payload on the Rust side.
+
+Previously, these callback panics were swallowed by sentinel return values or
+ignored outputs. Code should not rely on those panics being converted into
+identity warps, infinite SDF samples, or zeroed property buffers.
+
+## Full mesh extraction
+
+Use `to_mesh_f32()` / `to_mesh_f64()` when you only need the tuple. Use the new
+container-returning methods when you need metadata:
+
+```rust
+let mesh = manifold.to_meshgl64();
+let run_ids = mesh.run_original_id();
+let face_ids = mesh.face_id();
+
+let mesh_with_normals = manifold.to_meshgl64_with_normals(3);
+```
+
+## Mesh construction with metadata
+
+Use `MeshGLOptions` / `MeshGL64Options` with `new_with_options()` when importing
+mesh data that already has run IDs, merge vectors, or halfedge tangents:
+
+```rust
+let mesh = MeshGL64::new_with_options(
+    &verts,
+    3,
+    &triangles,
+    MeshGL64Options::new()
+        .runs(&run_indices, &run_original_ids)
+        .merge_vertices(&merge_from, &merge_to)
+        .halfedge_tangents(&halfedge_tangents),
+)?;
+let manifold = Manifold::from_meshgl64(&mesh)?;
+```
+
+The current C shim exposes this subset of upstream `MeshGL` input metadata.
+Face IDs, run transforms, run flags, and tolerance are still output-only from
+the safe wrapper until the C shim exposes them for construction.
+
+## AI prompt
+
+> I have Rust code using `manifold-csg = "0.2.x"` (or `manifold3d = "0.2.x"`).
+> Please migrate it to the `0.3.0` line using the migration guide at
+> https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_0.2.0_TO_0.3.0.md
+>
+> Key rules:
+> 1. Bump the Cargo.toml dependency from `0.2.x` to `0.3.0`.
+> 2. Rewrite `m.status()` callers for `Result<(), CsgError>`. Use
+>    `m.raw_status()` only when code truly needs `ManifoldError`.
+> 3. Add `?`, `.expect(...)`, or explicit error handling for `MeshGL::new`,
+>    `MeshGL64::new`, and their `new_with_tangents` variants.
+> 4. Replace uses of `CsgError::EmptyMesh`; empty meshes are valid now.
+> 5. If code relied on EvenOdd polygon filling, rewrite
+>    `CrossSection::from_polygons(&polys)` to
+>    `CrossSection::from_polygons_with_fill_rule(&polys, FillRule::EvenOdd)`.
+>    Audit `slice_to_cross_section()` uses for the same Positive fill-rule
+>    behavior.
+> 6. Rewrite `CrossSection::from_simple_polygon(&points, rule)` to
+>    `CrossSection::from_simple_polygon_with_fill_rule(&points, rule)`.
+> 7. Use `manifold_csg::OpType` instead of `manifold_csg_sys::ManifoldOpType`
+>    with safe `boolean` APIs.
+> 8. Add wildcard arms to exhaustive matches over safe public manifold enum
+>    types and `manifold_csg_sys::ManifoldError`.
+> 9. Do not rely on panics in `warp`, `set_properties`, `from_sdf`,
+>    `from_sdf_seq`, or cross-section `warp` callbacks being swallowed; they
+>    now propagate after FFI cleanup.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Notes:
 - **Migration guides** — one per breaking-change version pair, each structured for AI-assisted migration:
   - [from 0.0.6](MIGRATION_FROM_0.0.6.md) — original `manifold3d` crate line (pre-transfer to this project).
   - [0.1.8 → 0.2.0](MIGRATION_0.1.8_TO_0.2.0.md) — `ExecutionContext` attachment API reshape.
+  - [0.2.0 → 0.3.0](MIGRATION_0.2.0_TO_0.3.0.md) — more idiomatic `Result` status/mesh APIs and upstream-aligned defaults.
 
 ## License
 

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.5.100"
+version = "3.5.101"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/manifold-csg-sys/src/lib.rs
+++ b/crates/manifold-csg-sys/src/lib.rs
@@ -178,31 +178,39 @@ pub struct ManifoldRayHit {
 }
 
 /// Options for constructing a `MeshGL` with additional metadata.
+///
+/// The upstream C header declares these input-only pointers as mutable. The
+/// Rust binding uses const pointers for the same ABI so safe wrappers can pass
+/// shared slices without casting away constness.
 #[repr(C)]
 #[derive(Debug)]
 pub struct ManifoldMeshGLOptions {
-    pub run_indices: *mut u32,
+    pub run_indices: *const u32,
     pub run_indices_length: usize,
-    pub run_original_ids: *mut u32,
+    pub run_original_ids: *const u32,
     pub run_original_ids_length: usize,
-    pub merge_from_vert: *mut u32,
-    pub merge_to_vert: *mut u32,
+    pub merge_from_vert: *const u32,
+    pub merge_to_vert: *const u32,
     pub merge_verts_length: usize,
-    pub halfedge_tangents: *mut f32,
+    pub halfedge_tangents: *const f32,
 }
 
 /// Options for constructing a `MeshGL64` with additional metadata.
+///
+/// The upstream C header declares these input-only pointers as mutable. The
+/// Rust binding uses const pointers for the same ABI so safe wrappers can pass
+/// shared slices without casting away constness.
 #[repr(C)]
 #[derive(Debug)]
 pub struct ManifoldMeshGL64Options {
-    pub run_indices: *mut u64,
+    pub run_indices: *const u64,
     pub run_indices_length: usize,
-    pub run_original_ids: *mut u32,
+    pub run_original_ids: *const u32,
     pub run_original_ids_length: usize,
-    pub merge_from_vert: *mut u64,
-    pub merge_to_vert: *mut u64,
+    pub merge_from_vert: *const u64,
+    pub merge_to_vert: *const u64,
     pub merge_verts_length: usize,
-    pub halfedge_tangents: *mut f64,
+    pub halfedge_tangents: *const f64,
 }
 
 // ── Enums ───────────────────────────────────────────────────────────────
@@ -238,6 +246,7 @@ pub enum ManifoldJoinType {
 
 /// Error codes from manifold3d status check.
 #[repr(C)]
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManifoldError {
     NoError = 0,
@@ -253,6 +262,22 @@ pub enum ManifoldError {
     FaceIdWrongLength = 10,
     InvalidConstruction = 11,
     ResultTooLarge = 12,
+    InvalidTangents = 13,
+    Cancelled = 14,
+}
+
+impl ManifoldError {
+    /// Returns true when the status is [`ManifoldError::NoError`].
+    #[must_use]
+    pub const fn is_ok(self) -> bool {
+        matches!(self, Self::NoError)
+    }
+
+    /// Returns true when the status represents an error.
+    #[must_use]
+    pub const fn is_err(self) -> bool {
+        !self.is_ok()
+    }
 }
 
 // ── Function pointer types ─────────────────────────────────────────────

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -19,7 +19,7 @@ nalgebra = ["dep:nalgebra"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.5.100", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.5.101", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }

--- a/crates/manifold-csg/src/cross_section.rs
+++ b/crates/manifold-csg/src/cross_section.rs
@@ -6,14 +6,17 @@
 
 use manifold_csg_sys::*;
 use std::ops;
+use std::sync::Mutex;
 
-use crate::manifold::read_polygons;
+use crate::manifold::{read_polygons, with_quality_lock_if_auto_segments};
 use crate::rect::Rect;
+use crate::types::{OpType, PanicPayload, store_panic, take_stored_panic};
 
 /// Join type for [`CrossSection::offset`].
 ///
 /// Determines how corners are handled when inflating/deflating a 2D shape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum JoinType {
     /// Square (flat) corners.
     Square,
@@ -41,6 +44,7 @@ impl JoinType {
 /// Determines how self-intersecting or overlapping polygon contours are
 /// interpreted when creating a [`CrossSection`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FillRule {
     /// Alternating inside/outside based on crossing count parity.
     EvenOdd,
@@ -109,10 +113,8 @@ pub struct CrossSection {
 impl std::fmt::Debug for CrossSection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CrossSection")
-            .field("is_empty", &self.is_empty())
-            .field("area", &self.area())
-            .field("num_vert", &self.num_vert())
-            .finish()
+            .field("ptr", &self.ptr)
+            .finish_non_exhaustive()
     }
 }
 
@@ -144,6 +146,12 @@ impl Drop for CrossSection {
     }
 }
 
+impl Default for CrossSection {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl CrossSection {
     // ── Constructors ────────────────────────────────────────────────
 
@@ -172,19 +180,22 @@ impl CrossSection {
     pub fn circle(radius: f64, segments: i32) -> Self {
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };
-        // SAFETY: ptr is valid from alloc.
-        unsafe { manifold_cross_section_circle(ptr, radius, segments) };
+        with_quality_lock_if_auto_segments(segments, || {
+            // SAFETY: ptr is valid from alloc.
+            unsafe { manifold_cross_section_circle(ptr, radius, segments) };
+        });
         Self { ptr }
     }
 
     /// Create a cross-section from polygon rings.
     ///
-    /// The first ring is the outer boundary; subsequent rings are holes.
-    /// Uses EvenOdd fill rule. For self-intersecting or overlapping polygons,
-    /// use [`from_polygons_with_fill_rule`](Self::from_polygons_with_fill_rule).
+    /// Uses the upstream default [`FillRule::Positive`], which treats
+    /// positively oriented contours as filled regions and negatively oriented
+    /// contours as holes. For other winding semantics, use
+    /// [`from_polygons_with_fill_rule`](Self::from_polygons_with_fill_rule).
     #[must_use]
     pub fn from_polygons(polygons: &[Vec<[f64; 2]>]) -> Self {
-        Self::from_polygons_with_fill_rule(polygons, FillRule::EvenOdd)
+        Self::from_polygons_with_fill_rule(polygons, FillRule::Positive)
     }
 
     /// Create a cross-section from polygon rings with a specified fill rule.
@@ -219,9 +230,22 @@ impl CrossSection {
 
     /// Create a cross-section from a single simple polygon (no holes).
     ///
+    /// Uses the upstream default [`FillRule::Positive`]. For other winding
+    /// semantics, use
+    /// [`from_simple_polygon_with_fill_rule`](Self::from_simple_polygon_with_fill_rule).
+    ///
     /// For polygons with holes, use [`from_polygons`](Self::from_polygons).
     #[must_use]
-    pub fn from_simple_polygon(points: &[[f64; 2]], fill_rule: FillRule) -> Self {
+    pub fn from_simple_polygon(points: &[[f64; 2]]) -> Self {
+        Self::from_simple_polygon_with_fill_rule(points, FillRule::Positive)
+    }
+
+    /// Create a cross-section from a single simple polygon with a specified
+    /// fill rule.
+    ///
+    /// For polygons with holes, use [`from_polygons`](Self::from_polygons).
+    #[must_use]
+    pub fn from_simple_polygon_with_fill_rule(points: &[[f64; 2]], fill_rule: FillRule) -> Self {
         if points.is_empty() {
             return Self::empty();
         }
@@ -335,11 +359,11 @@ impl CrossSection {
     /// [`difference`](Self::difference), [`intersection`](Self::intersection))
     /// or operator overloads for readability.
     #[must_use]
-    pub fn boolean(&self, other: &Self, op: ManifoldOpType) -> Self {
+    pub fn boolean(&self, other: &Self, op: OpType) -> Self {
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };
         // SAFETY: all three pointers are valid.
-        unsafe { manifold_cross_section_boolean(ptr, self.ptr, other.ptr, op) };
+        unsafe { manifold_cross_section_boolean(ptr, self.ptr, other.ptr, op.to_ffi()) };
         Self { ptr }
     }
 
@@ -365,17 +389,19 @@ impl CrossSection {
     ) -> Self {
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };
-        // SAFETY: ptr and self.ptr are valid.
-        unsafe {
-            manifold_cross_section_offset(
-                ptr,
-                self.ptr,
-                delta,
-                join_type.to_ffi(),
-                miter_limit,
-                circular_segments,
-            );
-        }
+        with_quality_lock_if_auto_segments(circular_segments, || {
+            // SAFETY: ptr and self.ptr are valid.
+            unsafe {
+                manifold_cross_section_offset(
+                    ptr,
+                    self.ptr,
+                    delta,
+                    join_type.to_ffi(),
+                    miter_limit,
+                    circular_segments,
+                );
+            }
+        });
         Self { ptr }
     }
 
@@ -545,7 +571,7 @@ impl CrossSection {
 
     /// Batch boolean: apply `op` across multiple cross-sections.
     #[must_use]
-    pub fn batch_boolean(sections: &[Self], op: crate::OpType) -> Self {
+    pub fn batch_boolean(sections: &[Self], op: OpType) -> Self {
         if sections.is_empty() {
             return Self::empty();
         }
@@ -566,7 +592,7 @@ impl CrossSection {
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };
         // SAFETY: ptr and vec_ptr are valid.
-        unsafe { manifold_cross_section_batch_boolean(ptr, vec_ptr, op) };
+        unsafe { manifold_cross_section_batch_boolean(ptr, vec_ptr, op.to_ffi()) };
         // SAFETY: vec_ptr is valid and no longer needed.
         unsafe { manifold_delete_cross_section_vec(vec_ptr) };
         Self { ptr }
@@ -575,7 +601,7 @@ impl CrossSection {
     /// Batch union of multiple cross-sections.
     #[must_use]
     pub fn batch_union(sections: &[Self]) -> Self {
-        Self::batch_boolean(sections, crate::OpType::Add)
+        Self::batch_boolean(sections, OpType::Add)
     }
 
     /// Batch hull of multiple cross-sections.
@@ -653,6 +679,11 @@ impl CrossSection {
     where
         F: FnMut(f64, f64) -> [f64; 2],
     {
+        struct Context<'a, F> {
+            f: &'a mut F,
+            panic: Mutex<Option<PanicPayload>>,
+        }
+
         unsafe extern "C" fn trampoline<F>(
             x: f64,
             y: f64,
@@ -663,23 +694,42 @@ impl CrossSection {
         {
             // Catch panics to prevent UB from unwinding through C stack frames.
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                // SAFETY: ctx was created from a &mut F and is valid for the call duration.
-                let f = unsafe { &mut *(ctx as *mut F) };
-                f(x, y)
+                // SAFETY: ctx was created from a &mut Context and is valid for
+                // the call duration.
+                let ctx = unsafe { &mut *(ctx as *mut Context<'_, F>) };
+                (ctx.f)(x, y)
             }));
             match result {
                 Ok([rx, ry]) => ManifoldVec2 { x: rx, y: ry },
-                // Return the original point on panic to avoid UB from unwinding through C.
-                Err(_) => ManifoldVec2 { x, y },
+                Err(payload) => {
+                    // Return the original point to avoid UB from unwinding
+                    // through C, then resume after the FFI call.
+                    // SAFETY: ctx was created from a &mut Context below and is
+                    // valid for the duration of the cross-section warp call.
+                    let ctx = unsafe { &*(ctx as *const Context<'_, F>) };
+                    store_panic(&ctx.panic, payload);
+                    ManifoldVec2 { x, y }
+                }
             }
         }
 
         let mut closure = f;
-        let ctx = &mut closure as *mut F as *mut std::ffi::c_void;
+        let mut ctx = Context {
+            f: &mut closure,
+            panic: Mutex::new(None),
+        };
+        let ctx_ptr = &mut ctx as *mut Context<'_, F> as *mut std::ffi::c_void;
         // SAFETY: manifold_alloc_cross_section returns a valid handle.
         let ptr = unsafe { manifold_alloc_cross_section() };
         // SAFETY: ptr valid from alloc, self.ptr valid (invariant), trampoline+ctx valid.
-        unsafe { manifold_cross_section_warp_context(ptr, self.ptr, Some(trampoline::<F>), ctx) };
+        unsafe {
+            manifold_cross_section_warp_context(ptr, self.ptr, Some(trampoline::<F>), ctx_ptr)
+        };
+        if let Some(payload) = take_stored_panic(&ctx.panic) {
+            // SAFETY: ptr was allocated above and will not be returned.
+            unsafe { manifold_delete_cross_section(ptr) };
+            std::panic::resume_unwind(payload);
+        }
         Self { ptr }
     }
 

--- a/crates/manifold-csg/src/execution.rs
+++ b/crates/manifold-csg/src/execution.rs
@@ -1,12 +1,12 @@
 //! Cooperative cancellation + progress observation for long-running boolean evaluations.
 //!
 //! Manifold operations are lazy: building a CSG tree is cheap, and the
-//! actual evaluation happens when you query results (e.g., via
-//! [`Manifold::with_context`](crate::Manifold::with_context) followed by
-//! [`Manifold::status`](crate::Manifold::status),
-//! `num_tri`, mesh extraction, etc.). An [`ExecutionContext`] lets you
-//! observe an in-flight evaluation from another thread and ask it to stop
-//! early.
+//! actual evaluation happens when you query results. Attach an
+//! [`ExecutionContext`] with [`Manifold::with_context`](crate::Manifold::with_context),
+//! then call an eager operation that consumes it, such as
+//! [`Manifold::status`](crate::Manifold::status) or `refine*`. An
+//! [`ExecutionContext`] lets you observe an in-flight evaluation from another
+//! thread and ask it to stop early.
 //!
 //! Cancellation is **sticky** (once cancelled, stays cancelled) and granular
 //! per-boolean (the upstream kernel checks the cancel flag at boolean
@@ -35,8 +35,8 @@
 //!
 //! let result = Manifold::cube(1.0, 1.0, 1.0, true);
 //! let status = result.with_context(&ctx).status();
-//! // `status` will be `NoError` for trivial work that finishes before
-//! // cancel fires; for a heavy boolean tree it would surface cancellation.
+//! // `status` will be `Ok(())` for trivial work that finishes before cancel
+//! // fires; for a heavy boolean tree it would surface cancellation as an error.
 //! # let _ = status;
 //! ```
 //!

--- a/crates/manifold-csg/src/lib.rs
+++ b/crates/manifold-csg/src/lib.rs
@@ -38,9 +38,8 @@ pub use manifold::{
     get_circular_segments, reserve_ids, reset_to_circular_defaults, set_circular_segments,
     set_min_circular_angle, set_min_circular_edge_length,
 };
-pub use manifold_csg_sys::ManifoldOpType as OpType;
-pub use mesh::{MeshGL, MeshGL64};
+pub use mesh::{MeshGL, MeshGL64, MeshGL64Options, MeshGLOptions};
 pub use ray::RayHit;
 pub use rect::Rect;
 pub use triangulation::triangulate_polygons;
-pub use types::CsgError;
+pub use types::{CsgError, OpType};

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -21,10 +21,12 @@
 
 use manifold_csg_sys::*;
 use std::ops;
+use std::sync::Mutex;
 
 use crate::bounding_box::BoundingBox;
 use crate::cross_section::CrossSection;
-use crate::types::CsgError;
+use crate::mesh::{MeshGL, MeshGL64};
+use crate::types::{CsgError, OpType, PanicPayload, store_panic, take_stored_panic};
 
 /// A safe wrapper around a manifold3d Manifold object.
 ///
@@ -40,10 +42,8 @@ pub struct Manifold {
 impl std::fmt::Debug for Manifold {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Manifold")
-            .field("is_empty", &self.is_empty())
-            .field("num_vert", &self.num_vert())
-            .field("num_tri", &self.num_tri())
-            .finish()
+            .field("ptr", &self.ptr)
+            .finish_non_exhaustive()
     }
 }
 
@@ -77,6 +77,12 @@ impl Drop for Manifold {
     }
 }
 
+impl Default for Manifold {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl Manifold {
     // ── Construction from raw mesh data ─────────────────────────────
 
@@ -94,52 +100,37 @@ impl Manifold {
     ///
     /// # Errors
     ///
-    /// Returns `CsgError::InvalidInput` if `n_props < 3`,
-    /// `CsgError::EmptyMesh` if no triangles, or `CsgError::ManifoldStatus`
-    /// if the mesh is invalid.
+    /// Returns `CsgError::InvalidInput` if the mesh buffers have invalid
+    /// shape, or `CsgError::ManifoldStatus` if the mesh is invalid.
     pub fn from_mesh_f64(
         vert_props: &[f64],
         n_props: usize,
         tri_indices: &[u64],
     ) -> Result<Self, CsgError> {
-        if tri_indices.is_empty() {
-            return Err(CsgError::EmptyMesh);
-        }
-        if n_props < 3 {
-            return Err(CsgError::InvalidInput(
-                "n_props must be >= 3 (x, y, z)".into(),
-            ));
-        }
-        let n_verts = vert_props.len() / n_props;
-        let n_tris = tri_indices.len() / 3;
+        let meshgl = MeshGL64::new(vert_props, n_props, tri_indices)?;
+        Self::from_meshgl64(&meshgl)
+    }
 
-        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
-        let meshgl = unsafe { manifold_alloc_meshgl64() };
-        // SAFETY: meshgl is valid. vert_props and tri_indices are valid slices.
-        unsafe {
-            manifold_meshgl64(
-                meshgl,
-                vert_props.as_ptr(),
-                n_verts,
-                n_props,
-                tri_indices.as_ptr(),
-                n_tris,
-            );
-        }
-
+    /// Create a Manifold from a [`MeshGL64`] container.
+    ///
+    /// Use this when the mesh was constructed with metadata via
+    /// [`MeshGL64::new_with_options`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `CsgError::ManifoldStatus` if the mesh is invalid.
+    pub fn from_meshgl64(meshgl: &MeshGL64) -> Result<Self, CsgError> {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let manifold = unsafe { manifold_alloc_manifold() };
         // SAFETY: manifold and meshgl are valid handles.
-        unsafe { manifold_of_meshgl64(manifold, meshgl) };
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl64(meshgl) };
+        unsafe { manifold_of_meshgl64(manifold, meshgl.ptr) };
 
         // SAFETY: manifold is valid. Read-only status query.
         let status = unsafe { manifold_status(manifold) };
-        if status != ManifoldError::NoError {
+        if let Err(err) = CsgError::from_status(status) {
             // SAFETY: manifold is valid. Frees the allocation on error path.
             unsafe { manifold_delete_manifold(manifold) };
-            return Err(CsgError::ManifoldStatus(status));
+            return Err(err);
         }
 
         Ok(Self { ptr: manifold })
@@ -154,44 +145,30 @@ impl Manifold {
         n_props: usize,
         tri_indices: &[u32],
     ) -> Result<Self, CsgError> {
-        if tri_indices.is_empty() {
-            return Err(CsgError::EmptyMesh);
-        }
-        if n_props < 3 {
-            return Err(CsgError::InvalidInput(
-                "n_props must be >= 3 (x, y, z)".into(),
-            ));
-        }
-        let n_verts = vert_props.len() / n_props;
-        let n_tris = tri_indices.len() / 3;
+        let meshgl = MeshGL::new(vert_props, n_props, tri_indices)?;
+        Self::from_meshgl(&meshgl)
+    }
 
-        // SAFETY: manifold_alloc_meshgl returns a valid handle.
-        let meshgl = unsafe { manifold_alloc_meshgl() };
-        // SAFETY: meshgl is valid. vert_props and tri_indices are valid slices.
-        unsafe {
-            manifold_meshgl(
-                meshgl,
-                vert_props.as_ptr(),
-                n_verts,
-                n_props,
-                tri_indices.as_ptr(),
-                n_tris,
-            );
-        }
-
+    /// Create a Manifold from a [`MeshGL`] container.
+    ///
+    /// Use this when the mesh was constructed with metadata via
+    /// [`MeshGL::new_with_options`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `CsgError::ManifoldStatus` if the mesh is invalid.
+    pub fn from_meshgl(meshgl: &MeshGL) -> Result<Self, CsgError> {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let manifold = unsafe { manifold_alloc_manifold() };
         // SAFETY: manifold and meshgl are valid handles.
-        unsafe { manifold_of_meshgl(manifold, meshgl) };
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl(meshgl) };
+        unsafe { manifold_of_meshgl(manifold, meshgl.ptr) };
 
         // SAFETY: manifold is valid. Read-only status query.
         let status = unsafe { manifold_status(manifold) };
-        if status != ManifoldError::NoError {
+        if let Err(err) = CsgError::from_status(status) {
             // SAFETY: manifold is valid. Frees the allocation on error path.
             unsafe { manifold_delete_manifold(manifold) };
-            return Err(CsgError::ManifoldStatus(status));
+            return Err(err);
         }
 
         Ok(Self { ptr: manifold })
@@ -220,22 +197,7 @@ impl Manifold {
             ));
         }
 
-        let n_verts = vert_props.len() / n_props;
-        let n_tris = tri_indices.len() / 3;
-
-        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
-        let meshgl = unsafe { manifold_alloc_meshgl64() };
-        // SAFETY: meshgl valid, slices valid with correct lengths.
-        unsafe {
-            manifold_meshgl64(
-                meshgl,
-                vert_props.as_ptr(),
-                n_verts,
-                n_props,
-                tri_indices.as_ptr(),
-                n_tris,
-            );
-        }
+        let meshgl = MeshGL64::new(vert_props, n_props, tri_indices)?;
 
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let manifold = unsafe { manifold_alloc_manifold() };
@@ -243,21 +205,19 @@ impl Manifold {
         unsafe {
             manifold_smooth64(
                 manifold,
-                meshgl,
+                meshgl.ptr,
                 half_edges.as_ptr(),
                 smoothness.as_ptr(),
                 half_edges.len(),
             );
         }
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl64(meshgl) };
 
         // SAFETY: manifold is valid. Read-only status query.
         let status = unsafe { manifold_status(manifold) };
-        if status != ManifoldError::NoError {
+        if let Err(err) = CsgError::from_status(status) {
             // SAFETY: manifold is valid. Frees the allocation on error path.
             unsafe { manifold_delete_manifold(manifold) };
-            return Err(CsgError::ManifoldStatus(status));
+            return Err(err);
         }
 
         Ok(Self { ptr: manifold })
@@ -279,22 +239,7 @@ impl Manifold {
             ));
         }
 
-        let n_verts = vert_props.len() / n_props;
-        let n_tris = tri_indices.len() / 3;
-
-        // SAFETY: manifold_alloc_meshgl returns a valid handle.
-        let meshgl = unsafe { manifold_alloc_meshgl() };
-        // SAFETY: meshgl valid, slices valid with correct lengths.
-        unsafe {
-            manifold_meshgl(
-                meshgl,
-                vert_props.as_ptr(),
-                n_verts,
-                n_props,
-                tri_indices.as_ptr(),
-                n_tris,
-            );
-        }
+        let meshgl = MeshGL::new(vert_props, n_props, tri_indices)?;
 
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let manifold = unsafe { manifold_alloc_manifold() };
@@ -302,21 +247,19 @@ impl Manifold {
         unsafe {
             manifold_smooth(
                 manifold,
-                meshgl,
+                meshgl.ptr,
                 half_edges.as_ptr(),
                 smoothness.as_ptr(),
                 half_edges.len(),
             );
         }
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl(meshgl) };
 
         // SAFETY: manifold is valid. Read-only status query.
         let status = unsafe { manifold_status(manifold) };
-        if status != ManifoldError::NoError {
+        if let Err(err) = CsgError::from_status(status) {
             // SAFETY: manifold is valid. Frees the allocation on error path.
             unsafe { manifold_delete_manifold(manifold) };
-            return Err(CsgError::ManifoldStatus(status));
+            return Err(err);
         }
 
         Ok(Self { ptr: manifold })
@@ -324,35 +267,44 @@ impl Manifold {
 
     /// Extract mesh data as f64 vertex properties and u64 triangle indices.
     ///
-    /// Returns `(vert_props, n_props, tri_indices)`.
+    /// Returns the full [`MeshGL64`] container, including run metadata, face
+    /// IDs, merge vectors, and tangents when present.
     #[must_use]
-    pub fn to_mesh_f64(&self) -> (Vec<f64>, usize, Vec<u64>) {
+    pub fn to_meshgl64(&self) -> MeshGL64 {
         // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
         let meshgl = unsafe { manifold_alloc_meshgl64() };
         // SAFETY: self.ptr and meshgl are valid handles.
         unsafe { manifold_get_meshgl64(meshgl, self.ptr) };
 
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_verts = unsafe { manifold_meshgl64_num_vert(meshgl) };
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_tris = unsafe { manifold_meshgl64_num_tri(meshgl) };
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_props = unsafe { manifold_meshgl64_num_prop(meshgl) };
+        MeshGL64 { ptr: meshgl }
+    }
 
-        // SAFETY: meshgl is valid. Returns total element count.
-        let vp_len = unsafe { manifold_meshgl64_vert_properties_length(meshgl) };
-        let mut vp_buf = vec![0.0f64; vp_len];
-        // SAFETY: vp_buf has capacity vp_len.
-        unsafe { manifold_meshgl64_vert_properties(vp_buf.as_mut_ptr(), meshgl) };
+    /// Extract mesh data as f64 with normals baked into vertex properties.
+    ///
+    /// Returns the full [`MeshGL64`] container. See
+    /// [`to_mesh_f64_with_normals`](Self::to_mesh_f64_with_normals) for the
+    /// `normal_idx` semantics.
+    #[must_use]
+    pub fn to_meshgl64_with_normals(&self, normal_idx: i32) -> MeshGL64 {
+        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
+        let meshgl = unsafe { manifold_alloc_meshgl64() };
+        // SAFETY: self.ptr and meshgl are valid handles.
+        unsafe { manifold_get_meshgl64_w_normals(meshgl, self.ptr, normal_idx) };
 
-        // SAFETY: meshgl is valid. Returns total element count.
-        let tri_len = unsafe { manifold_meshgl64_tri_length(meshgl) };
-        let mut tri_buf = vec![0u64; tri_len];
-        // SAFETY: tri_buf has capacity tri_len.
-        unsafe { manifold_meshgl64_tri_verts(tri_buf.as_mut_ptr(), meshgl) };
+        MeshGL64 { ptr: meshgl }
+    }
 
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl64(meshgl) };
+    /// Extract mesh data as f64 vertex properties and u64 triangle indices.
+    ///
+    /// Returns `(vert_props, n_props, tri_indices)`.
+    #[must_use]
+    pub fn to_mesh_f64(&self) -> (Vec<f64>, usize, Vec<u64>) {
+        let meshgl = self.to_meshgl64();
+        let n_verts = meshgl.num_vert();
+        let n_tris = meshgl.num_tri();
+        let n_props = meshgl.num_prop();
+        let vp_buf = meshgl.vert_properties();
+        let tri_buf = meshgl.tri_verts();
 
         debug_assert_eq!(vp_buf.len(), n_verts * n_props);
         debug_assert_eq!(tri_buf.len(), n_tris * 3);
@@ -369,29 +321,9 @@ impl Manifold {
     /// Returns `(vert_props, n_props, tri_indices)`.
     #[must_use]
     pub fn to_mesh_f64_with_normals(&self, normal_idx: i32) -> (Vec<f64>, usize, Vec<u64>) {
-        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
-        let meshgl = unsafe { manifold_alloc_meshgl64() };
-        // SAFETY: self.ptr and meshgl are valid handles.
-        unsafe { manifold_get_meshgl64_w_normals(meshgl, self.ptr, normal_idx) };
-
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_props = unsafe { manifold_meshgl64_num_prop(meshgl) };
-        // SAFETY: meshgl is valid. Returns total element count.
-        let vp_len = unsafe { manifold_meshgl64_vert_properties_length(meshgl) };
-        let mut vp_buf = vec![0.0f64; vp_len];
-        // SAFETY: vp_buf has capacity vp_len.
-        unsafe { manifold_meshgl64_vert_properties(vp_buf.as_mut_ptr(), meshgl) };
-
-        // SAFETY: meshgl is valid. Returns total element count.
-        let tri_len = unsafe { manifold_meshgl64_tri_length(meshgl) };
-        let mut tri_buf = vec![0u64; tri_len];
-        // SAFETY: tri_buf has capacity tri_len.
-        unsafe { manifold_meshgl64_tri_verts(tri_buf.as_mut_ptr(), meshgl) };
-
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl64(meshgl) };
-
-        (vp_buf, n_props, tri_buf)
+        let meshgl = self.to_meshgl64_with_normals(normal_idx);
+        let n_props = meshgl.num_prop();
+        (meshgl.vert_properties(), n_props, meshgl.tri_verts())
     }
 
     /// Extract mesh data as f32 with normals baked into vertex properties.
@@ -399,29 +331,38 @@ impl Manifold {
     /// See [`to_mesh_f64_with_normals`](Self::to_mesh_f64_with_normals) for details.
     #[must_use]
     pub fn to_mesh_f32_with_normals(&self, normal_idx: i32) -> (Vec<f32>, usize, Vec<u32>) {
+        let meshgl = self.to_meshgl_with_normals(normal_idx);
+        let n_props = meshgl.num_prop();
+        (meshgl.vert_properties(), n_props, meshgl.tri_verts())
+    }
+
+    /// Extract mesh data as f32 vertex properties and u32 triangle indices.
+    ///
+    /// Returns the full [`MeshGL`] container, including run metadata, face IDs,
+    /// merge vectors, and tangents when present.
+    #[must_use]
+    pub fn to_meshgl(&self) -> MeshGL {
+        // SAFETY: manifold_alloc_meshgl returns a valid handle.
+        let meshgl = unsafe { manifold_alloc_meshgl() };
+        // SAFETY: self.ptr and meshgl are valid handles.
+        unsafe { manifold_get_meshgl(meshgl, self.ptr) };
+
+        MeshGL { ptr: meshgl }
+    }
+
+    /// Extract mesh data as f32 with normals baked into vertex properties.
+    ///
+    /// Returns the full [`MeshGL`] container. See
+    /// [`to_mesh_f64_with_normals`](Self::to_mesh_f64_with_normals) for the
+    /// `normal_idx` semantics.
+    #[must_use]
+    pub fn to_meshgl_with_normals(&self, normal_idx: i32) -> MeshGL {
         // SAFETY: manifold_alloc_meshgl returns a valid handle.
         let meshgl = unsafe { manifold_alloc_meshgl() };
         // SAFETY: self.ptr and meshgl are valid handles.
         unsafe { manifold_get_meshgl_w_normals(meshgl, self.ptr, normal_idx) };
 
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_props = unsafe { manifold_meshgl_num_prop(meshgl) };
-        // SAFETY: meshgl is valid. Returns total element count.
-        let vp_len = unsafe { manifold_meshgl_vert_properties_length(meshgl) };
-        let mut vp_buf = vec![0.0f32; vp_len];
-        // SAFETY: vp_buf has capacity vp_len.
-        unsafe { manifold_meshgl_vert_properties(vp_buf.as_mut_ptr(), meshgl) };
-
-        // SAFETY: meshgl is valid. Returns total element count.
-        let tri_len = unsafe { manifold_meshgl_tri_length(meshgl) };
-        let mut tri_buf = vec![0u32; tri_len];
-        // SAFETY: tri_buf has capacity tri_len.
-        unsafe { manifold_meshgl_tri_verts(tri_buf.as_mut_ptr(), meshgl) };
-
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl(meshgl) };
-
-        (vp_buf, n_props, tri_buf)
+        MeshGL { ptr: meshgl }
     }
 
     /// Extract mesh data as f32 vertex properties and u32 triangle indices.
@@ -429,32 +370,12 @@ impl Manifold {
     /// Returns `(vert_props, n_props, tri_indices)`.
     #[must_use]
     pub fn to_mesh_f32(&self) -> (Vec<f32>, usize, Vec<u32>) {
-        // SAFETY: manifold_alloc_meshgl returns a valid handle.
-        let meshgl = unsafe { manifold_alloc_meshgl() };
-        // SAFETY: self.ptr and meshgl are valid handles.
-        unsafe { manifold_get_meshgl(meshgl, self.ptr) };
-
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_verts = unsafe { manifold_meshgl_num_vert(meshgl) };
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_tris = unsafe { manifold_meshgl_num_tri(meshgl) };
-        // SAFETY: meshgl is valid. Read-only query.
-        let n_props = unsafe { manifold_meshgl_num_prop(meshgl) };
-
-        // SAFETY: meshgl is valid. Returns total element count.
-        let vp_len = unsafe { manifold_meshgl_vert_properties_length(meshgl) };
-        let mut vp_buf = vec![0.0f32; vp_len];
-        // SAFETY: vp_buf has capacity vp_len.
-        unsafe { manifold_meshgl_vert_properties(vp_buf.as_mut_ptr(), meshgl) };
-
-        // SAFETY: meshgl is valid. Returns total element count.
-        let tri_len = unsafe { manifold_meshgl_tri_length(meshgl) };
-        let mut tri_buf = vec![0u32; tri_len];
-        // SAFETY: tri_buf has capacity tri_len.
-        unsafe { manifold_meshgl_tri_verts(tri_buf.as_mut_ptr(), meshgl) };
-
-        // SAFETY: meshgl is valid and no longer needed.
-        unsafe { manifold_delete_meshgl(meshgl) };
+        let meshgl = self.to_meshgl();
+        let n_verts = meshgl.num_vert();
+        let n_tris = meshgl.num_tri();
+        let n_props = meshgl.num_prop();
+        let vp_buf = meshgl.vert_properties();
+        let tri_buf = meshgl.tri_verts();
 
         debug_assert_eq!(vp_buf.len(), n_verts * n_props);
         debug_assert_eq!(tri_buf.len(), n_tris * 3);
@@ -491,17 +412,19 @@ impl Manifold {
     ) -> Self {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
-        // SAFETY: ptr is valid from alloc.
-        unsafe {
-            manifold_cylinder(
-                ptr,
-                height,
-                radius_low,
-                radius_high,
-                segments,
-                i32::from(center),
-            )
-        };
+        with_quality_lock_if_auto_segments(segments, || {
+            // SAFETY: ptr is valid from alloc.
+            unsafe {
+                manifold_cylinder(
+                    ptr,
+                    height,
+                    radius_low,
+                    radius_high,
+                    segments,
+                    i32::from(center),
+                )
+            };
+        });
         Self { ptr }
     }
 
@@ -510,8 +433,10 @@ impl Manifold {
     pub fn sphere(radius: f64, segments: i32) -> Self {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
-        // SAFETY: ptr is valid from alloc.
-        unsafe { manifold_sphere(ptr, radius, segments) };
+        with_quality_lock_if_auto_segments(segments, || {
+            // SAFETY: ptr is valid from alloc.
+            unsafe { manifold_sphere(ptr, radius, segments) };
+        });
         Self { ptr }
     }
 
@@ -650,7 +575,7 @@ impl Manifold {
         let cs_ptr = unsafe { manifold_alloc_cross_section() };
         // SAFETY: cs_ptr and poly_ptr are valid.
         unsafe {
-            manifold_cross_section_of_polygons(cs_ptr, poly_ptr, ManifoldFillRule::EvenOdd);
+            manifold_cross_section_of_polygons(cs_ptr, poly_ptr, ManifoldFillRule::Positive);
         }
 
         // SAFETY: poly_ptr is valid and no longer needed.
@@ -685,16 +610,16 @@ impl Manifold {
     /// Batch union: combine multiple manifolds in a single operation.
     #[must_use]
     pub fn batch_union(manifolds: &[Self]) -> Self {
-        Self::batch_boolean(manifolds, ManifoldOpType::Add)
+        Self::batch_boolean(manifolds, OpType::Add)
     }
 
     /// Batch difference: subtract all subsequent manifolds from the first.
     #[must_use]
     pub fn batch_difference(manifolds: &[Self]) -> Self {
-        Self::batch_boolean(manifolds, ManifoldOpType::Subtract)
+        Self::batch_boolean(manifolds, OpType::Subtract)
     }
 
-    fn batch_boolean(manifolds: &[Self], op: ManifoldOpType) -> Self {
+    fn batch_boolean(manifolds: &[Self], op: OpType) -> Self {
         if manifolds.is_empty() {
             return Self::empty();
         }
@@ -719,7 +644,7 @@ impl Manifold {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let result_ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: result_ptr and vec_ptr are valid.
-        unsafe { manifold_batch_boolean(result_ptr, vec_ptr, op) };
+        unsafe { manifold_batch_boolean(result_ptr, vec_ptr, op.to_ffi()) };
 
         // SAFETY: vec_ptr is valid and no longer needed.
         unsafe { manifold_delete_manifold_vec(vec_ptr) };
@@ -789,11 +714,6 @@ impl Manifold {
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: all three pointers are valid.
         unsafe { manifold_difference(ptr, self.ptr, other.ptr) };
-        // SAFETY: ptr is valid.
-        let status = unsafe { manifold_status(ptr) };
-        if status != ManifoldError::NoError {
-            log::warn!("CSG difference produced error status: {status:?}");
-        }
         Self { ptr }
     }
 
@@ -804,11 +724,6 @@ impl Manifold {
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: all three pointers are valid.
         unsafe { manifold_union(ptr, self.ptr, other.ptr) };
-        // SAFETY: ptr is valid.
-        let status = unsafe { manifold_status(ptr) };
-        if status != ManifoldError::NoError {
-            log::warn!("CSG union produced error status: {status:?}");
-        }
         Self { ptr }
     }
 
@@ -819,11 +734,6 @@ impl Manifold {
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: all three pointers are valid.
         unsafe { manifold_intersection(ptr, self.ptr, other.ptr) };
-        // SAFETY: ptr is valid.
-        let status = unsafe { manifold_status(ptr) };
-        if status != ManifoldError::NoError {
-            log::warn!("CSG intersection produced error status: {status:?}");
-        }
         Self { ptr }
     }
 
@@ -834,11 +744,11 @@ impl Manifold {
     /// or operator overloads (`+`, `-`, `^`) for readability. This method
     /// is useful when the operation type is determined at runtime.
     #[must_use]
-    pub fn boolean(&self, other: &Self, op: ManifoldOpType) -> Self {
+    pub fn boolean(&self, other: &Self, op: OpType) -> Self {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: all three pointers are valid.
-        unsafe { manifold_boolean(ptr, self.ptr, other.ptr, op) };
+        unsafe { manifold_boolean(ptr, self.ptr, other.ptr, op.to_ffi()) };
         Self { ptr }
     }
 
@@ -1040,8 +950,10 @@ impl Manifold {
         unsafe { manifold_cross_section_to_polygons(poly_ptr, cross_section.ptr) };
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
-        // SAFETY: ptr is valid from alloc, poly_ptr is valid.
-        unsafe { manifold_revolve(ptr, poly_ptr, circular_segments, revolve_degrees) };
+        with_quality_lock_if_auto_segments(circular_segments, || {
+            // SAFETY: ptr is valid from alloc, poly_ptr is valid.
+            unsafe { manifold_revolve(ptr, poly_ptr, circular_segments, revolve_degrees) };
+        });
         // SAFETY: poly_ptr is valid and no longer needed.
         unsafe { manifold_delete_polygons(poly_ptr) };
         Self { ptr }
@@ -1226,15 +1138,14 @@ impl Manifold {
 
     // ── Cancellable evaluation ──────────────────────────────────────
 
-    /// Force evaluation of this manifold's lazy CSG tree and return the
-    /// result status.
+    /// Force evaluation of this manifold's lazy CSG tree.
     ///
     /// Manifold operations are lazy: building a CSG tree is cheap and
     /// synchronous; the actual evaluation happens when something queries
     /// the result. Most queries (`num_tri`, mesh extraction, volume,
-    /// etc.) also force evaluation as a side effect, so this method is
-    /// rarely needed standalone. Its main use is checking evaluation
-    /// status under an attached [`ExecutionContext`](crate::ExecutionContext)
+    /// etc.) also force evaluation as a side effect, but not all of them
+    /// observe an attached [`ExecutionContext`](crate::ExecutionContext).
+    /// This method is the primary way to force evaluation under a context
     /// without consuming a property.
     ///
     /// To run the evaluation under a cancellable
@@ -1245,18 +1156,26 @@ impl Manifold {
     /// # use manifold_csg::{ExecutionContext, Manifold};
     /// # let manifold = Manifold::cube(1.0, 1.0, 1.0, true);
     /// let ctx = ExecutionContext::new();
-    /// let status = manifold.with_context(&ctx).status();
-    /// # let _ = status;
+    /// manifold.with_context(&ctx).status()?;
+    /// # Ok::<(), manifold_csg::CsgError>(())
     /// ```
+    pub fn status(&self) -> Result<(), CsgError> {
+        CsgError::from_status(self.raw_status())
+    }
+
+    /// Force evaluation of this manifold's lazy CSG tree and return the raw
+    /// manifold3d status code.
+    ///
+    /// Prefer [`status`](Self::status) when you only need success/failure.
     #[must_use]
-    pub fn status(&self) -> manifold_csg_sys::ManifoldError {
+    pub fn raw_status(&self) -> manifold_csg_sys::ManifoldError {
         // SAFETY: self.ptr is a valid handle.
         unsafe { manifold_status(self.ptr) }
     }
 
-    /// Return a copy of this manifold with `ctx` attached. The next
-    /// eager op (such as [`status`](Self::status), `refine*`, mesh
-    /// extraction) on the returned value observes `ctx`. Deferred ops
+    /// Return a copy of this manifold with `ctx` attached. The next eager op
+    /// that consumes an execution context (such as [`status`](Self::status)
+    /// or `refine*`) on the returned value observes `ctx`. Deferred ops
     /// (booleans, transforms, batch ops) ignore the attached context
     /// and produce results with no attached context.
     ///
@@ -1280,8 +1199,8 @@ impl Manifold {
     ///     // ctx drops here; `attached` still holds the inner state
     ///     // via shared_ptr, so the eager op below is safe.
     /// };
-    /// let status = attached.status();
-    /// # let _ = status;
+    /// attached.status()?;
+    /// # Ok::<(), manifold_csg::CsgError>(())
     /// ```
     #[must_use]
     pub fn with_context(&self, ctx: &crate::ExecutionContext) -> Self {
@@ -1363,6 +1282,11 @@ impl Manifold {
     where
         F: FnMut(f64, f64, f64) -> [f64; 3],
     {
+        struct Context<'a, F> {
+            f: &'a mut F,
+            panic: Mutex<Option<PanicPayload>>,
+        }
+
         unsafe extern "C" fn trampoline<F>(
             x: f64,
             y: f64,
@@ -1373,10 +1297,10 @@ impl Manifold {
             F: FnMut(f64, f64, f64) -> [f64; 3],
         {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                // SAFETY: ctx was created from a &mut F below and is valid for
-                // the duration of the manifold_warp call.
-                let f = unsafe { &mut *(ctx as *mut F) };
-                f(x, y, z)
+                // SAFETY: ctx was created from a &mut Context below and is valid
+                // for the duration of the manifold_warp call.
+                let ctx = unsafe { &mut *(ctx as *mut Context<'_, F>) };
+                (ctx.f)(x, y, z)
             }));
             match result {
                 Ok([rx, ry, rz]) => ManifoldVec3 {
@@ -1384,18 +1308,34 @@ impl Manifold {
                     y: ry,
                     z: rz,
                 },
-                // Return the original point on panic to avoid UB from unwinding through C.
-                Err(_) => ManifoldVec3 { x, y, z },
+                Err(payload) => {
+                    // Return the original point to avoid UB from unwinding
+                    // through C, then resume the panic after the FFI call.
+                    // SAFETY: ctx was created from a &mut Context below and is
+                    // valid for the duration of the manifold_warp call.
+                    let ctx = unsafe { &*(ctx as *const Context<'_, F>) };
+                    store_panic(&ctx.panic, payload);
+                    ManifoldVec3 { x, y, z }
+                }
             }
         }
 
         let mut closure = f;
-        let ctx = &mut closure as *mut F as *mut std::ffi::c_void;
+        let mut ctx = Context {
+            f: &mut closure,
+            panic: Mutex::new(None),
+        };
+        let ctx_ptr = &mut ctx as *mut Context<'_, F> as *mut std::ffi::c_void;
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
         // SAFETY: ptr is valid from alloc, self.ptr is valid (invariant).
         // The trampoline and ctx are valid for the duration of this call.
-        unsafe { manifold_warp(ptr, self.ptr, Some(trampoline::<F>), ctx) };
+        unsafe { manifold_warp(ptr, self.ptr, Some(trampoline::<F>), ctx_ptr) };
+        if let Some(payload) = take_stored_panic(&ctx.panic) {
+            // SAFETY: ptr was allocated above and will not be returned.
+            unsafe { manifold_delete_manifold(ptr) };
+            std::panic::resume_unwind(payload);
+        }
         Self { ptr }
     }
 
@@ -1423,6 +1363,7 @@ impl Manifold {
             f: &'a mut F,
             old_num_prop: usize,
             new_num_prop: usize,
+            panic: Mutex<Option<PanicPayload>>,
         }
 
         unsafe extern "C" fn trampoline<F>(
@@ -1434,10 +1375,10 @@ impl Manifold {
             F: FnMut(&mut [f64], [f64; 3], &[f64]),
         {
             // Catch panics to prevent UB from unwinding through C stack frames.
-            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                // SAFETY: ctx was created from a &mut Context below and is valid
-                // for the duration of the manifold_set_properties call.
-                let ctx = unsafe { &mut *(ctx as *mut Context<'_, F>) };
+            // SAFETY: ctx was created from a &mut Context below and is valid
+            // for the duration of the manifold_set_properties call.
+            let ctx = unsafe { &mut *(ctx as *mut Context<'_, F>) };
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let pos = [position.x, position.y, position.z];
                 // SAFETY: new_prop has ctx.new_num_prop elements (guaranteed by C API).
                 let new_slice =
@@ -1455,12 +1396,16 @@ impl Manifold {
                 };
                 (ctx.f)(new_slice, pos, old_slice);
             }));
+            if let Err(payload) = result {
+                store_panic(&ctx.panic, payload);
+            }
         }
 
         let mut ctx = Context {
             f: &mut f,
             old_num_prop,
             new_num_prop,
+            panic: Mutex::new(None),
         };
         let ctx_ptr = &mut ctx as *mut Context<'_, F> as *mut std::ffi::c_void;
         // SAFETY: manifold_alloc_manifold returns a valid handle.
@@ -1476,6 +1421,11 @@ impl Manifold {
                 ctx_ptr,
             )
         };
+        if let Some(payload) = take_stored_panic(&ctx.panic) {
+            // SAFETY: ptr was allocated above and will not be returned.
+            unsafe { manifold_delete_manifold(ptr) };
+            std::panic::resume_unwind(payload);
+        }
         Self { ptr }
     }
 
@@ -1500,10 +1450,10 @@ impl Manifold {
         unsafe { manifold_read_obj(ptr, c_str.as_ptr()) };
         // SAFETY: ptr is valid. Read-only status query.
         let status = unsafe { manifold_status(ptr) };
-        if status != ManifoldError::NoError {
+        if let Err(err) = CsgError::from_status(status) {
             // SAFETY: ptr is valid. Frees on error path.
             unsafe { manifold_delete_manifold(ptr) };
-            return Err(CsgError::ManifoldStatus(status));
+            return Err(err);
         }
         Ok(Self { ptr })
     }
@@ -1553,6 +1503,11 @@ impl Manifold {
     where
         F: Fn(f64, f64, f64) -> f64 + Sync,
     {
+        struct Context<'a, F> {
+            f: &'a F,
+            panic: Mutex<Option<PanicPayload>>,
+        }
+
         unsafe extern "C" fn trampoline<F>(
             x: f64,
             y: f64,
@@ -1564,16 +1519,30 @@ impl Manifold {
         {
             // Catch panics to prevent UB from unwinding through C stack frames.
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                // SAFETY: ctx points to an F that is Sync, so shared access
-                // from multiple C threads is sound.
-                let f = unsafe { &*(ctx as *const F) };
-                f(x, y, z)
+                // SAFETY: ctx points to a Context with an F that is Sync, so
+                // shared access from multiple C threads is sound.
+                let ctx = unsafe { &*(ctx as *const Context<'_, F>) };
+                (ctx.f)(x, y, z)
             }));
-            // Return large positive distance on panic (outside surface).
-            result.unwrap_or(f64::MAX)
+            match result {
+                Ok(distance) => distance,
+                Err(payload) => {
+                    // Return large positive distance to avoid UB from
+                    // unwinding through C, then resume after the FFI call.
+                    // SAFETY: ctx points to a Context that remains valid for
+                    // the duration of the manifold_level_set call.
+                    let ctx = unsafe { &*(ctx as *const Context<'_, F>) };
+                    store_panic(&ctx.panic, payload);
+                    f64::MAX
+                }
+            }
         }
 
-        let ctx = &f as *const F as *mut std::ffi::c_void;
+        let ctx = Context {
+            f: &f,
+            panic: Mutex::new(None),
+        };
+        let ctx_ptr = &ctx as *const Context<'_, F> as *mut std::ffi::c_void;
         // SAFETY: manifold_alloc_box returns a valid handle.
         let box_ptr = unsafe { manifold_alloc_box() };
         // SAFETY: box_ptr is valid from alloc.
@@ -1599,9 +1568,16 @@ impl Manifold {
                 edge_length,
                 level,
                 tolerance,
-                ctx,
+                ctx_ptr,
             )
         };
+        if let Some(payload) = take_stored_panic(&ctx.panic) {
+            // SAFETY: ptr was allocated above and will not be returned.
+            unsafe { manifold_delete_manifold(ptr) };
+            // SAFETY: box_ptr was allocated above and will not be used again.
+            unsafe { manifold_delete_box(box_ptr) };
+            std::panic::resume_unwind(payload);
+        }
         // SAFETY: box_ptr is valid and no longer needed.
         unsafe { manifold_delete_box(box_ptr) };
         Self { ptr }
@@ -1624,6 +1600,11 @@ impl Manifold {
     where
         F: FnMut(f64, f64, f64) -> f64,
     {
+        struct Context<'a, F> {
+            f: &'a mut F,
+            panic: Mutex<Option<PanicPayload>>,
+        }
+
         unsafe extern "C" fn trampoline<F>(
             x: f64,
             y: f64,
@@ -1635,14 +1616,30 @@ impl Manifold {
         {
             // Catch panics to prevent UB from unwinding through C stack frames.
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                // SAFETY: ctx was created from a &mut F and is valid for the call duration.
-                let f = unsafe { &mut *(ctx as *mut F) };
-                f(x, y, z)
+                // SAFETY: ctx was created from a &mut Context and is valid for
+                // the call duration.
+                let ctx = unsafe { &mut *(ctx as *mut Context<'_, F>) };
+                (ctx.f)(x, y, z)
             }));
-            result.unwrap_or(f64::MAX)
+            match result {
+                Ok(distance) => distance,
+                Err(payload) => {
+                    // Return large positive distance to avoid UB from
+                    // unwinding through C, then resume after the FFI call.
+                    // SAFETY: ctx was created from a &mut Context below and is
+                    // valid for the duration of the manifold_level_set_seq call.
+                    let ctx = unsafe { &*(ctx as *const Context<'_, F>) };
+                    store_panic(&ctx.panic, payload);
+                    f64::MAX
+                }
+            }
         }
 
-        let ctx = &mut f as *mut F as *mut std::ffi::c_void;
+        let mut ctx = Context {
+            f: &mut f,
+            panic: Mutex::new(None),
+        };
+        let ctx_ptr = &mut ctx as *mut Context<'_, F> as *mut std::ffi::c_void;
         // SAFETY: manifold_alloc_box returns a valid handle.
         let box_ptr = unsafe { manifold_alloc_box() };
         // SAFETY: box_ptr is valid from alloc.
@@ -1668,9 +1665,16 @@ impl Manifold {
                 edge_length,
                 level,
                 tolerance,
-                ctx,
+                ctx_ptr,
             )
         };
+        if let Some(payload) = take_stored_panic(&ctx.panic) {
+            // SAFETY: ptr was allocated above and will not be returned.
+            unsafe { manifold_delete_manifold(ptr) };
+            // SAFETY: box_ptr was allocated above and will not be used again.
+            unsafe { manifold_delete_box(box_ptr) };
+            std::panic::resume_unwind(payload);
+        }
         // SAFETY: box_ptr is valid and no longer needed.
         unsafe { manifold_delete_box(box_ptr) };
         Self { ptr }
@@ -1810,18 +1814,32 @@ impl Manifold {
 
 // ── Quality globals ─────────────────────────────────────────────────────
 
-/// Guard for global quality setters. The C API's global state is not
+/// Guard for global quality parameters. The C API's global state is not
 /// thread-safe, so we serialize access from the Rust side.
 static QUALITY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+pub(crate) fn with_quality_lock<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    f()
+}
+
+pub(crate) fn with_quality_lock_if_auto_segments<T>(segments: i32, f: impl FnOnce() -> T) -> T {
+    if segments <= 0 {
+        with_quality_lock(f)
+    } else {
+        f()
+    }
+}
 
 /// Set the minimum circular angle (degrees) for tessellation.
 ///
 /// This modifies global state shared by all manifold operations in the
 /// current process.
 pub fn set_min_circular_angle(degrees: f64) {
-    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
-    unsafe { manifold_set_min_circular_angle(degrees) };
+    with_quality_lock(|| {
+        // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
+        unsafe { manifold_set_min_circular_angle(degrees) };
+    });
 }
 
 /// Set the minimum circular edge length for tessellation.
@@ -1829,9 +1847,10 @@ pub fn set_min_circular_angle(degrees: f64) {
 /// This modifies global state shared by all manifold operations in the
 /// current process.
 pub fn set_min_circular_edge_length(length: f64) {
-    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
-    unsafe { manifold_set_min_circular_edge_length(length) };
+    with_quality_lock(|| {
+        // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
+        unsafe { manifold_set_min_circular_edge_length(length) };
+    });
 }
 
 /// Set the number of circular segments for tessellation.
@@ -1839,9 +1858,10 @@ pub fn set_min_circular_edge_length(length: f64) {
 /// This modifies global state shared by all manifold operations in the
 /// current process.
 pub fn set_circular_segments(number: i32) {
-    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
-    unsafe { manifold_set_circular_segments(number) };
+    with_quality_lock(|| {
+        // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
+        unsafe { manifold_set_circular_segments(number) };
+    });
 }
 
 /// Reset circular tessellation parameters to defaults.
@@ -1849,16 +1869,19 @@ pub fn set_circular_segments(number: i32) {
 /// This modifies global state shared by all manifold operations in the
 /// current process.
 pub fn reset_to_circular_defaults() {
-    let _guard = QUALITY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
-    unsafe { manifold_reset_to_circular_defaults() };
+    with_quality_lock(|| {
+        // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
+        unsafe { manifold_reset_to_circular_defaults() };
+    });
 }
 
 /// Get the number of circular segments for a given radius.
 #[must_use]
 pub fn get_circular_segments(radius: f64) -> i32 {
-    // SAFETY: Pure query with no pointer invariants.
-    unsafe { manifold_get_circular_segments(radius) }
+    with_quality_lock(|| {
+        // SAFETY: Serialized by QUALITY_LOCK. No pointer invariants.
+        unsafe { manifold_get_circular_segments(radius) }
+    })
 }
 
 /// Reserve a block of `n` original IDs for use with manifold tracking.

--- a/crates/manifold-csg/src/mesh.rs
+++ b/crates/manifold-csg/src/mesh.rs
@@ -6,12 +6,113 @@
 
 use manifold_csg_sys::*;
 
+use crate::types::CsgError;
+
+/// Optional metadata for constructing a [`MeshGL`].
+///
+/// Use this when importing mesh data that already has manifold topology
+/// metadata. The current C shim supports run indices/original IDs, merge
+/// vectors, and halfedge tangents. Other upstream `MeshGL` fields can be added
+/// as builder methods later without changing this type's construction pattern.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MeshGLOptions<'a> {
+    runs: Option<(&'a [u32], &'a [u32])>,
+    merge_vertices: Option<(&'a [u32], &'a [u32])>,
+    halfedge_tangents: Option<&'a [f32]>,
+}
+
+impl<'a> MeshGLOptions<'a> {
+    /// Create empty mesh-construction options.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            runs: None,
+            merge_vertices: None,
+            halfedge_tangents: None,
+        }
+    }
+
+    /// Attach triangle run indices and original IDs.
+    ///
+    /// `run_indices` indexes into the flat `tri_verts` array and should be the
+    /// same length as `run_original_ids`, or one longer with a final sentinel.
+    #[must_use]
+    pub const fn runs(mut self, run_indices: &'a [u32], run_original_ids: &'a [u32]) -> Self {
+        self.runs = Some((run_indices, run_original_ids));
+        self
+    }
+
+    /// Attach explicit vertex-merge pairs.
+    #[must_use]
+    pub const fn merge_vertices(mut self, merge_from: &'a [u32], merge_to: &'a [u32]) -> Self {
+        self.merge_vertices = Some((merge_from, merge_to));
+        self
+    }
+
+    /// Attach halfedge tangent data.
+    ///
+    /// The tangent slice must have `num_tri * 3 * 4` elements.
+    #[must_use]
+    pub const fn halfedge_tangents(mut self, halfedge_tangents: &'a [f32]) -> Self {
+        self.halfedge_tangents = Some(halfedge_tangents);
+        self
+    }
+}
+
+/// Optional metadata for constructing a [`MeshGL64`].
+///
+/// This is the f64/u64 counterpart to [`MeshGLOptions`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MeshGL64Options<'a> {
+    runs: Option<(&'a [u64], &'a [u32])>,
+    merge_vertices: Option<(&'a [u64], &'a [u64])>,
+    halfedge_tangents: Option<&'a [f64]>,
+}
+
+impl<'a> MeshGL64Options<'a> {
+    /// Create empty mesh-construction options.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            runs: None,
+            merge_vertices: None,
+            halfedge_tangents: None,
+        }
+    }
+
+    /// Attach triangle run indices and original IDs.
+    ///
+    /// `run_indices` indexes into the flat `tri_verts` array and should be the
+    /// same length as `run_original_ids`, or one longer with a final sentinel.
+    #[must_use]
+    pub const fn runs(mut self, run_indices: &'a [u64], run_original_ids: &'a [u32]) -> Self {
+        self.runs = Some((run_indices, run_original_ids));
+        self
+    }
+
+    /// Attach explicit vertex-merge pairs.
+    #[must_use]
+    pub const fn merge_vertices(mut self, merge_from: &'a [u64], merge_to: &'a [u64]) -> Self {
+        self.merge_vertices = Some((merge_from, merge_to));
+        self
+    }
+
+    /// Attach halfedge tangent data.
+    ///
+    /// The tangent slice must have `num_tri * 3 * 4` elements.
+    #[must_use]
+    pub const fn halfedge_tangents(mut self, halfedge_tangents: &'a [f64]) -> Self {
+        self.halfedge_tangents = Some(halfedge_tangents);
+        self
+    }
+}
+
 /// Safe wrapper around a manifold3d MeshGL object (f32 vertices, u32 indices).
 ///
 /// See the [upstream `MeshGL` docs](https://elalish.github.io/manifold/docs/html/structmanifold_1_1_mesh_g_l_p.html)
 /// for field semantics (run indices, merge vectors, tangents, etc.).
 pub struct MeshGL {
-    ptr: *mut ManifoldMeshGL,
+    pub(crate) ptr: *mut ManifoldMeshGL,
 }
 
 // SAFETY: MeshGL owns its heap allocation with no thread-local state.
@@ -36,21 +137,14 @@ impl MeshGL {
     /// `vert_props` is a flat array with `n_props` values per vertex
     /// (minimum 3 for x, y, z). `tri_indices` has 3 values per triangle.
     ///
-    /// # Panics
+    /// Empty vertex and triangle buffers are valid.
     ///
-    /// Panics if `n_props < 3`, if `vert_props.len()` is not divisible by
-    /// `n_props`, or if `tri_indices.len()` is not divisible by 3.
-    #[must_use]
-    pub fn new(vert_props: &[f32], n_props: usize, tri_indices: &[u32]) -> Self {
-        assert!(n_props >= 3, "n_props must be >= 3");
-        assert!(
-            vert_props.len() % n_props == 0,
-            "vert_props length must be divisible by n_props"
-        );
-        assert!(
-            tri_indices.len() % 3 == 0,
-            "tri_indices length must be divisible by 3"
-        );
+    /// # Errors
+    ///
+    /// Returns [`CsgError::InvalidInput`] if `n_props < 3`, `vert_props` is
+    /// not divisible by `n_props`, or `tri_indices` is not divisible by 3.
+    pub fn new(vert_props: &[f32], n_props: usize, tri_indices: &[u32]) -> Result<Self, CsgError> {
+        validate_mesh_shape(vert_props.len(), n_props, tri_indices.len())?;
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
 
@@ -67,7 +161,7 @@ impl MeshGL {
                 n_tris,
             );
         }
-        Self { ptr }
+        Ok(Self { ptr })
     }
 
     /// Create a MeshGL with halfedge tangent data.
@@ -75,21 +169,20 @@ impl MeshGL {
     /// `halfedge_tangent` must have `num_tri * 3 * 4` elements (4 floats per
     /// halfedge, 3 halfedges per triangle).
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Same as [`new`](Self::new).
-    #[must_use]
+    /// Returns [`CsgError::InvalidInput`] if the mesh buffers are malformed or
+    /// the tangent buffer length is not `num_tri * 3 * 4`.
     pub fn new_with_tangents(
         vert_props: &[f32],
         n_props: usize,
         tri_indices: &[u32],
         halfedge_tangent: &[f32],
-    ) -> Self {
-        assert!(n_props >= 3, "n_props must be >= 3");
-        assert!(vert_props.len() % n_props == 0);
-        assert!(tri_indices.len() % 3 == 0);
+    ) -> Result<Self, CsgError> {
+        validate_mesh_shape(vert_props.len(), n_props, tri_indices.len())?;
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
+        validate_tangent_len(halfedge_tangent.len(), n_tris)?;
 
         // SAFETY: manifold_alloc_meshgl returns a valid handle.
         let ptr = unsafe { manifold_alloc_meshgl() };
@@ -105,7 +198,55 @@ impl MeshGL {
                 halfedge_tangent.as_ptr(),
             );
         }
-        Self { ptr }
+        Ok(Self { ptr })
+    }
+
+    /// Create a MeshGL with optional run, merge, and tangent metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CsgError::InvalidInput`] if the mesh buffers or metadata
+    /// buffers are malformed.
+    pub fn new_with_options(
+        vert_props: &[f32],
+        n_props: usize,
+        tri_indices: &[u32],
+        options: MeshGLOptions<'_>,
+    ) -> Result<Self, CsgError> {
+        validate_mesh_shape(vert_props.len(), n_props, tri_indices.len())?;
+        let n_verts = vert_props.len() / n_props;
+        let n_tris = tri_indices.len() / 3;
+        validate_meshgl_options(n_tris, tri_indices.len(), options)?;
+
+        let (run_indices, run_original_ids) = options.runs.unwrap_or((&[], &[]));
+        let (merge_from, merge_to) = options.merge_vertices.unwrap_or((&[], &[]));
+        let halfedge_tangents = options.halfedge_tangents.unwrap_or(&[]);
+        let sys_options = ManifoldMeshGLOptions {
+            run_indices: slice_ptr(run_indices),
+            run_indices_length: run_indices.len(),
+            run_original_ids: slice_ptr(run_original_ids),
+            run_original_ids_length: run_original_ids.len(),
+            merge_from_vert: slice_ptr(merge_from),
+            merge_to_vert: slice_ptr(merge_to),
+            merge_verts_length: merge_from.len(),
+            halfedge_tangents: slice_ptr(halfedge_tangents),
+        };
+
+        // SAFETY: manifold_alloc_meshgl returns a valid handle.
+        let ptr = unsafe { manifold_alloc_meshgl() };
+        // SAFETY: ptr is valid. All slices outlive the call and were validated.
+        unsafe {
+            manifold_meshgl_w_options(
+                ptr,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+                &sys_options,
+            );
+        }
+        Ok(Self { ptr })
     }
 
     /// Number of vertices.
@@ -285,7 +426,7 @@ impl Clone for MeshGL {
 /// See the [upstream `MeshGL` docs](https://elalish.github.io/manifold/docs/html/structmanifold_1_1_mesh_g_l_p.html)
 /// for field semantics (run indices, merge vectors, tangents, etc.).
 pub struct MeshGL64 {
-    ptr: *mut ManifoldMeshGL64,
+    pub(crate) ptr: *mut ManifoldMeshGL64,
 }
 
 // SAFETY: MeshGL64 owns its heap allocation with no thread-local state.
@@ -307,21 +448,16 @@ impl Drop for MeshGL64 {
 impl MeshGL64 {
     /// Create a MeshGL64 from f64 vertex properties and u64 triangle indices.
     ///
-    /// # Panics
+    /// `vert_props` is a flat array with `n_props` values per vertex
+    /// (minimum 3 for x, y, z). `tri_indices` has 3 values per triangle.
+    /// Empty vertex and triangle buffers are valid.
     ///
-    /// Panics if `n_props < 3`, if `vert_props.len()` is not divisible by
-    /// `n_props`, or if `tri_indices.len()` is not divisible by 3.
-    #[must_use]
-    pub fn new(vert_props: &[f64], n_props: usize, tri_indices: &[u64]) -> Self {
-        assert!(n_props >= 3, "n_props must be >= 3");
-        assert!(
-            vert_props.len() % n_props == 0,
-            "vert_props length must be divisible by n_props"
-        );
-        assert!(
-            tri_indices.len() % 3 == 0,
-            "tri_indices length must be divisible by 3"
-        );
+    /// # Errors
+    ///
+    /// Returns [`CsgError::InvalidInput`] if `n_props < 3`, `vert_props` is
+    /// not divisible by `n_props`, or `tri_indices` is not divisible by 3.
+    pub fn new(vert_props: &[f64], n_props: usize, tri_indices: &[u64]) -> Result<Self, CsgError> {
+        validate_mesh_shape(vert_props.len(), n_props, tri_indices.len())?;
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
 
@@ -338,24 +474,27 @@ impl MeshGL64 {
                 n_tris,
             );
         }
-        Self { ptr }
+        Ok(Self { ptr })
     }
 
     /// Create a MeshGL64 with halfedge tangent data.
     ///
     /// See [`MeshGL::new_with_tangents`] for details.
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CsgError::InvalidInput`] if the mesh buffers are malformed or
+    /// the tangent buffer length is not `num_tri * 3 * 4`.
     pub fn new_with_tangents(
         vert_props: &[f64],
         n_props: usize,
         tri_indices: &[u64],
         halfedge_tangent: &[f64],
-    ) -> Self {
-        assert!(n_props >= 3, "n_props must be >= 3");
-        assert!(vert_props.len() % n_props == 0);
-        assert!(tri_indices.len() % 3 == 0);
+    ) -> Result<Self, CsgError> {
+        validate_mesh_shape(vert_props.len(), n_props, tri_indices.len())?;
         let n_verts = vert_props.len() / n_props;
         let n_tris = tri_indices.len() / 3;
+        validate_tangent_len(halfedge_tangent.len(), n_tris)?;
 
         // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
         let ptr = unsafe { manifold_alloc_meshgl64() };
@@ -371,7 +510,55 @@ impl MeshGL64 {
                 halfedge_tangent.as_ptr(),
             );
         }
-        Self { ptr }
+        Ok(Self { ptr })
+    }
+
+    /// Create a MeshGL64 with optional run, merge, and tangent metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CsgError::InvalidInput`] if the mesh buffers or metadata
+    /// buffers are malformed.
+    pub fn new_with_options(
+        vert_props: &[f64],
+        n_props: usize,
+        tri_indices: &[u64],
+        options: MeshGL64Options<'_>,
+    ) -> Result<Self, CsgError> {
+        validate_mesh_shape(vert_props.len(), n_props, tri_indices.len())?;
+        let n_verts = vert_props.len() / n_props;
+        let n_tris = tri_indices.len() / 3;
+        validate_meshgl64_options(n_tris, tri_indices.len(), options)?;
+
+        let (run_indices, run_original_ids) = options.runs.unwrap_or((&[], &[]));
+        let (merge_from, merge_to) = options.merge_vertices.unwrap_or((&[], &[]));
+        let halfedge_tangents = options.halfedge_tangents.unwrap_or(&[]);
+        let sys_options = ManifoldMeshGL64Options {
+            run_indices: slice_ptr(run_indices),
+            run_indices_length: run_indices.len(),
+            run_original_ids: slice_ptr(run_original_ids),
+            run_original_ids_length: run_original_ids.len(),
+            merge_from_vert: slice_ptr(merge_from),
+            merge_to_vert: slice_ptr(merge_to),
+            merge_verts_length: merge_from.len(),
+            halfedge_tangents: slice_ptr(halfedge_tangents),
+        };
+
+        // SAFETY: manifold_alloc_meshgl64 returns a valid handle.
+        let ptr = unsafe { manifold_alloc_meshgl64() };
+        // SAFETY: ptr is valid. All slices outlive the call and were validated.
+        unsafe {
+            manifold_meshgl64_w_options(
+                ptr,
+                vert_props.as_ptr(),
+                n_verts,
+                n_props,
+                tri_indices.as_ptr(),
+                n_tris,
+                &sys_options,
+            );
+        }
+        Ok(Self { ptr })
     }
 
     /// Number of vertices.
@@ -581,5 +768,146 @@ impl Clone for MeshGL64 {
         // SAFETY: ptr and self.ptr are valid.
         unsafe { manifold_meshgl64_copy(ptr, self.ptr) };
         Self { ptr }
+    }
+}
+
+fn validate_mesh_shape(
+    vert_props_len: usize,
+    n_props: usize,
+    tri_indices_len: usize,
+) -> Result<(), CsgError> {
+    if n_props < 3 {
+        return Err(CsgError::InvalidInput(
+            "n_props must be >= 3 (x, y, z)".into(),
+        ));
+    }
+    if vert_props_len % n_props != 0 {
+        return Err(CsgError::InvalidInput(
+            "vert_props length must be divisible by n_props".into(),
+        ));
+    }
+    if tri_indices_len % 3 != 0 {
+        return Err(CsgError::InvalidInput(
+            "tri_indices length must be divisible by 3".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_tangent_len(tangent_len: usize, n_tris: usize) -> Result<(), CsgError> {
+    let expected = n_tris
+        .checked_mul(3)
+        .and_then(|n| n.checked_mul(4))
+        .ok_or_else(|| CsgError::InvalidInput("tangent length overflow".into()))?;
+    if tangent_len != expected {
+        return Err(CsgError::InvalidInput(format!(
+            "halfedge_tangent length must be num_tri * 3 * 4 ({expected}), got {tangent_len}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_meshgl_options(
+    n_tris: usize,
+    tri_indices_len: usize,
+    options: MeshGLOptions<'_>,
+) -> Result<(), CsgError> {
+    if let Some(tangents) = options.halfedge_tangents {
+        validate_tangent_len(tangents.len(), n_tris)?;
+    }
+    if let Some((run_indices, run_original_ids)) = options.runs {
+        validate_run_metadata(run_indices, run_original_ids.len(), tri_indices_len)?;
+    }
+    if let Some((merge_from, merge_to)) = options.merge_vertices {
+        validate_merge_metadata(merge_from.len(), merge_to.len())?;
+    }
+    Ok(())
+}
+
+fn validate_meshgl64_options(
+    n_tris: usize,
+    tri_indices_len: usize,
+    options: MeshGL64Options<'_>,
+) -> Result<(), CsgError> {
+    if let Some(tangents) = options.halfedge_tangents {
+        validate_tangent_len(tangents.len(), n_tris)?;
+    }
+    if let Some((run_indices, run_original_ids)) = options.runs {
+        validate_run_metadata(run_indices, run_original_ids.len(), tri_indices_len)?;
+    }
+    if let Some((merge_from, merge_to)) = options.merge_vertices {
+        validate_merge_metadata(merge_from.len(), merge_to.len())?;
+    }
+    Ok(())
+}
+
+fn validate_run_metadata<I>(
+    run_indices: &[I],
+    run_original_ids_len: usize,
+    tri_indices_len: usize,
+) -> Result<(), CsgError>
+where
+    I: Copy + Into<u64>,
+{
+    if run_original_ids_len == 0 {
+        return Err(CsgError::InvalidInput(
+            "run metadata requires at least one run_original_id".into(),
+        ));
+    }
+    if run_indices.len() != run_original_ids_len && run_indices.len() != run_original_ids_len + 1 {
+        return Err(CsgError::InvalidInput(
+            "run_indices length must equal run_original_ids length, or be one longer".into(),
+        ));
+    }
+    let Some(first) = run_indices.first() else {
+        return Err(CsgError::InvalidInput(
+            "run metadata requires at least one run_index".into(),
+        ));
+    };
+    if (*first).into() != 0 {
+        return Err(CsgError::InvalidInput("run_indices must start at 0".into()));
+    }
+    let mut previous = (*first).into();
+    for &index in run_indices {
+        let index = index.into();
+        if index % 3 != 0 {
+            return Err(CsgError::InvalidInput(
+                "run_indices values must be divisible by 3".into(),
+            ));
+        }
+        if index > tri_indices_len as u64 {
+            return Err(CsgError::InvalidInput(
+                "run_indices values must not exceed tri_indices length".into(),
+            ));
+        }
+        if index < previous {
+            return Err(CsgError::InvalidInput("run_indices must be sorted".into()));
+        }
+        previous = index;
+    }
+    if run_indices.len() == run_original_ids_len + 1
+        && run_indices.last().copied().map(Into::into) != Some(tri_indices_len as u64)
+    {
+        return Err(CsgError::InvalidInput(
+            "run_indices sentinel must equal tri_indices length".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_merge_metadata(merge_from_len: usize, merge_to_len: usize) -> Result<(), CsgError> {
+    if merge_from_len != merge_to_len {
+        return Err(CsgError::InvalidInput(
+            "merge_from and merge_to must have the same length".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn slice_ptr<T>(slice: &[T]) -> *const T {
+    if slice.is_empty() {
+        std::ptr::null()
+    } else {
+        slice.as_ptr()
     }
 }

--- a/crates/manifold-csg/src/types.rs
+++ b/crates/manifold-csg/src/types.rs
@@ -1,6 +1,11 @@
 //! Common types and error definitions.
 
+use std::sync::Mutex;
+
+use manifold_csg_sys::ManifoldOpType;
+
 /// Errors from manifold3d operations.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum CsgError {
     #[error("manifold3d status: {0:?}")]
@@ -8,7 +13,49 @@ pub enum CsgError {
 
     #[error("invalid input: {0}")]
     InvalidInput(String),
+}
 
-    #[error("empty mesh (no faces)")]
-    EmptyMesh,
+impl CsgError {
+    pub(crate) fn from_status(status: manifold_csg_sys::ManifoldError) -> Result<(), Self> {
+        if status.is_ok() {
+            Ok(())
+        } else {
+            Err(Self::ManifoldStatus(status))
+        }
+    }
+}
+
+/// Boolean operation type for generic manifold and cross-section booleans.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpType {
+    /// Union/addition.
+    Add,
+    /// Difference/subtraction.
+    Subtract,
+    /// Intersection.
+    Intersect,
+}
+
+impl OpType {
+    pub(crate) const fn to_ffi(self) -> ManifoldOpType {
+        match self {
+            Self::Add => ManifoldOpType::Add,
+            Self::Subtract => ManifoldOpType::Subtract,
+            Self::Intersect => ManifoldOpType::Intersect,
+        }
+    }
+}
+
+pub(crate) type PanicPayload = Box<dyn std::any::Any + Send + 'static>;
+
+pub(crate) fn store_panic(slot: &Mutex<Option<PanicPayload>>, payload: PanicPayload) {
+    let mut guard = slot.lock().unwrap_or_else(|e| e.into_inner());
+    if guard.is_none() {
+        *guard = Some(payload);
+    }
+}
+
+pub(crate) fn take_stored_panic(slot: &Mutex<Option<PanicPayload>>) -> Option<PanicPayload> {
+    slot.lock().unwrap_or_else(|e| e.into_inner()).take()
 }

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -1,8 +1,9 @@
 use approx::assert_relative_eq;
 use manifold_csg::{
-    BoundingBox, CrossSection, FillRule, JoinType, Manifold, MeshGL, MeshGL64, OpType, Rect,
-    get_circular_segments, reserve_ids, reset_to_circular_defaults, set_circular_segments,
-    set_min_circular_angle, set_min_circular_edge_length, triangulate_polygons,
+    BoundingBox, CrossSection, FillRule, JoinType, Manifold, MeshGL, MeshGL64, MeshGL64Options,
+    MeshGLOptions, OpType, Rect, get_circular_segments, reserve_ids, reset_to_circular_defaults,
+    set_circular_segments, set_min_circular_angle, set_min_circular_edge_length,
+    triangulate_polygons,
 };
 
 // ── Primitive tests ─────────────────────────────────────────────────────
@@ -182,6 +183,35 @@ fn mesh_f32_round_trip() {
 }
 
 #[test]
+fn to_meshgl_returns_full_mesh_container() {
+    let cube = Manifold::cube(2.0, 3.0, 4.0, true);
+
+    let mesh32 = cube.to_meshgl();
+    let (verts32, n_props32, indices32) = cube.to_mesh_f32();
+    assert_eq!(mesh32.vert_properties(), verts32);
+    assert_eq!(mesh32.num_prop(), n_props32);
+    assert_eq!(mesh32.tri_verts(), indices32);
+
+    let mesh64 = cube.to_meshgl64();
+    let (verts64, n_props64, indices64) = cube.to_mesh_f64();
+    assert_eq!(mesh64.vert_properties(), verts64);
+    assert_eq!(mesh64.num_prop(), n_props64);
+    assert_eq!(mesh64.tri_verts(), indices64);
+
+    let mesh32_normals = cube.to_meshgl_with_normals(3);
+    let (verts32_normals, n_props32_normals, indices32_normals) = cube.to_mesh_f32_with_normals(3);
+    assert_eq!(mesh32_normals.vert_properties(), verts32_normals);
+    assert_eq!(mesh32_normals.num_prop(), n_props32_normals);
+    assert_eq!(mesh32_normals.tri_verts(), indices32_normals);
+
+    let mesh64_normals = cube.to_meshgl64_with_normals(3);
+    let (verts64_normals, n_props64_normals, indices64_normals) = cube.to_mesh_f64_with_normals(3);
+    assert_eq!(mesh64_normals.vert_properties(), verts64_normals);
+    assert_eq!(mesh64_normals.num_prop(), n_props64_normals);
+    assert_eq!(mesh64_normals.tri_verts(), indices64_normals);
+}
+
+#[test]
 fn csg_result_round_trip() {
     let big = Manifold::cube(10.0, 10.0, 10.0, true);
     let small = Manifold::cube(4.0, 4.0, 4.0, true);
@@ -192,9 +222,17 @@ fn csg_result_round_trip() {
 }
 
 #[test]
-fn empty_mesh_returns_error() {
+fn empty_mesh_returns_empty_manifold() {
     let result = Manifold::from_mesh_f64(&[], 3, &[]);
-    assert!(result.is_err());
+    let manifold = result.expect("empty mesh should be valid");
+    assert!(manifold.is_empty());
+    assert!(manifold.status().is_ok());
+}
+
+#[test]
+fn default_values_are_empty() {
+    assert!(Manifold::default().is_empty());
+    assert!(CrossSection::default().is_empty());
 }
 
 // ── Chained operations ──────────────────────────────────────────────────
@@ -621,7 +659,7 @@ fn meshgl_basic() {
     // A single triangle.
     let verts: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
     let indices: Vec<u32> = vec![0, 1, 2];
-    let mesh = MeshGL::new(&verts, 3, &indices);
+    let mesh = MeshGL::new(&verts, 3, &indices).expect("valid MeshGL");
     assert_eq!(mesh.num_vert(), 3);
     assert_eq!(mesh.num_tri(), 1);
     assert_eq!(mesh.num_prop(), 3);
@@ -632,10 +670,170 @@ fn meshgl64_basic() {
     use manifold_csg::MeshGL64;
     let verts: Vec<f64> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
     let indices: Vec<u64> = vec![0, 1, 2];
-    let mesh = MeshGL64::new(&verts, 3, &indices);
+    let mesh = MeshGL64::new(&verts, 3, &indices).expect("valid MeshGL64");
     assert_eq!(mesh.num_vert(), 3);
     assert_eq!(mesh.num_tri(), 1);
     assert_eq!(mesh.num_prop(), 3);
+}
+
+#[test]
+fn meshgl_empty_is_valid() {
+    let mesh = MeshGL::new(&[], 3, &[]).expect("empty MeshGL should be valid");
+    assert_eq!(mesh.num_vert(), 0);
+    assert_eq!(mesh.num_tri(), 0);
+    assert_eq!(mesh.num_prop(), 3);
+    assert!(mesh.vert_properties().is_empty());
+    assert!(mesh.tri_verts().is_empty());
+
+    let mesh64 = MeshGL64::new(&[], 3, &[]).expect("empty MeshGL64 should be valid");
+    assert_eq!(mesh64.num_vert(), 0);
+    assert_eq!(mesh64.num_tri(), 0);
+    assert_eq!(mesh64.num_prop(), 3);
+    assert!(mesh64.vert_properties().is_empty());
+    assert!(mesh64.tri_verts().is_empty());
+}
+
+#[test]
+fn meshgl_invalid_shapes_return_error() {
+    assert!(MeshGL::new(&[], 2, &[]).is_err());
+    assert!(MeshGL::new(&[0.0, 0.0], 3, &[]).is_err());
+    assert!(MeshGL::new(&[], 3, &[0, 1]).is_err());
+    assert!(MeshGL::new_with_tangents(&[], 3, &[], &[0.0]).is_err());
+
+    assert!(MeshGL64::new(&[], 2, &[]).is_err());
+    assert!(MeshGL64::new(&[0.0, 0.0], 3, &[]).is_err());
+    assert!(MeshGL64::new(&[], 3, &[0, 1]).is_err());
+    assert!(MeshGL64::new_with_tangents(&[], 3, &[], &[0.0]).is_err());
+}
+
+#[test]
+fn meshgl_new_with_options_preserves_metadata() {
+    let verts: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let indices: Vec<u32> = vec![0, 1, 2];
+    let run_indices = vec![0, 3];
+    let run_original_ids = vec![42];
+    let merge_from = vec![1];
+    let merge_to = vec![2];
+    let tangents = vec![0.0f32; 12];
+
+    let mesh = MeshGL::new_with_options(
+        &verts,
+        3,
+        &indices,
+        MeshGLOptions::new()
+            .runs(&run_indices, &run_original_ids)
+            .merge_vertices(&merge_from, &merge_to)
+            .halfedge_tangents(&tangents),
+    )
+    .expect("valid MeshGL options");
+
+    assert_eq!(mesh.run_index(), run_indices);
+    assert_eq!(mesh.run_original_id(), run_original_ids);
+    assert_eq!(mesh.merge_from_vert(), merge_from);
+    assert_eq!(mesh.merge_to_vert(), merge_to);
+    assert_eq!(mesh.halfedge_tangent().len(), tangents.len());
+}
+
+#[test]
+fn meshgl64_new_with_options_preserves_metadata() {
+    let verts: Vec<f64> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let indices: Vec<u64> = vec![0, 1, 2];
+    let run_indices = vec![0, 3];
+    let run_original_ids = vec![43];
+    let merge_from = vec![1];
+    let merge_to = vec![2];
+    let tangents = vec![0.0f64; 12];
+
+    let mesh = MeshGL64::new_with_options(
+        &verts,
+        3,
+        &indices,
+        MeshGL64Options::new()
+            .runs(&run_indices, &run_original_ids)
+            .merge_vertices(&merge_from, &merge_to)
+            .halfedge_tangents(&tangents),
+    )
+    .expect("valid MeshGL64 options");
+
+    assert_eq!(mesh.run_index(), run_indices);
+    assert_eq!(mesh.run_original_id(), run_original_ids);
+    assert_eq!(mesh.merge_from_vert(), merge_from);
+    assert_eq!(mesh.merge_to_vert(), merge_to);
+    assert_eq!(mesh.halfedge_tangent().len(), tangents.len());
+}
+
+#[test]
+fn meshgl_options_invalid_metadata_returns_error() {
+    let verts: Vec<f32> = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let indices: Vec<u32> = vec![0, 1, 2];
+
+    assert!(
+        MeshGL::new_with_options(&verts, 3, &indices, MeshGLOptions::new().runs(&[0], &[]))
+            .is_err()
+    );
+    assert!(
+        MeshGL::new_with_options(&verts, 3, &indices, MeshGLOptions::new().runs(&[1], &[1]))
+            .is_err()
+    );
+    assert!(
+        MeshGL::new_with_options(
+            &verts,
+            3,
+            &[0, 1, 2, 0, 2, 1],
+            MeshGLOptions::new().runs(&[0, 3], &[1])
+        )
+        .is_err()
+    );
+    assert!(
+        MeshGL::new_with_options(
+            &verts,
+            3,
+            &indices,
+            MeshGLOptions::new().merge_vertices(&[1, 2], &[1])
+        )
+        .is_err()
+    );
+    assert!(
+        MeshGL64::new_with_options(
+            &[0.0f64, 0.0, 0.0],
+            3,
+            &[0, 0, 0],
+            MeshGL64Options::new().halfedge_tangents(&[0.0])
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn manifold_from_meshgl_with_options() {
+    let cube = Manifold::cube(2.0, 2.0, 2.0, true);
+    let (verts, n_props, indices) = cube.to_mesh_f32();
+    let mesh = MeshGL::new_with_options(
+        &verts,
+        n_props,
+        &indices,
+        MeshGLOptions::new().runs(&[0], &[reserve_ids(1)]),
+    )
+    .expect("valid MeshGL options");
+
+    let rebuilt = Manifold::from_meshgl(&mesh).expect("MeshGL should produce a manifold");
+    assert_relative_eq!(rebuilt.volume(), cube.volume(), epsilon = 0.01);
+}
+
+#[test]
+fn manifold_from_meshgl64_with_options() {
+    let cube = Manifold::cube(2.0, 2.0, 2.0, true);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let mesh = MeshGL64::new_with_options(
+        &verts,
+        n_props,
+        &indices,
+        MeshGL64Options::new().runs(&[0], &[reserve_ids(1)]),
+    )
+    .expect("valid MeshGL64 options");
+
+    let rebuilt = Manifold::from_meshgl64(&mesh).expect("MeshGL64 should produce a manifold");
+    assert_relative_eq!(rebuilt.volume(), cube.volume(), epsilon = 0.01);
 }
 
 // ── Hull tests ──────────────────────────────────────────────────────
@@ -1314,13 +1512,17 @@ fn rect_is_empty() {
 // ── FillRule tests ─────────────────────────────────────────────────────
 
 #[test]
-fn fill_rule_even_odd_default() {
-    // A simple square polygon should produce the same result with explicit EvenOdd
-    // as with the default from_polygons.
-    let square = vec![vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]]];
-    let default_cs = CrossSection::from_polygons(&square);
-    let explicit_cs = CrossSection::from_polygons_with_fill_rule(&square, FillRule::EvenOdd);
-    assert_relative_eq!(default_cs.area(), explicit_cs.area(), epsilon = 0.1);
+fn fill_rule_positive_default() {
+    // A clockwise square distinguishes Positive from EvenOdd: Positive treats
+    // it as outside, while EvenOdd still fills it.
+    let clockwise_square = vec![vec![[0.0, 0.0], [0.0, 10.0], [10.0, 10.0], [10.0, 0.0]]];
+    let default_cs = CrossSection::from_polygons(&clockwise_square);
+    let positive_cs =
+        CrossSection::from_polygons_with_fill_rule(&clockwise_square, FillRule::Positive);
+    let even_odd_cs =
+        CrossSection::from_polygons_with_fill_rule(&clockwise_square, FillRule::EvenOdd);
+    assert_relative_eq!(default_cs.area(), positive_cs.area(), epsilon = 0.1);
+    assert!((default_cs.area() - even_odd_cs.area()).abs() > 1.0);
 }
 
 #[test]
@@ -1410,7 +1612,7 @@ fn as_original_preserves_geometry() {
 fn meshgl_clone_is_independent() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f32();
-    let mesh = MeshGL::new(&verts, n_props, &indices);
+    let mesh = MeshGL::new(&verts, n_props, &indices).expect("valid MeshGL");
     let clone = mesh.clone();
     assert_eq!(mesh.num_vert(), clone.num_vert());
     assert_eq!(mesh.num_tri(), clone.num_tri());
@@ -1423,16 +1625,32 @@ fn meshgl_clone_is_independent() {
 fn meshgl64_clone_is_independent() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
-    let mesh = MeshGL64::new(&verts, n_props, &indices);
+    let mesh = MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64");
     let clone = mesh.clone();
     assert_eq!(mesh.num_vert(), clone.num_vert());
     drop(mesh);
     assert!(clone.num_vert() > 0);
 }
 
-// NOTE: MeshGL::merge() / MeshGL64::merge() are NOT exposed because the C API's
-// manifold_meshgl_merge returns a mesh that shares internal buffers with the
-// source, causing double-free on drop. This needs further upstream investigation.
+#[test]
+fn meshgl_merge_smoke() {
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f32();
+    let mesh = MeshGL::new(&verts, n_props, &indices).expect("valid MeshGL");
+    let merged = mesh.merge();
+    assert_eq!(merged.num_prop(), mesh.num_prop());
+    assert!(merged.num_vert() <= mesh.num_vert());
+}
+
+#[test]
+fn meshgl64_merge_smoke() {
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let mesh = MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64");
+    let merged = mesh.merge();
+    assert_eq!(merged.num_prop(), mesh.num_prop());
+    assert!(merged.num_vert() <= mesh.num_vert());
+}
 
 // ── Binding-specific: Drop safety ──────────────────────────────────────
 
@@ -1519,7 +1737,7 @@ fn rect_send_across_thread() {
 fn meshgl64_send_across_thread() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
-    let mesh = MeshGL64::new(&verts, n_props, &indices);
+    let mesh = MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64");
     let nv = std::thread::spawn(move || mesh.num_vert()).join().unwrap();
     assert!(nv > 0);
 }
@@ -1572,7 +1790,8 @@ fn cross_section_sync_concurrent_reads() {
 fn meshgl64_sync_concurrent_reads() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
-    let mesh = std::sync::Arc::new(MeshGL64::new(&verts, n_props, &indices));
+    let mesh =
+        std::sync::Arc::new(MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64"));
     let handles: Vec<_> = (0..4)
         .map(|_| {
             let m = std::sync::Arc::clone(&mesh);
@@ -1692,6 +1911,18 @@ fn cross_section_clone_is_independent() {
 
 // ── Binding-specific: callback catch_unwind ────────────────────────────
 
+fn assert_panic_message(result: std::thread::Result<()>, expected: &str) {
+    let payload = match result {
+        Ok(()) => panic!("expected callback panic"),
+        Err(payload) => payload,
+    };
+    let message = payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str));
+    assert_eq!(message, Some(expected));
+}
+
 #[test]
 fn warp_callback_doesnt_crash_on_identity() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, true);
@@ -1700,10 +1931,65 @@ fn warp_callback_doesnt_crash_on_identity() {
 }
 
 #[test]
+fn warp_callback_panic_resumes_after_ffi() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, true);
+    let result = std::panic::catch_unwind(|| {
+        let _ = cube.warp(|_, _, _| panic!("warp panic"));
+    });
+    assert_panic_message(result, "warp panic");
+}
+
+#[test]
+fn set_properties_callback_panic_resumes_after_ffi() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, true);
+    let result = std::panic::catch_unwind(|| {
+        let _ = cube.set_properties(3, |_, _, _| panic!("properties panic"));
+    });
+    assert_panic_message(result, "properties panic");
+}
+
+#[test]
+fn from_sdf_callback_panic_resumes_after_ffi() {
+    let result = std::panic::catch_unwind(|| {
+        let _ = Manifold::from_sdf(
+            |_, _, _| panic!("sdf panic"),
+            ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]),
+            1.0,
+            0.0,
+            0.01,
+        );
+    });
+    assert_panic_message(result, "sdf panic");
+}
+
+#[test]
+fn from_sdf_seq_callback_panic_resumes_after_ffi() {
+    let result = std::panic::catch_unwind(|| {
+        let _ = Manifold::from_sdf_seq(
+            |_, _, _| panic!("sdf panic"),
+            ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]),
+            1.0,
+            0.0,
+            0.01,
+        );
+    });
+    assert_panic_message(result, "sdf panic");
+}
+
+#[test]
 fn cross_section_warp_identity() {
     let cs = CrossSection::square(10.0, 10.0, false);
     let warped = cs.warp(|x, y| [x, y]);
     assert_relative_eq!(warped.area(), cs.area(), epsilon = 1.0);
+}
+
+#[test]
+fn cross_section_warp_callback_panic_resumes_after_ffi() {
+    let cs = CrossSection::square(10.0, 10.0, false);
+    let result = std::panic::catch_unwind(|| {
+        let _ = cs.warp(|_, _| panic!("cross-section warp panic"));
+    });
+    assert_panic_message(result, "cross-section warp panic");
 }
 
 // ── Binding-specific: bounds() returns rich Rect ───────────────────────
@@ -1862,7 +2148,7 @@ fn debug_formatting_manifold() {
     let cube = Manifold::cube(1.0, 1.0, 1.0, false);
     let dbg = format!("{cube:?}");
     assert!(dbg.contains("Manifold"));
-    assert!(dbg.contains("num_vert"));
+    assert!(dbg.contains("ptr"));
 }
 
 #[test]
@@ -1945,7 +2231,7 @@ fn cross_section_operator_xor() {
 fn meshgl_accessors_return_consistent_lengths() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f32();
-    let mesh = MeshGL::new(&verts, n_props, &indices);
+    let mesh = MeshGL::new(&verts, n_props, &indices).expect("valid MeshGL");
     // merge vectors should be paired
     assert_eq!(mesh.merge_from_vert().len(), mesh.merge_to_vert().len());
     // face_id is either empty or has one per triangle
@@ -1960,7 +2246,7 @@ fn meshgl_accessors_return_consistent_lengths() {
 fn meshgl64_accessors_return_consistent_lengths() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
-    let mesh = MeshGL64::new(&verts, n_props, &indices);
+    let mesh = MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64");
     assert_eq!(mesh.merge_from_vert().len(), mesh.merge_to_vert().len());
     let fid = mesh.face_id();
     assert!(fid.is_empty() || fid.len() == mesh.num_tri());
@@ -1972,7 +2258,7 @@ fn meshgl64_accessors_return_consistent_lengths() {
 fn meshgl_run_accessors_consistent() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false).as_original();
     let (verts, n_props, indices) = cube.to_mesh_f32();
-    let mesh = MeshGL::new(&verts, n_props, &indices);
+    let mesh = MeshGL::new(&verts, n_props, &indices).expect("valid MeshGL");
     let ri = mesh.run_index();
     let ro = mesh.run_original_id();
     let rt = mesh.run_transform();
@@ -1986,7 +2272,7 @@ fn meshgl_run_accessors_consistent() {
 fn meshgl64_run_accessors_consistent() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false).as_original();
     let (verts, n_props, indices) = cube.to_mesh_f64();
-    let mesh = MeshGL64::new(&verts, n_props, &indices);
+    let mesh = MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64");
     let ri = mesh.run_index();
     let ro = mesh.run_original_id();
     let rt = mesh.run_transform();
@@ -2031,8 +2317,17 @@ fn smooth_mismatched_arrays_returns_error() {
 #[test]
 fn cross_section_from_simple_polygon() {
     let points = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
-    let cs = CrossSection::from_simple_polygon(&points, FillRule::EvenOdd);
+    let cs = CrossSection::from_simple_polygon_with_fill_rule(&points, FillRule::EvenOdd);
     assert_relative_eq!(cs.area(), 100.0, epsilon = 0.1);
+}
+
+#[test]
+fn cross_section_from_simple_polygon_default_is_positive() {
+    let cw_square = vec![[0.0, 0.0], [0.0, 10.0], [10.0, 10.0], [10.0, 0.0]];
+    let default_cs = CrossSection::from_simple_polygon(&cw_square);
+    let positive_cs =
+        CrossSection::from_simple_polygon_with_fill_rule(&cw_square, FillRule::Positive);
+    assert_relative_eq!(default_cs.area(), positive_cs.area(), epsilon = 0.1);
 }
 
 #[test]
@@ -2064,7 +2359,7 @@ fn cross_section_hull_polygons() {
 
 #[test]
 fn cross_section_from_simple_polygon_empty() {
-    let cs = CrossSection::from_simple_polygon(&[], FillRule::EvenOdd);
+    let cs = CrossSection::from_simple_polygon_with_fill_rule(&[], FillRule::EvenOdd);
     assert!(cs.is_empty());
 }
 
@@ -2094,7 +2389,7 @@ fn cross_section_boolean_subtract() {
 fn meshgl64_obj_round_trip() {
     let cube = Manifold::cube(10.0, 10.0, 10.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f64();
-    let mesh = MeshGL64::new(&verts, n_props, &indices);
+    let mesh = MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64");
     let obj = mesh.to_obj();
     assert!(!obj.is_empty());
     assert!(obj.contains("v "));
@@ -2114,7 +2409,8 @@ fn meshgl_new_with_tangents() {
     let n_tris = indices.len() / 3;
     // 4 floats per halfedge, 3 halfedges per triangle
     let tangents = vec![0.0f32; n_tris * 3 * 4];
-    let mesh = MeshGL::new_with_tangents(&verts, n_props, &indices, &tangents);
+    let mesh =
+        MeshGL::new_with_tangents(&verts, n_props, &indices, &tangents).expect("valid MeshGL");
     assert_eq!(mesh.num_vert(), verts.len() / n_props);
     assert_eq!(mesh.num_tri(), n_tris);
     assert_eq!(mesh.halfedge_tangent().len(), tangents.len());
@@ -2126,7 +2422,8 @@ fn meshgl64_new_with_tangents() {
     let (verts, n_props, indices) = cube.to_mesh_f64();
     let n_tris = indices.len() / 3;
     let tangents = vec![0.0f64; n_tris * 3 * 4];
-    let mesh = MeshGL64::new_with_tangents(&verts, n_props, &indices, &tangents);
+    let mesh =
+        MeshGL64::new_with_tangents(&verts, n_props, &indices, &tangents).expect("valid MeshGL64");
     assert_eq!(mesh.num_vert(), verts.len() / n_props);
     assert_eq!(mesh.num_tri(), n_tris);
     assert_eq!(mesh.halfedge_tangent().len(), tangents.len());
@@ -2213,7 +2510,7 @@ fn manifold_boolean_subtract_and_intersect() {
 fn meshgl_is_send() {
     let cube = Manifold::cube(5.0, 5.0, 5.0, false);
     let (verts, n_props, indices) = cube.to_mesh_f32();
-    let mesh = MeshGL::new(&verts, n_props, &indices);
+    let mesh = MeshGL::new(&verts, n_props, &indices).expect("valid MeshGL");
     let handle = std::thread::spawn(move || {
         assert!(mesh.num_vert() > 0);
     });
@@ -2327,12 +2624,11 @@ fn execution_context_cross_thread_cancel() {
 
 #[test]
 fn manifold_with_context_then_status_no_cancel() {
-    use manifold_csg_sys::ManifoldError;
     let cube = Manifold::cube(1.0, 1.0, 1.0, true);
     let ctx = manifold_csg::ExecutionContext::new();
     // Trivial Manifold; evaluation finishes immediately. Exercises the
     // 3.5.0 attach-then-eager-op pattern.
-    assert_eq!(cube.with_context(&ctx).status(), ManifoldError::NoError);
+    assert!(cube.with_context(&ctx).status().is_ok());
 }
 
 #[test]
@@ -2341,7 +2637,7 @@ fn manifold_with_context_already_cancelled() {
     let ctx = manifold_csg::ExecutionContext::new();
     ctx.cancel();
     // Don't assert on the specific status code: upstream may surface
-    // cancellation as NoError for trivial work that doesn't poll the flag,
+    // cancellation as success for trivial work that doesn't poll the flag,
     // or as a specific cancellation status. Just proves the attach + eager
     // call is well-formed and doesn't panic / leak / crash.
     let _ = cube.with_context(&ctx).status();
@@ -2352,12 +2648,12 @@ fn manifold_status_returns_no_error_for_basic_cube() {
     use manifold_csg_sys::ManifoldError;
     let cube = Manifold::cube(1.0, 1.0, 1.0, true);
     // Bare status() with no context attached: just forces lazy eval.
-    assert_eq!(cube.status(), ManifoldError::NoError);
+    assert!(cube.status().is_ok());
+    assert_eq!(cube.raw_status(), ManifoldError::NoError);
 }
 
 #[test]
 fn manifold_with_context_survives_ctx_drop() {
-    use manifold_csg_sys::ManifoldError;
     // A bare cube is a leaf; status() on it can short-circuit without
     // consulting the attached context. Use a real CSG tree so the eager
     // evaluation has to traverse the deferred boolean under the context.
@@ -2370,7 +2666,7 @@ fn manifold_with_context_survives_ctx_drop() {
     };
     // If the shared_ptr story were wrong, status() (and the subsequent
     // num_tri()) would read freed memory while walking the boolean.
-    assert_eq!(attached.status(), ManifoldError::NoError);
+    assert!(attached.status().is_ok());
     assert!(attached.num_tri() > 0);
 }
 

--- a/crates/manifold3d-sys/Cargo.toml
+++ b/crates/manifold3d-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold3d-sys"
 description = "Raw FFI bindings to the manifold3d C API (facade crate — re-exports manifold-csg-sys)"
-version = "3.5.100"
+version = "3.5.101"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ parallel = ["manifold-csg-sys/parallel"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.5.100", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.5.101", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["parallel"]

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -16,7 +16,7 @@ nalgebra = ["manifold-csg/nalgebra"]
 unstable-wasm-uu = ["manifold-csg/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg = { path = "../manifold-csg", version = "=0.2.0", default-features = false }
+manifold-csg = { path = "../manifold-csg", version = "=0.3.0", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]


### PR DESCRIPTION
## Summary

This prepares the `manifold-csg` 0.3.0 release with the Rust API cleanup from the binding audit: status and mesh construction now use `Result`, cross-section defaults align with upstream, callback panics are handled safely, and the missing MeshGL metadata options surface is wrapped.

## Highlights

- Change `Manifold::status()` to return `Result<(), CsgError>` and add `raw_status()` for callers that need the upstream `ManifoldError`.
- Change `MeshGL` / `MeshGL64` constructors to return `Result` instead of panicking, and allow empty meshes as valid input.
- Align `CrossSection::from_polygons()` and `from_simple_polygon()` with upstream `FillRule::Positive` defaults, with explicit `_with_fill_rule` constructors for callers that need old behavior.
- Add safe `OpType`, mark safe public enums non-exhaustive, and stop exposing raw sys enums through the safe API.
- Add full mesh container extraction APIs, MeshGL metadata construction options, and `from_meshgl` / `from_meshgl64`.
- Fix callback panic handling so panics are caught before crossing FFI, partial handles are cleaned up, and the original panic resumes on the Rust side.
- Complete `ManifoldError` in `manifold-csg-sys` with upstream `InvalidTangents` and `Cancelled`, fixing a reachable invalid-enum UB bug.
- Add `MIGRATION_0.2.0_TO_0.3.0.md` and link it from the README.

## Semver Notes

The safe crate bumps to `0.3.0` because this intentionally includes breaking API changes.

The sys crate bumps to `3.5.101` while continuing to track bundled manifold3d 3.5.x. This patch release includes two documented binding-correction exceptions: completing `ManifoldError` to match status codes the bundled library can already return, and tightening input-only MeshGL option pointers from `*mut` to `*const`.

## Credit

Thanks to @JaminKoke for #47, which called out the missing `MeshGL` / `MeshGL64` `new_with_options` surface and prompted the metadata-construction API included here.

## Verification

- `cargo fmt`
- `git diff --check`
- `cargo test -p manifold-csg --features nalgebra --test integration`
- `cargo clippy -p manifold-csg --all-targets --features nalgebra -- -D warnings`
- `cargo test --workspace`
- `cargo build --target wasm32-unknown-unknown -p manifold-csg --no-default-features --features unstable-wasm-uu`