### PR TITLE
Offline manifold build hatch, v3.5.1 pin + ExecutionContext factories

### DIFF
--- a/.claude/skills/update-upstream/SKILL.md
+++ b/.claude/skills/update-upstream/SKILL.md
@@ -40,6 +40,8 @@ git checkout -b update-upstream-<ref>
 
 Edit `MANIFOLD_VERSION` in `crates/manifold-csg-sys/build.rs`. The constant accepts tags, branches, or commit SHAs — prefer SHAs for reproducibility (commit on master) or tags for tagged releases.
 
+Then update the Nix offline lane to match: run `nix flake update` and commit the new `flake.lock`. The `nix-offline` CI lane links nixpkgs' prebuilt `manifold` via `MANIFOLD_CSG_LIB_DIR`, so the locked nixpkgs must resolve to a `manifold` matching the new pin (or the lane links an ABI-mismatched library). If nixpkgs hasn't caught up to the new upstream version yet, note it for the user - the lane may fail until nixpkgs ships it.
+
 ### 4. Carry-patch audit
 
 For each patch in `crates/manifold-csg-sys/patches/`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,37 @@ jobs:
       - name: Test (no parallel)
         run: cargo test --no-default-features
 
+  nix-offline:
+    name: Nix (offline / prebuilt manifold)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # The rust toolchain comes from the pinned nixpkgs (flake.lock), so key
+      # on it: a nixpkgs bump changes rustc and must invalidate target/. No
+      # cmake/clone artifacts here (the offline hatch skips both), so this is
+      # purely the rust compile cache, same as the other compiling jobs.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-nix-offline-${{ hashFiles('flake.lock') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg/build.rs') }}
+          restore-keys: ${{ runner.os }}-cargo-nix-offline-${{ hashFiles('flake.lock') }}-
+
+      # Exercises the MANIFOLD_CSG_LIB_DIR offline hatch (issue #49): the
+      # devShell links nixpkgs' prebuilt `manifold` (3.5.1, matching our pin)
+      # instead of cloning + compiling manifold3d, so build.rs skips the clone
+      # AND cmake. This is the only lane that covers the from-source bypass.
+      - name: Build + test against prebuilt manifold
+        run: nix develop --command bash -c "cargo test --features nalgebra"
+
   emscripten:
     name: Emscripten (wasm32)
     runs-on: ubuntu-latest

--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -336,6 +336,12 @@ Used internally by batch operations, decompose, etc.
 | `manifold_execution_context_cancel` | [`ExecutionContext::cancel`](crates/manifold-csg/src/execution.rs) |
 | `manifold_execution_context_cancelled` | [`ExecutionContext::is_cancelled`](crates/manifold-csg/src/execution.rs) |
 | `manifold_execution_context_progress` | [`ExecutionContext::progress`](crates/manifold-csg/src/execution.rs) |
