### PR TITLE
fix(link): Link to c++ instead of stdc++ for Apple devices

### DIFF
--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -32,6 +32,11 @@ pub(crate) const MANIFOLD_VERSION: &str = "v3.5.1";
 /// faster, but every rebuild that hits the cache skips the C++ compile
 /// entirely. See issue #45.
 ///
+/// Whether `target_os` (from `CARGO_CFG_TARGET_OS`) is an Apple platform.
+fn is_apple(target_os: &str) -> bool {
+    matches!(target_os, "macos" | "ios" | "tvos" | "watchos" | "visionos")
+}
+
 /// We rerun-if-env-changed on the opt-out var and on `RUSTC_WRAPPER`
 /// (which often holds sccache for the Rust side) so users get consistent
 /// invalidation when they flip sccache on or off.
@@ -178,9 +183,9 @@ fn try_external_lib(target_env: &str, target_os: &str) -> bool {
     }
 
     // C++ standard library, same logic as the from-source build. MSVC links
-    // it automatically; macOS uses libc++; everything else libstdc++.
+    // it automatically; Apple platforms use libc++; everything else libstdc++.
     if target_env != "msvc" {
-        if target_os == "macos" {
+        if is_apple(target_os) {
             println!("cargo:rustc-link-lib=c++");
         } else {
             println!("cargo:rustc-link-lib=stdc++");

--- a/crates/manifold-csg-sys/build/build.rs
+++ b/crates/manifold-csg-sys/build/build.rs
@@ -15,7 +15,7 @@
 
 use std::{env, path::Path, process::Command};
 
-use super::{cmake_launcher_args, find_lib_recursive};
+use super::{cmake_launcher_args, find_lib_recursive, is_apple};
 
 pub fn build(
     is_emscripten: bool,
@@ -156,8 +156,10 @@ pub fn build(
     //
     // - MSVC links the C++ runtime automatically — no explicit link needed.
     // - Emscripten's emcc auto-links libc++ during the final wasm link.
+    // - Apple SDKs (macOS, iOS, tvOS, watchOS, visionOS) only ship libc++;
+    //   there is no libstdc++ to link, so `stdc++` fails at link time.
     if !is_emscripten && target_env != "msvc" {
-        if target_os == "macos" {
+        if is_apple(target_os) {
             println!("cargo:rustc-link-lib=c++");
         } else {
             println!("cargo:rustc-link-lib=stdc++");


### PR DESCRIPTION
Was trying to build for iPad and it failed to link since it needs c++ instead of stdc++