+| `manifold_execution_context_level_set` | [`Manifold::from_sdf_with_context`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_execution_context_level_set_seq` | [`Manifold::from_sdf_seq_with_context`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_execution_context_of_meshgl` | [`Manifold::from_meshgl_with_context`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_execution_context_of_meshgl64` | [`Manifold::from_meshgl64_with_context`](crates/manifold-csg/src/manifold.rs) |
+| `manifold_execution_context_smooth` | Not wrapped (no f32 `smooth` in safe API; see `manifold_smooth`) |
+| `manifold_execution_context_smooth64` | [`Manifold::smooth_f64_with_context`](crates/manifold-csg/src/manifold.rs) |
 | `manifold_execution_context_size` | Not needed (alloc size) |
 
 ## Allocation & Deallocation (Internal)
@@ -365,13 +371,14 @@ and `Drop` implementations.
 | CrossSection transforms & queries | 15 | 0 |
 | MeshGL/MeshGL64 | 20 | 6 |
 | Triangulation | 1 | 2 |
+| ExecutionContext (cancel/progress + v3.5.1 factories) | 9 | 0 |
 | Quality globals | 6 | 0 |
 | Box3D (BoundingBox) | 16 | 0 |
 | Rect2D (Rect) | 16 | 0 |
 | Polygon helpers | 0 | 7 |
 | Vector containers | 0 | 10 |
 | Alloc/delete/destruct | 0 | 24 |
-| **Total** | **150** | **49** |
+| **Total** | **159** | **49** |
 
 Unwrapped functions are primarily allocation infrastructure (`destruct_*` variants,
 unused vector ops), internal size queries, and specialized construction variants.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,19 @@ Safe Rust bindings to the [manifold3d](https://github.com/elalish/manifold) geom
 
 ## Build
 
-The sys crate clones manifold3d (currently pinned to v3.5.0) via git and builds with cmake. Requires:
+The sys crate clones manifold3d (currently pinned to v3.5.1) via git and builds with cmake. Requires:
 - git, cmake, a C++ compiler
 - First build is slow (clones + compiles manifold3d); subsequent builds are cached
+
+### Offline / bring-your-own manifold (issue #49)
+
+For sandboxed builders (Nix, airgapped CI) that can't run the build script's `git clone`, an env-var escape hatch bypasses the fetch. See [`docs/plans/offline-build.md`](docs/plans/offline-build.md).
+
+- **`MANIFOLD_CSG_LIB_DIR`** - link a pre-built manifold install (dir containing `libmanifoldc` + `libmanifold`); skips clone **and** cmake. Fully offline, no C++ compile. Optional `MANIFOLD_CSG_LIB_KIND` (`dylib` default, or `static`). Works because our FFI is hand-written `extern` decls (no bindgen), so only libraries are needed - no headers. The caller owns version/flag matching against `MANIFOLD_VERSION`. `dylib` needs the lib dir on the runtime search path (rpath); Nix `buildInputs = [ manifold ]` handles this automatically.
+
+A source-tree override (`MANIFOLD_CSG_SOURCE_DIR`, skip clone but still cmake) is deferred - see the design doc - because our `build/build.rs` hardcodes builtin Clipper2/TBB, which `FetchContent`-clones at configure time, so it wouldn't be truly offline without a system-deps lever.
+
+A repo-root `flake.nix` exposes a devShell that links nixpkgs' prebuilt `manifold` (3.5.1) via `MANIFOLD_CSG_LIB_DIR`; the `nix-offline` CI job (`.github/workflows/ci.yml`) runs `nix develop -c cargo test` through it, exercising the offline hatch. No buildable `packages.default` - `buildRustPackage` would need a committed `Cargo.lock` (gitignored here by convention).
 
 ## Versioning
 
@@ -22,6 +32,7 @@ The sys crate clones manifold3d (currently pinned to v3.5.0) via git and builds 
 - Exception: `3.5.101` completes `ManifoldError` to match bundled manifold3d 3.5.0 status codes (`InvalidTangents`, `Cancelled`), marks `ManifoldError` `#[non_exhaustive]`, and tightens the public `ManifoldMeshGLOptions` / `ManifoldMeshGL64Options` input pointers from `*mut` to `*const`. These are documented patch-level binding corrections: the previous incomplete enum could construct invalid Rust enum values from safe status queries, the non-exhaustive marker prevents recurring downstream match breaks when upstream adds status codes, and the option pointers are input-only fields that should not require safe wrappers to cast shared slices to mutable pointers.
 - **`manifold-csg`** uses standard semver (`0.1.0`, etc.) independent of the upstream version. Its `Cargo.toml` pins the sys crate version it depends on.
 - When bumping the manifold3d pin in `build.rs`, the sys crate version must be updated to match (e.g., manifold3d v3.5.0 -> sys crate `3.5.100`).
+- When bumping `MANIFOLD_VERSION`, also run `nix flake update` and commit the new `flake.lock`: the `nix-offline` lane links nixpkgs' prebuilt `manifold`, which must resolve to the new pinned version or the lane links an ABI-mismatched library. The committed lock is what makes the "nixpkgs manifold matches our pin" guarantee reproducible (see [`docs/plans/offline-build.md`](docs/plans/offline-build.md)).
 - **Before bumping `MANIFOLD_VERSION`, check that `wasm-cxx-shim` supports the new pin.** The shim's helper (`wasm_cxx_shim_add_manifold()`) ships carry-patches generated against a specific manifold commit; pins past that point may not patch cleanly, and FFI declarations for any C API added in the gap will produce wasm-uu link failures. Two paths if the shim hasn't caught up: (1) wait for a shim release that pins past your target SHA, or (2) cfg-gate the new FFI surface on `not(all(target_arch = "wasm32", target_os = "unknown"))` so the wasm-uu lane stays on the shim's tested pin. The "Pin / shim follow-ups" section below covers the post-bump cleanups for path (2).
 - The sys crate pins upstream to a specific commit SHA rather than a tag. This is necessary because upstream doesn't follow strict semver — minor releases can include breaking changes. Pinning to a commit gives us the same reproducibility as a tag, while allowing us to pick up post-release fixes and carry-patches between releases.
 - **Version bumps**: feature PRs may (and usually should) include their own version bump so the merge is ready to publish. The `/publish` skill will bump at publish time only if no PR has done so since the last release. Note that `cargo-semver-checks` CI requires a bump whenever the PR changes the public API in a way the current version doesn't allow (e.g., a breaking change requires a minor bump pre-1.0).
@@ -51,7 +62,7 @@ The sys crate clones manifold3d (currently pinned to v3.5.0) via git and builds 
 
 Things to revisit whenever the manifold pin moves OR `wasm-cxx-shim` cuts a new release:
 
-- **Re-evaluate wasm32-unknown-unknown cfg-gates.** Any FFI declaration / safe wrapper / test gated on `not(all(target_arch = "wasm32", target_os = "unknown"))` exists because that surface postdates the shim's tested manifold pin. When the shim's tested pin moves up to (or past) our host pin, those gates can be dropped and the surface unified across targets. Current gated surface: `manifold_*_obj` (OBJ I/O — gated for a different reason: iostream patches strip it; this stays regardless). The shim's tested pin currently matches our host pin (no extra gating needed). Grep for `target_os = "unknown"` to enumerate.
+- **Re-evaluate wasm32-unknown-unknown cfg-gates.** Any FFI declaration / safe wrapper / test gated on `not(all(target_arch = "wasm32", target_os = "unknown"))` exists because that surface postdates the shim's tested manifold pin. When the shim's tested pin moves up to (or past) our host pin, those gates can be dropped and the surface unified across targets. Current gated surface: `manifold_*_obj` (OBJ I/O - gated for a different reason: iostream patches strip it; this stays regardless). NOTE: as of the v3.5.1 pin bump the host pin (v3.5.1) is one patch release PAST the shim v0.5.0 tested pin (v3.5.0). The wasm-uu lane passes `MANIFOLD_GIT_TAG=v3.5.1` to the shim helper, so it builds v3.5.1 against the shim's carry-patches; this is expected to apply (patch release) but is unverified until the wasm-uu CI lane runs. The v3.5.1-only `manifold_execution_context_*` factories ARE bound (unconditionally, no cfg-gate) - correct because the wasm-uu lane builds the same v3.5.1 pin, so those symbols are present on both host and wasm-uu. A cfg-gate would only be needed if the wasm-uu lane were pinned to an older manifold lacking the symbols. Grep for `target_os = "unknown"` to enumerate the (unrelated) currently-gated surface.
 - **Re-evaluate carry-patches.** For each patch in `crates/manifold-csg-sys/patches/` (if any), check whether it's merged upstream and included in the new pin; if so, delete it.
 
 ## Carry-patches

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ cargo build           # builds both crates
 cargo test --features nalgebra   # runs the test suite
 ```
 
+### Offline / pre-built manifold
+
+For sandboxed or airgapped builders (Nix, restricted CI) that can't run the
+initial clone, set `MANIFOLD_CSG_LIB_DIR` to a directory holding a pre-built
+manifold install (`libmanifoldc` + `libmanifold`, e.g. `${pkgs.manifold}/lib`).
+This skips the clone *and* the C++ compile entirely. Set
+`MANIFOLD_CSG_LIB_KIND=static` if the install is static (default is `dylib`).
+The pre-built manifold must match the pinned upstream version and be built with
+the C bindings + cross-section. For the default `dylib` kind, the directory must
+also be on the runtime library search path (rpath / `LD_LIBRARY_PATH`); under
+Nix, `buildInputs = [ manifold ]` arranges this for you.
+
+A repo-root `flake.nix` wires this up for Nix: `nix develop` drops you into a
+shell that links nixpkgs' prebuilt `manifold` via `MANIFOLD_CSG_LIB_DIR`, so
+`cargo build` / `cargo test` skip the manifold3d clone and C++ compile entirely.
+
+See [`docs/plans/offline-build.md`](docs/plans/offline-build.md) for details and a
+Nix recipe.
+
 Tested on Linux, macOS, Windows, `wasm32-unknown-emscripten`, and
 `wasm32-unknown-unknown` (see below).
 

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.5.101"
+version = "3.5.102"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -20,7 +20,7 @@ use std::sync::OnceLock;
 /// wasm-uu build (which passes it through to the shim's
 /// `wasm_cxx_shim_add_manifold()` helper as `MANIFOLD_GIT_TAG`, so both
 /// paths build against the same C API surface).
-pub(crate) const MANIFOLD_VERSION: &str = "v3.5.0";
+pub(crate) const MANIFOLD_VERSION: &str = "v3.5.1";
 
 /// Detect `sccache` on PATH and return cmake args that route the C/C++
 /// compiler through it as a launcher. Returns empty if sccache isn't
@@ -66,6 +66,190 @@ fn cmake_launcher_args() -> Vec<String> {
         ]
     })
     .clone()
+}
+
+/// Link against an externally-provided manifold install instead of
+/// cloning and compiling it. Driven by `MANIFOLD_CSG_LIB_DIR` (a
+/// directory containing `libmanifoldc` + `libmanifold`, e.g. a nixpkgs
+/// `manifold` output's `lib/`). Returns `true` if the override was active
+/// and link directives were emitted, `false` if the var was unset (caller
+/// falls through to the clone+cmake path).
+///
+/// This is the fully-offline path: no network, no C++ compile. Because we
+/// have no build-time header dependency (the FFI is hand-written `extern`
+/// declarations, not bindgen), only the libraries are needed.
+///
+/// Link kind defaults to `dylib` (matching how distros, nixpkgs, and the
+/// upstream flake build manifold - `BUILD_SHARED_LIBS=ON`). A shared
+/// `libmanifold` records its own `Clipper2`/`tbb`/`stdc++` dependencies as
+/// `NEEDED`, so we don't re-link them. Set `MANIFOLD_CSG_LIB_KIND=static`
+/// for a static external build; then we additionally link `Clipper2` (and
+/// `tbb` under the `parallel` feature), since a static archive carries no
+/// transitive deps.
+///
+/// Caller must restrict this to host targets - the wasm/emscripten lanes
+/// have their own build paths and are bypassed before this is consulted.
+fn try_external_lib(target_env: &str, target_os: &str) -> bool {
+    // `env::var` returns Ok("") for a set-but-empty var, so a blank or
+    // unset-via-expansion `MANIFOLD_CSG_LIB_DIR=$UNSET cargo build` would
+    // otherwise hijack the build and emit an empty link-search. Treat
+    // trimmed-blank as unset and fall through to the source build.
+    let lib_dir = match env::var("MANIFOLD_CSG_LIB_DIR") {
+        Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
+        _ => {
+            // Surface a likely mistake: KIND only takes effect alongside DIR.
+            if env::var("MANIFOLD_CSG_LIB_KIND").is_ok_and(|v| !v.trim().is_empty()) {
+                println!(
+                    "cargo:warning=manifold-csg-sys: MANIFOLD_CSG_LIB_KIND is set but \
+                     MANIFOLD_CSG_LIB_DIR is not - ignoring it and building from source."
+                );
+            }
+            return false;
+        }
+    };
+    let kind = env::var("MANIFOLD_CSG_LIB_KIND")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "dylib".to_string());
+    assert!(
+        kind == "dylib" || kind == "static",
+        "MANIFOLD_CSG_LIB_KIND must be 'dylib' or 'static', got {kind:?}"
+    );
+
+    // Fail loudly here rather than deferring a typo'd path or a dir missing
+    // the libs to an opaque downstream linker error. We check the flat dir
+    // for the exact filenames the linker will resolve for `-l{name}`.
+    let lib_path = Path::new(&lib_dir);
+    assert!(
+        lib_path.is_dir(),
+        "MANIFOLD_CSG_LIB_DIR={lib_dir:?} is not a directory"
+    );
+    // For static we also emit `-lClipper2` below, so verify it too - else a
+    // dir with the manifold archives but no Clipper2 passes this check and
+    // then dies with exactly the opaque linker error we're guarding against.
+    // (The from-source path checks Clipper2 for the same reason.) `tbb` is
+    // handled separately below: its presence is best-effort, not required.
+    let mut required = vec!["manifoldc", "manifold"];
+    if kind == "static" {
+        required.push("Clipper2");
+    }
+    for name in required {
+        assert!(
+            external_lib_present(lib_path, name, &kind, target_env, target_os),
+            "MANIFOLD_CSG_LIB_DIR={lib_dir:?} has no {kind} '{name}' library (looked for \
+             {names:?} directly in that dir); check the path and MANIFOLD_CSG_LIB_KIND",
+            names = external_lib_filenames(name, &kind, target_env, target_os),
+        );
+    }
+
+    println!("cargo:rustc-link-search=native={lib_dir}");
+    println!("cargo:rustc-link-lib={kind}=manifoldc");
+    println!("cargo:rustc-link-lib={kind}=manifold");
+    if kind == "static" {
+        // Static archives carry no transitive deps - link them ourselves.
+        // Mirrors the static link set from `super::build`.
+        println!("cargo:rustc-link-lib=static=Clipper2");
+        if env::var("CARGO_FEATURE_PARALLEL").is_ok() {
+            // TBB's static archive is named differently across platforms
+            // (libtbb.a, tbb12.lib, tbb12_static.lib). Probe the same flat
+            // dir the linker actually searches (we emit a single
+            // link-search=native above), so the name we pick is one that
+            // links - keeping the probe consistent with the emit.
+            match ["tbb", "tbb12", "tbb12_static"]
+                .into_iter()
+                .find(|n| external_lib_present(lib_path, n, "static", target_env, target_os))
+            {
+                Some(tbb_name) => println!("cargo:rustc-link-lib=static={tbb_name}"),
+                None => {
+                    // Don't hard-fail: a static manifold may fold TBB in or be
+                    // built without it. Warn (so a later `-ltbb` failure is
+                    // explained) and emit the default name as a best effort.
+                    println!(
+                        "cargo:warning=manifold-csg-sys: parallel feature is on with \
+                         MANIFOLD_CSG_LIB_KIND=static, but no tbb/tbb12/tbb12_static archive \
+                         was found in {lib_dir}; linking will use -ltbb and may fail. If your \
+                         static manifold bundles TBB or was built without it, ignore this."
+                    );
+                    println!("cargo:rustc-link-lib=static=tbb");
+                }
+            }
+        }
+    }
+
+    // C++ standard library, same logic as the from-source build. MSVC links
+    // it automatically; macOS uses libc++; everything else libstdc++.
+    if target_env != "msvc" {
+        if target_os == "macos" {
+            println!("cargo:rustc-link-lib=c++");
+        } else {
+            println!("cargo:rustc-link-lib=stdc++");
+        }
+    }
+
+    println!(
+        "cargo:warning=manifold-csg-sys: linking external manifold from \
+         MANIFOLD_CSG_LIB_DIR={lib_dir} (kind={kind}); skipping clone + cmake. \
+         You are responsible for matching the pinned upstream version (see \
+         MANIFOLD_VERSION) and build flags (CROSS_SECTION, C bindings)."
+    );
+    if kind == "dylib" {
+        println!(
+            "cargo:warning=manifold-csg-sys: kind=dylib links at build time only; the lib \
+             dir must also be on the runtime search path (rpath or LD_LIBRARY_PATH) or the \
+             final binary fails to load libmanifold at startup. Nix buildInputs sets rpath \
+             automatically."
+        );
+    }
+    true
+}
+
+/// Candidate filenames the platform linker resolves for `-l{name}` of the
+/// given `kind`. A file matching one of these in the lib dir is one that
+/// actually links, so it doubles as the existence-check target set.
+fn external_lib_filenames(
+    name: &str,
+    kind: &str,
+    target_env: &str,
+    target_os: &str,
+) -> Vec<String> {
+    if kind == "static" {
+        if target_env == "msvc" {
+            vec![format!("{name}.lib")]
+        } else {
+            vec![format!("lib{name}.a")]
+        }
+    } else if target_env == "msvc" {
+        // The DLL's import library is what the linker consumes.
+        vec![format!("{name}.lib"), format!("{name}.dll.lib")]
+    } else if target_os == "windows" {
+        // windows-gnu (mingw): `-l{name}` resolves to a DLL import lib, not a
+        // `.so`. Cover the mingw import-lib name and the plainer fallbacks.
+        vec![
+            format!("lib{name}.dll.a"),
+            format!("lib{name}.a"),
+            format!("{name}.lib"),
+        ]
+    } else if target_os == "macos" {
+        vec![format!("lib{name}.dylib")]
+    } else {
+        vec![format!("lib{name}.so")]
+    }
+}
+
+/// Whether a `{kind}` library `name` is present directly in `dir` (flat,
+/// matching the single `link-search=native` we emit). `exists()` follows
+/// symlinks, so a versioned `.so` reached via its dev symlink counts.
+fn external_lib_present(
+    dir: &Path,
+    name: &str,
+    kind: &str,
+    target_env: &str,
+    target_os: &str,
+) -> bool {
+    external_lib_filenames(name, kind, target_env, target_os)
+        .iter()
+        .any(|f| dir.join(f).exists())
 }
 
 /// Recursively search for a static library under `dir`.
@@ -116,6 +300,27 @@ fn main() {
         return;
     }
 
+    // Prevent unnecessary build script re-execution. Emitted before any
+    // early return below so the rerun rules apply on every host code path
+    // (including the MANIFOLD_CSG_LIB_DIR override) - emitting any
+    // rerun-if-* directive opts out of cargo's default "rerun on package
+    // change", so these must be unconditional.
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build");
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=patches");
+
+    // Offline / bring-your-own build override (host only). Lets consumers
+    // who can't run the build-script's `git clone` (sandboxed builders like
+    // Nix, airgapped CI) link a pre-built manifold install via
+    // `MANIFOLD_CSG_LIB_DIR`, skipping clone AND cmake entirely. Fully
+    // offline, no C++ compile. See docs/plans/offline-build.md and issue #49.
+    println!("cargo:rerun-if-env-changed=MANIFOLD_CSG_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=MANIFOLD_CSG_LIB_KIND");
+    if !is_emscripten && try_external_lib(&target_env, &target_os) {
+        return;
+    }
+
     if is_emscripten {
         // emcmake/emmake wrap cmake to inject the Emscripten toolchain. They
         // come from the Emscripten SDK (`brew install emscripten` or the raw
@@ -129,12 +334,6 @@ fn main() {
             );
         }
     }
-
-    // Prevent unnecessary build script re-execution.
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=build");
-    println!("cargo:rerun-if-changed=src/lib.rs");
-    println!("cargo:rerun-if-changed=patches");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let patches_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("patches");

--- a/crates/manifold-csg-sys/build/wasm.rs
+++ b/crates/manifold-csg-sys/build/wasm.rs
@@ -33,10 +33,19 @@ const WASM_CXX_SHIM_GIT: &str = "https://github.com/zmerlynn/wasm-cxx-shim.git";
 // v0.5.0 catches up to manifold v3.5.0: adds `assert.h` to libc and
 // `<memory>` shared_ptr atomic-free-function stubs to libcxx, both
 // surfaced by v3.5.0's new ExecutionContext-attached-via-shared_ptr
-// model. Default `MANIFOLD_GIT_TAG` is now `v3.5.0`, matching our host
-// pin. Build.rs still passes `-DMANIFOLD_GIT_TAG=<our pin>` so future
-// host bumps past the shim's default don't break the wasm-uu lane
-// silently (see CLAUDE.md "Versioning" for the playbook).
+// model. The shim's tested-pin default is `v3.5.0`.
+//
+// Our host pin (MANIFOLD_VERSION) is now `v3.5.1`, which is PAST the
+// shim's tested pin. Build.rs passes `-DMANIFOLD_GIT_TAG=<our pin>`
+// (below), so the wasm-uu lane builds v3.5.1 against shim v0.5.0's
+// carry-patches. v3.5.1 is a patch release over v3.5.0 (ExecutionContext
+// threading + bug fixes; see the upstream compare), so the iostream /
+// MANIFOLD_NO_FILESYSTEM carry-patches are expected to still apply - but
+// this is unverified until the wasm-uu CI lane runs. If they don't apply,
+// the fix is either (a) a shim release pinned past v3.5.1, or (b) pin this
+// lane to v3.5.0 here and cfg-gate any v3.5.1-only FFI on
+// `not(all(target_arch = "wasm32", target_os = "unknown"))`. See CLAUDE.md
+// "Versioning" / "Pin / shim follow-ups".
 const WASM_CXX_SHIM_TAG: &str = "v0.5.0";
 
 /// Diagnostic context populated up-front in `build_wasm_unknown_unknown()`,

--- a/crates/manifold-csg-sys/src/lib.rs
+++ b/crates/manifold-csg-sys/src/lib.rs
@@ -1139,6 +1139,72 @@ unsafe extern "C" {
     /// Progress in [0.0, 1.0] for an in-flight evaluation observing this context.
     pub fn manifold_execution_context_progress(ctx: *mut ManifoldExecutionContext) -> f64;
 
+    // -- Execution-context static factories ------------------------------
+    //
+    // ctx-aware variants of `manifold_level_set` / `manifold_of_meshgl` /
+    // `manifold_smooth`. These have no source manifold to attach a context
+    // to via `manifold_with_context`, so they run on the
+    // `ExecutionContext` directly to report progress / observe
+    // cancellation. Added upstream in v3.5.1.
+
+    /// ctx-aware [`manifold_level_set`]. `sdf_context` is the SDF callback's user-data.
+    pub fn manifold_execution_context_level_set(
+        mem: *mut ManifoldManifold,
+        ec: *mut ManifoldExecutionContext,
+        sdf: ManifoldSdf,
+        bounds: *mut ManifoldBox,
+        edge_length: f64,
+        level: f64,
+        tolerance: f64,
+        sdf_context: *mut std::ffi::c_void,
+    ) -> *mut ManifoldManifold;
+
+    /// ctx-aware [`manifold_level_set_seq`] (sequential execution).
+    pub fn manifold_execution_context_level_set_seq(
+        mem: *mut ManifoldManifold,
+        ec: *mut ManifoldExecutionContext,
+        sdf: ManifoldSdf,
+        bounds: *mut ManifoldBox,
+        edge_length: f64,
+        level: f64,
+        tolerance: f64,
+        sdf_context: *mut std::ffi::c_void,
+    ) -> *mut ManifoldManifold;
+
+    /// ctx-aware [`manifold_of_meshgl`].
+    pub fn manifold_execution_context_of_meshgl(
+        mem: *mut ManifoldManifold,
+        ec: *mut ManifoldExecutionContext,
+        mesh: *const ManifoldMeshGL,
+    ) -> *mut ManifoldManifold;
+
+    /// ctx-aware [`manifold_of_meshgl64`].
+    pub fn manifold_execution_context_of_meshgl64(
+        mem: *mut ManifoldManifold,
+        ec: *mut ManifoldExecutionContext,
+        mesh: *const ManifoldMeshGL64,
+    ) -> *mut ManifoldManifold;
+
+    /// ctx-aware [`manifold_smooth`] (f32 mesh).
+    pub fn manifold_execution_context_smooth(
+        mem: *mut ManifoldManifold,
+        ec: *mut ManifoldExecutionContext,
+        mesh: *const ManifoldMeshGL,
+        half_edges: *const usize,
+        smoothness: *const f64,
+        n_edges: usize,
+    ) -> *mut ManifoldManifold;
+
+    /// ctx-aware [`manifold_smooth64`] (f64 mesh).
+    pub fn manifold_execution_context_smooth64(
+        mem: *mut ManifoldManifold,
+        ec: *mut ManifoldExecutionContext,
+        mesh: *const ManifoldMeshGL64,
+        half_edges: *const usize,
+        smoothness: *const f64,
+        n_edges: usize,
+    ) -> *mut ManifoldManifold;
+
     // ── Bounding box ────────────────────────────────────────────────────
 
     pub fn manifold_bounding_box(

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -19,7 +19,7 @@ nalgebra = ["dep:nalgebra"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.5.101", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.5.102", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }

--- a/crates/manifold-csg/src/manifold.rs
+++ b/crates/manifold-csg/src/manifold.rs
@@ -120,10 +120,41 @@ impl Manifold {
     ///
     /// Returns `CsgError::ManifoldStatus` if the mesh is invalid.
     pub fn from_meshgl64(meshgl: &MeshGL64) -> Result<Self, CsgError> {
+        Self::from_meshgl64_impl(meshgl, std::ptr::null_mut())
+    }
+
+    /// Create a Manifold from a [`MeshGL64`] container, reporting progress and
+    /// observing cancellation through an
+    /// [`ExecutionContext`](crate::ExecutionContext).
+    ///
+    /// Like [`from_meshgl64`](Self::from_meshgl64) but the ingest runs on `ctx`
+    /// directly. Added upstream in v3.5.1.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CsgError::ManifoldStatus` if the mesh is invalid.
+    pub fn from_meshgl64_with_context(
+        ctx: &crate::ExecutionContext,
+        meshgl: &MeshGL64,
+    ) -> Result<Self, CsgError> {
+        Self::from_meshgl64_impl(meshgl, ctx.as_ptr())
+    }
+
+    /// Shared body for [`from_meshgl64`](Self::from_meshgl64) /
+    /// [`from_meshgl64_with_context`](Self::from_meshgl64_with_context).
+    fn from_meshgl64_impl(
+        meshgl: &MeshGL64,
+        ec: *mut ManifoldExecutionContext,
+    ) -> Result<Self, CsgError> {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let manifold = unsafe { manifold_alloc_manifold() };
-        // SAFETY: manifold and meshgl are valid handles.
-        unsafe { manifold_of_meshgl64(manifold, meshgl.ptr) };
+        if ec.is_null() {
+            // SAFETY: manifold and meshgl are valid handles.
+            unsafe { manifold_of_meshgl64(manifold, meshgl.ptr) };
+        } else {
+            // SAFETY: manifold/meshgl valid; ec is a valid context borrowed for the call.
+            unsafe { manifold_execution_context_of_meshgl64(manifold, ec, meshgl.ptr) };
+        }
 
         // SAFETY: manifold is valid. Read-only status query.
         let status = unsafe { manifold_status(manifold) };
@@ -158,10 +189,41 @@ impl Manifold {
     ///
     /// Returns `CsgError::ManifoldStatus` if the mesh is invalid.
     pub fn from_meshgl(meshgl: &MeshGL) -> Result<Self, CsgError> {
+        Self::from_meshgl_impl(meshgl, std::ptr::null_mut())
+    }
+
+    /// Create a Manifold from a [`MeshGL`] container, reporting progress and
+    /// observing cancellation through an
+    /// [`ExecutionContext`](crate::ExecutionContext).
+    ///
+    /// Like [`from_meshgl`](Self::from_meshgl) but the ingest runs on `ctx`
+    /// directly. Added upstream in v3.5.1.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CsgError::ManifoldStatus` if the mesh is invalid.
+    pub fn from_meshgl_with_context(
+        ctx: &crate::ExecutionContext,
+        meshgl: &MeshGL,
+    ) -> Result<Self, CsgError> {
+        Self::from_meshgl_impl(meshgl, ctx.as_ptr())
+    }
+
+    /// Shared body for [`from_meshgl`](Self::from_meshgl) /
+    /// [`from_meshgl_with_context`](Self::from_meshgl_with_context).
+    fn from_meshgl_impl(
+        meshgl: &MeshGL,
+        ec: *mut ManifoldExecutionContext,
+    ) -> Result<Self, CsgError> {
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let manifold = unsafe { manifold_alloc_manifold() };
-        // SAFETY: manifold and meshgl are valid handles.
-        unsafe { manifold_of_meshgl(manifold, meshgl.ptr) };
+        if ec.is_null() {
+            // SAFETY: manifold and meshgl are valid handles.
+            unsafe { manifold_of_meshgl(manifold, meshgl.ptr) };
+        } else {
+            // SAFETY: manifold/meshgl valid; ec is a valid context borrowed for the call.
+            unsafe { manifold_execution_context_of_meshgl(manifold, ec, meshgl.ptr) };
+        }
 
         // SAFETY: manifold is valid. Read-only status query.
         let status = unsafe { manifold_status(manifold) };
@@ -191,6 +253,55 @@ impl Manifold {
         half_edges: &[usize],
         smoothness: &[f64],
     ) -> Result<Self, CsgError> {
+        Self::smooth_f64_impl(
+            vert_props,
+            n_props,
+            tri_indices,
+            half_edges,
+            smoothness,
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// Create a smooth manifold from f64 mesh data, reporting progress and
+    /// observing cancellation through an
+    /// [`ExecutionContext`](crate::ExecutionContext).
+    ///
+    /// Like [`smooth_f64`](Self::smooth_f64) but the smoothing runs on `ctx`
+    /// directly. Added upstream in v3.5.1.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CsgError::InvalidInput` if array lengths don't match or
+    /// `CsgError::ManifoldStatus` if the mesh is invalid.
+    pub fn smooth_f64_with_context(
+        ctx: &crate::ExecutionContext,
+        vert_props: &[f64],
+        n_props: usize,
+        tri_indices: &[u64],
+        half_edges: &[usize],
+        smoothness: &[f64],
+    ) -> Result<Self, CsgError> {
+        Self::smooth_f64_impl(
+            vert_props,
+            n_props,
+            tri_indices,
+            half_edges,
+            smoothness,
+            ctx.as_ptr(),
+        )
+    }
+
+    /// Shared body for [`smooth_f64`](Self::smooth_f64) /
+    /// [`smooth_f64_with_context`](Self::smooth_f64_with_context).
+    fn smooth_f64_impl(
+        vert_props: &[f64],
+        n_props: usize,
+        tri_indices: &[u64],
+        half_edges: &[usize],
+        smoothness: &[f64],
+        ec: *mut ManifoldExecutionContext,
+    ) -> Result<Self, CsgError> {
         if half_edges.len() != smoothness.len() {
             return Err(CsgError::InvalidInput(
                 "half_edges and smoothness must have the same length".into(),
@@ -201,15 +312,30 @@ impl Manifold {
 
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let manifold = unsafe { manifold_alloc_manifold() };
-        // SAFETY: all pointers valid, array lengths match.
-        unsafe {
-            manifold_smooth64(
-                manifold,
-                meshgl.ptr,
-                half_edges.as_ptr(),
-                smoothness.as_ptr(),
-                half_edges.len(),
-            );
+        if ec.is_null() {
+            // SAFETY: all pointers valid, array lengths match.
+            unsafe {
+                manifold_smooth64(
+                    manifold,
+                    meshgl.ptr,
+                    half_edges.as_ptr(),
+                    smoothness.as_ptr(),
+                    half_edges.len(),
+                );
+            }
+        } else {
+            // SAFETY: all pointers valid, lengths match; ec is a valid context
+            // borrowed for the call.
+            unsafe {
+                manifold_execution_context_smooth64(
+                    manifold,
+                    ec,
+                    meshgl.ptr,
+                    half_edges.as_ptr(),
+                    smoothness.as_ptr(),
+                    half_edges.len(),
+                );
+            }
         }
 
         // SAFETY: manifold is valid. Read-only status query.
@@ -1503,6 +1629,54 @@ impl Manifold {
     where
         F: Fn(f64, f64, f64) -> f64 + Sync,
     {
+        Self::from_sdf_impl(
+            f,
+            bounds,
+            edge_length,
+            level,
+            tolerance,
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// Construct a manifold from an SDF, reporting progress and observing
+    /// cancellation through an [`ExecutionContext`](crate::ExecutionContext).
+    ///
+    /// Like [`from_sdf`](Self::from_sdf), but the level-set evaluation runs on
+    /// `ctx` directly (these static factories have no source manifold to attach
+    /// a context to via [`with_context`](Self::with_context)). Cancelling `ctx`
+    /// from another thread requests early termination; [`progress`](crate::ExecutionContext::progress)
+    /// observes the in-flight fraction. Added upstream in v3.5.1.
+    #[must_use]
+    pub fn from_sdf_with_context<F>(
+        ctx: &crate::ExecutionContext,
+        f: F,
+        bounds: ([f64; 3], [f64; 3]),
+        edge_length: f64,
+        level: f64,
+        tolerance: f64,
+    ) -> Self
+    where
+        F: Fn(f64, f64, f64) -> f64 + Sync,
+    {
+        Self::from_sdf_impl(f, bounds, edge_length, level, tolerance, ctx.as_ptr())
+    }
+
+    /// Shared body for [`from_sdf`](Self::from_sdf) /
+    /// [`from_sdf_with_context`](Self::from_sdf_with_context). A null `ec`
+    /// selects the non-context `manifold_level_set`; a non-null `ec` selects
+    /// the ctx-aware factory.
+    fn from_sdf_impl<F>(
+        f: F,
+        bounds: ([f64; 3], [f64; 3]),
+        edge_length: f64,
+        level: f64,
+        tolerance: f64,
+        ec: *mut ManifoldExecutionContext,
+    ) -> Self
+    where
+        F: Fn(f64, f64, f64) -> f64 + Sync,
+    {
         struct Context<'a, F> {
             f: &'a F,
             panic: Mutex<Option<PanicPayload>>,
@@ -1559,18 +1733,35 @@ impl Manifold {
         }
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
-        // SAFETY: ptr valid, box_ptr valid, trampoline+ctx valid for call duration.
-        unsafe {
-            manifold_level_set(
-                ptr,
-                Some(trampoline::<F>),
-                box_ptr,
-                edge_length,
-                level,
-                tolerance,
-                ctx_ptr,
-            )
-        };
+        if ec.is_null() {
+            // SAFETY: ptr valid, box_ptr valid, trampoline+ctx valid for call duration.
+            unsafe {
+                manifold_level_set(
+                    ptr,
+                    Some(trampoline::<F>),
+                    box_ptr,
+                    edge_length,
+                    level,
+                    tolerance,
+                    ctx_ptr,
+                )
+            };
+        } else {
+            // SAFETY: ptr/box_ptr/trampoline+ctx valid for call duration; ec is a
+            // valid ExecutionContext pointer borrowed for this call.
+            unsafe {
+                manifold_execution_context_level_set(
+                    ptr,
+                    ec,
+                    Some(trampoline::<F>),
+                    box_ptr,
+                    edge_length,
+                    level,
+                    tolerance,
+                    ctx_ptr,
+                )
+            };
+        }
         if let Some(payload) = take_stored_panic(&ctx.panic) {
             // SAFETY: ptr was allocated above and will not be returned.
             unsafe { manifold_delete_manifold(ptr) };
@@ -1591,11 +1782,54 @@ impl Manifold {
     /// closures (e.g., Python or Ruby runtimes with a GIL).
     #[must_use]
     pub fn from_sdf_seq<F>(
+        f: F,
+        bounds: ([f64; 3], [f64; 3]),
+        edge_length: f64,
+        level: f64,
+        tolerance: f64,
+    ) -> Self
+    where
+        F: FnMut(f64, f64, f64) -> f64,
+    {
+        Self::from_sdf_seq_impl(
+            f,
+            bounds,
+            edge_length,
+            level,
+            tolerance,
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// Sequential [`from_sdf_with_context`](Self::from_sdf_with_context).
+    ///
+    /// Combines the sequential evaluation of [`from_sdf_seq`](Self::from_sdf_seq)
+    /// with progress/cancellation through an
+    /// [`ExecutionContext`](crate::ExecutionContext). Added upstream in v3.5.1.
+    #[must_use]
+    pub fn from_sdf_seq_with_context<F>(
+        ctx: &crate::ExecutionContext,
+        f: F,
+        bounds: ([f64; 3], [f64; 3]),
+        edge_length: f64,
+        level: f64,
+        tolerance: f64,
+    ) -> Self
+    where
+        F: FnMut(f64, f64, f64) -> f64,
+    {
+        Self::from_sdf_seq_impl(f, bounds, edge_length, level, tolerance, ctx.as_ptr())
+    }
+
+    /// Shared body for the sequential SDF constructors. A null `ec` selects
+    /// `manifold_level_set_seq`; a non-null `ec` selects the ctx-aware factory.
+    fn from_sdf_seq_impl<F>(
         mut f: F,
         bounds: ([f64; 3], [f64; 3]),
         edge_length: f64,
         level: f64,
         tolerance: f64,
+        ec: *mut ManifoldExecutionContext,
     ) -> Self
     where
         F: FnMut(f64, f64, f64) -> f64,
@@ -1656,18 +1890,35 @@ impl Manifold {
         }
         // SAFETY: manifold_alloc_manifold returns a valid handle.
         let ptr = unsafe { manifold_alloc_manifold() };
-        // SAFETY: ptr valid, box_ptr valid, trampoline+ctx valid for call duration.
-        unsafe {
-            manifold_level_set_seq(
-                ptr,
-                Some(trampoline::<F>),
-                box_ptr,
-                edge_length,
-                level,
-                tolerance,
-                ctx_ptr,
-            )
-        };
+        if ec.is_null() {
+            // SAFETY: ptr valid, box_ptr valid, trampoline+ctx valid for call duration.
+            unsafe {
+                manifold_level_set_seq(
+                    ptr,
+                    Some(trampoline::<F>),
+                    box_ptr,
+                    edge_length,
+                    level,
+                    tolerance,
+                    ctx_ptr,
+                )
+            };
+        } else {
+            // SAFETY: ptr/box_ptr/trampoline+ctx valid for call duration; ec is a
+            // valid ExecutionContext pointer borrowed for this call.
+            unsafe {
+                manifold_execution_context_level_set_seq(
+                    ptr,
+                    ec,
+                    Some(trampoline::<F>),
+                    box_ptr,
+                    edge_length,
+                    level,
+                    tolerance,
+                    ctx_ptr,
+                )
+            };
+        }
         if let Some(payload) = take_stored_panic(&ctx.panic) {
             // SAFETY: ptr was allocated above and will not be returned.
             unsafe { manifold_delete_manifold(ptr) };

--- a/crates/manifold-csg/tests/integration.rs
+++ b/crates/manifold-csg/tests/integration.rs
@@ -2312,6 +2312,107 @@ fn smooth_mismatched_arrays_returns_error() {
     assert!(result.is_err());
 }
 
+// -- ExecutionContext static factories (v3.5.1) -------------------------
+
+#[test]
+fn from_sdf_with_context_creates_manifold() {
+    let ctx = manifold_csg::ExecutionContext::new();
+    // SDF for a sphere of radius 5, evaluated on the context directly.
+    let result = Manifold::from_sdf_with_context(
+        &ctx,
+        |x, y, z| (x * x + y * y + z * z).sqrt() - 5.0,
+        ([-6.0, -6.0, -6.0], [6.0, 6.0, 6.0]),
+        1.0,
+        0.0,
+        0.05,
+    );
+    assert!(!result.is_empty());
+    assert!(result.volume() > 0.0);
+    // Fresh context, evaluation ran to completion: not cancelled.
+    assert!(!ctx.is_cancelled());
+}
+
+#[test]
+fn from_sdf_seq_with_context_creates_manifold() {
+    let ctx = manifold_csg::ExecutionContext::new();
+    let mut calls = 0_u64;
+    let result = Manifold::from_sdf_seq_with_context(
+        &ctx,
+        |x, y, z| {
+            calls += 1; // FnMut: exercises the sequential trampoline.
+            (x * x + y * y + z * z).sqrt() - 5.0
+        },
+        ([-6.0, -6.0, -6.0], [6.0, 6.0, 6.0]),
+        1.0,
+        0.0,
+        0.05,
+    );
+    assert!(!result.is_empty());
+    assert!(calls > 0);
+}
+
+#[test]
+fn from_sdf_with_context_precancelled_does_not_crash() {
+    // A pre-cancelled context should let the factory bail without UB. We only
+    // assert it returns and the context stays cancelled (sticky), not the
+    // exact result shape - upstream may return an empty manifold.
+    let ctx = manifold_csg::ExecutionContext::new();
+    ctx.cancel();
+    let _result = Manifold::from_sdf_with_context(
+        &ctx,
+        |x, y, z| (x * x + y * y + z * z).sqrt() - 5.0,
+        ([-6.0, -6.0, -6.0], [6.0, 6.0, 6.0]),
+        1.0,
+        0.0,
+        0.05,
+    );
+    assert!(ctx.is_cancelled());
+}
+
+#[test]
+fn from_meshgl64_with_context_roundtrips() {
+    let cube = Manifold::cube(2.0, 2.0, 2.0, true);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let mesh = MeshGL64::new(&verts, n_props, &indices).expect("valid MeshGL64");
+    let ctx = manifold_csg::ExecutionContext::new();
+    let rebuilt = Manifold::from_meshgl64_with_context(&ctx, &mesh)
+        .expect("MeshGL64 should produce a manifold");
+    assert_relative_eq!(rebuilt.volume(), cube.volume(), epsilon = 0.01);
+}
+
+#[test]
+fn from_meshgl_with_context_roundtrips() {
+    let cube = Manifold::cube(2.0, 2.0, 2.0, true);
+    let (verts, n_props, indices) = cube.to_mesh_f32();
+    let mesh = MeshGL::new(&verts, n_props, &indices).expect("valid MeshGL");
+    let ctx = manifold_csg::ExecutionContext::new();
+    let rebuilt =
+        Manifold::from_meshgl_with_context(&ctx, &mesh).expect("MeshGL should produce a manifold");
+    assert_relative_eq!(rebuilt.volume(), cube.volume(), epsilon = 0.01);
+}
+
+#[test]
+fn smooth_f64_with_context_smooths() {
+    let cube = Manifold::cube(10.0, 10.0, 10.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let ctx = manifold_csg::ExecutionContext::new();
+    let result = Manifold::smooth_f64_with_context(&ctx, &verts, n_props, &indices, &[], &[]);
+    assert!(result.is_ok());
+    let m = result.unwrap();
+    assert!(!m.is_empty());
+    assert_relative_eq!(m.volume(), 1000.0, epsilon = 1.0);
+}
+
+#[test]
+fn smooth_f64_with_context_mismatched_arrays_returns_error() {
+    let cube = Manifold::cube(5.0, 5.0, 5.0, false);
+    let (verts, n_props, indices) = cube.to_mesh_f64();
+    let ctx = manifold_csg::ExecutionContext::new();
+    let result =
+        Manifold::smooth_f64_with_context(&ctx, &verts, n_props, &indices, &[0, 1], &[0.5]);
+    assert!(result.is_err());
+}
+
 // ── CrossSection gaps ──────────────────────────────────────────────────
 
 #[test]

--- a/crates/manifold3d-sys/Cargo.toml
+++ b/crates/manifold3d-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold3d-sys"
 description = "Raw FFI bindings to the manifold3d C API (facade crate — re-exports manifold-csg-sys)"
-version = "3.5.101"
+version = "3.5.102"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ parallel = ["manifold-csg-sys/parallel"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.5.101", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.5.102", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["parallel"]

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -16,7 +16,7 @@ nalgebra = ["manifold-csg/nalgebra"]
 unstable-wasm-uu = ["manifold-csg/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg = { path = "../manifold-csg", version = "=0.3.0", default-features = false }
+manifold-csg = { path = "../manifold-csg", version = "=0.3.1", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]

--- a/docs/plans/offline-build.md
+++ b/docs/plans/offline-build.md
@@ -1,0 +1,61 @@
+# Offline / bring-your-own manifold build
+
+Tracks issue #49 (offline build support), closely related to #45 (build-time levers).
+
+## Problem
+
+`crates/manifold-csg-sys/build.rs` unconditionally `git clone`s manifold3d from GitHub at build time (`build/fetch.rs::clone_manifold3d`). Any builder that forbids arbitrary network access during the build fails at the clone. The motivating report is **Nix**: a derivation only gets network access if it is fixed-output (a deterministic hash of its result is declared up front); a build script making arbitrary network requests breaks that model. nixpkgs already ships a working `manifold` package, but there was no way to hand it to this crate.
+
+## Why this is tractable
+
+The sys crate has **no build-time header dependency** - the FFI surface is hand-written `extern` declarations in `src/lib.rs`, not bindgen. (This is also why docs.rs builds with `--network=none`.) So linking an externally-provided manifold needs only the libraries, not headers or a `.pc` file (manifold ships neither a pkg-config file nor, usefully here, anything we must parse - it exports a CMake package config).
+
+## External manifold sources (for the link path)
+
+| | upstream flake (`github:elalish/manifold`) | nixpkgs `manifold` |
+|---|---|---|
+| Version | self-referential (`src = self`): pin the input to `v3.5.1` to match our pin exactly | 3.5.1 (tracks the tag) |
+| C bindings (`manifoldc`) | `MANIFOLD_CBIND=ON` | inherited ON (`cmake_dependent_option`, CROSS_SECTION on) |
+| Libs | shared (`BUILD_SHARED_LIBS=ON`) | shared |
+| Clipper2 / TBB | system | system (propagated clipper2, onetbb) |
+
+Both are **shared** + **system Clipper2/TBB**, whereas the from-source build here is **static** + **builtin** Clipper2/TBB. A shared `libmanifold` records its `Clipper2`/`tbb`/`stdc++` deps as `NEEDED`, so the link path only links `manifoldc` + `manifold` and lets the dynamic linker resolve the rest.
+
+## The escape hatch (implemented)
+
+Env-var driven, consulted only on host targets (the wasm-uu and emscripten lanes have their own build paths and return before this is reached).
+
+**`MANIFOLD_CSG_LIB_DIR`** - link a pre-built install. Skips clone **and** cmake. Fully offline, no C++ compile. `MANIFOLD_CSG_LIB_KIND` selects `dylib` (default) or `static`; the static case additionally links `Clipper2` (+ `tbb`, probing `tbb`/`tbb12`/`tbb12_static` like the from-source build, under `parallel`). For `dylib`, the directory must also be on the runtime search path (rpath / `LD_LIBRARY_PATH`) - `link-search=native` is link-time only; Nix `buildInputs` arranges rpath automatically. This is the recommended path for Nix.
+
+## Deferred: `MANIFOLD_CSG_SOURCE_DIR` (build from a supplied source tree)
+
+A "skip the clone but still run cmake" override was prototyped and cut before merge. The problem: `build/build.rs` hardcodes `-DMANIFOLD_USE_BUILTIN_CLIPPER2=ON` (and builtin TBB under `parallel`), and manifold's `cmake/manifoldDeps.cmake` turns those into `FetchContent_Declare(... GIT_REPOSITORY ...)` of Clipper2 / oneTBB **at configure time**. So a source-dir build still hits the network for the deps - it doesn't deliver the offline goal, and there's no env lever for the caller to opt into system deps.
+
+manifold *does* support system deps: with `MANIFOLD_USE_BUILTIN_CLIPPER2=OFF` / `MANIFOLD_USE_BUILTIN_TBB=OFF`, `manifoldDeps.cmake` runs `find_package` + a pkg-config fallback. So a proper version of this hatch (`MANIFOLD_CSG_SYSTEM_DEPS=1`) would flip both builtin flags off. Two things make it more than a flag:
+
+- **Silent fallback footgun:** if Clipper2 builtin is off and the system copy isn't found, manifold's cmake *forces builtin back on and FetchContents anyway* (network returns silently); TBB just goes missing and parallel breaks. The lever only helps a builder that actually provides system clipper2/tbb (Nix does).
+- **Link-set rework:** with system deps, `Clipper2`/`tbb` are shared system libs, not archives under `build_dir`, so `build/build.rs`'s `find_lib_recursive(build_dir, ...)` + `static=` link lines must switch to system/dynamic linking for that case.
+
+Tracked as future work; the `MANIFOLD_CSG_LIB_DIR` path already covers the motivating Nix case.
+
+## Nix consumption sketch
+
+```nix
+# manifold from the upstream flake, pinned to our exact MANIFOLD_VERSION:
+#   inputs.manifold.url = "github:elalish/manifold/v3.5.1";
+# or nixpkgs' pkgs.manifold (also 3.5.1).
+buildRustPackage {
+  # ...
+  MANIFOLD_CSG_LIB_DIR = "${manifold}/lib";   # dylib by default
+  buildInputs = [ manifold ];                 # rpath / NEEDED pulls clipper2 + tbb
+}
+```
+
+## Decisions / open items for review
+
+- **Version alignment:** the pin was bumped v3.5.0 -> v3.5.1 alongside this, so nixpkgs' `manifold` (3.5.1) and the flake at `v3.5.1` match our pin exactly - no ABI/version drift for the link path. A committed `flake.lock` pins the nixpkgs revision that resolves manifold 3.5.1, so the match is reproducible rather than dependent on whatever `nixos-unstable` resolves at `nix develop` time; bumping `MANIFOLD_VERSION` should be paired with a `nix flake update` to a nixpkgs that ships the new version.
+- **Link kind default is `dylib`.** Correct for the Nix/distro case; the static escape (`MANIFOLD_CSG_LIB_KIND=static`) covers a caller who built a static manifold but then owns the Clipper2/TBB link set matching their build flags.
+- **Presence is validated; version is not.** build.rs checks the lib dir actually contains the `manifoldc`/`manifold` libraries for the chosen kind (the exact filenames the linker resolves for `-l{name}`), failing with a build.rs diagnostic rather than an opaque downstream link error. It does NOT validate they match `MANIFOLD_VERSION` - we emit a `cargo:warning` putting that on the caller. A future enhancement could probe a version symbol, but there's no stable C API for it.
+- **v3.5.1 adds 6 `manifold_execution_context_*` C functions** (ctx-aware FromMeshGL / LevelSet / Smooth factories). These ARE bound in this change as `Manifold::*_with_context` constructors (the existing `from_sdf` / `from_meshgl` / `smooth_f64` constructors were refactored to share a body that dispatches on an optional context pointer). The f32 `manifold_execution_context_smooth` is FFI-declared but not safe-wrapped, mirroring the unwrapped f32 `manifold_smooth`.
+- **wasm-uu risk:** the lane passes `MANIFOLD_GIT_TAG=v3.5.1` to wasm-cxx-shim v0.5.0 (tested at v3.5.0). Patch-release carry-patches are expected to still apply but are unverified until the wasm-uu CI lane runs.
+- **CI coverage:** a repo-root `flake.nix` provides a devShell that links nixpkgs' prebuilt `manifold` (3.5.1, matching our pin) via `MANIFOLD_CSG_LIB_DIR`, and the `nix-offline` CI job runs `nix develop -c cargo test --features nalgebra` through it - the one lane that exercises the from-source bypass end-to-end. A buildable `packages.default` (`nix build`) is intentionally omitted: `rustPlatform.buildRustPackage` needs a committed `Cargo.lock`, which this workspace gitignores by convention. Commit a lock first to add a package output.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "manifold-csg - safe Rust bindings to the manifold3d geometry kernel";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  # This flake targets the *offline* build path (issue #49): it links the
+  # pre-built `manifold` package from nixpkgs via the crate's
+  # `MANIFOLD_CSG_LIB_DIR` escape hatch instead of letting build.rs clone +
+  # compile manifold3d. nixpkgs' `manifold` is 3.5.1, matching this crate's
+  # MANIFOLD_VERSION pin exactly, so there's no ABI/version drift. The
+  # committed flake.lock pins the exact nixpkgs revision that resolves
+  # manifold 3.5.1, so `nix develop` is reproducible (run `nix flake update`
+  # to advance, which must stay in step with MANIFOLD_VERSION). See
+  # docs/plans/offline-build.md.
+  #
+  # It exposes a devShell (and CI uses `nix develop -c cargo test ...` to
+  # exercise the hatch). A buildable `packages.default` via
+  # `rustPlatform.buildRustPackage` is intentionally omitted: that needs a
+  # committed `Cargo.lock`, which this workspace deliberately gitignores.
+  # Commit a lock first if you want a `nix build` package output.
+  outputs =
+    { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        # libmanifold.so / libmanifoldc.so live here. nixpkgs builds manifold
+        # shared with the C bindings on (CROSS_SECTION => CBIND) and records its
+        # Clipper2/TBB deps as absolute-store RUNPATH entries, so linking just
+        # manifoldc + manifold (the crate's dylib path) resolves the rest.
+        manifoldLib = "${pkgs.manifold}/lib";
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          # `manifold` in buildInputs makes its headers/libs discoverable and,
+          # combined with LD_LIBRARY_PATH below, lets the test binaries find
+          # libmanifold.so at runtime (the dylib path is link-time only).
+          buildInputs = [ pkgs.manifold ];
+          nativeBuildInputs = [
+            pkgs.cargo
+            pkgs.rustc
+            pkgs.clippy
+            pkgs.rustfmt
+            # cmake isn't invoked on the MANIFOLD_CSG_LIB_DIR path (build.rs
+            # returns before any cmake call), but keep it available for anyone
+            # who unsets the override and falls back to the from-source build.
+            pkgs.cmake
+          ];
+
+          # Drive the crate's offline hatch: link nixpkgs' prebuilt manifold,
+          # skipping the clone + C++ compile entirely.
+          MANIFOLD_CSG_LIB_DIR = manifoldLib;
+          # dylib kind needs the lib dir on the runtime search path too.
+          LD_LIBRARY_PATH = manifoldLib;
+
+          shellHook = ''
+            echo "manifold-csg devShell: linking prebuilt manifold from ${manifoldLib}"
+            echo "  (offline build via MANIFOLD_CSG_LIB_DIR - no manifold3d clone/compile)"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Closes #49.

## Summary

- **Offline / bring-your-own manifold (`MANIFOLD_CSG_LIB_DIR`).** Sandboxed builders (Nix, airgapped CI) that cannot run the build script `git clone` can point this at a dir of pre-built manifold libs; `build.rs` then skips the clone **and** cmake, emitting only link directives. `MANIFOLD_CSG_LIB_KIND` selects `dylib` (default) or `static`. The path validates the dir and that the required libraries are present (the exact filenames the linker resolves for `-l<name>`, per target/kind), failing loudly with a build.rs diagnostic instead of an opaque downstream link error, and warns that the `dylib` path also needs the dir on the runtime search path (rpath/`LD_LIBRARY_PATH`). Works because the FFI is hand-written `extern` decls (no bindgen), so only libraries are needed.
- **Pin bump v3.5.0 -> v3.5.1** so nixpkgs `manifold` (3.5.1) matches our pin exactly. Versions: sys `3.5.101 -> 3.5.102`, `manifold-csg` `0.3.0 -> 0.3.1` (additive; `cargo-semver-checks` clean), facade `=` pins updated in lockstep.
- **ExecutionContext factories (new in v3.5.1).** Bound the 6 new `manifold_execution_context_*` C functions and exposed ctx-aware constructors `Manifold::{from_sdf, from_sdf_seq, from_meshgl, from_meshgl64, smooth_f64}_with_context`. The existing constructors were refactored to share a body dispatching on an optional context pointer, so SDF trampoline/cleanup logic is not duplicated. The f32 `manifold_execution_context_smooth` is FFI-declared but not safe-wrapped, mirroring the unwrapped f32 `manifold_smooth`.
- **Nix flake + CI.** A repo-root `flake.nix` devShell links nixpkgs prebuilt manifold via the offline hatch; a committed `flake.lock` pins the resolving nixpkgs rev so the version match is reproducible; the `nix-offline` CI lane (with cargo cache) exercises the hatch end to end - the only lane covering the from-source bypass.

A source-tree-only override (`MANIFOLD_CSG_SOURCE_DIR`, skip clone but still cmake) was prototyped and cut: `build/build.rs` FetchContent-clones builtin Clipper2/TBB at configure time, so it would not be truly offline without a system-deps lever. See `docs/plans/offline-build.md`.

## Test plan

- `cargo test --features nalgebra` -> 248 integration + 5 doc tests pass against the v3.5.1 pin.
- `cargo clippy --all-targets --features nalgebra -- -D warnings` and `cargo fmt --all --check` clean.
- `cargo semver-checks -p manifold-csg` -> `0.3.0 -> 0.3.1`, no bump required (additive).
- Offline hatch exercised locally via the `nix develop` devShell: build.rs skips clone+cmake, links nixpkgs manifold 3.5.1, 248 tests pass; both offline warnings fire; the existence check fails loudly on empty/nonexistent/wrong-kind dirs.
- wasm32-uu lane built locally against the v3.5.1 pin (sys + csg with the new execution_context FFI) and the smoke example runs.
- `cargo publish --dry-run` of `manifold-csg-sys` verifies from the packaged tarball.

Watch the `nix-offline`, `wasm32-uu`, and `sanitizer` CI lanes specifically.
