### PR TITLE
Detect Apple platforms by target vendor + release 0.3.3 / sys 3.5.103

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/crates/manifold-csg-sys/Cargo.toml
+++ b/crates/manifold-csg-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold-csg-sys"
 description = "Raw FFI bindings to the manifold3d C API for constructive solid geometry"
-version = "3.5.102"
+version = "3.5.103"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -32,11 +32,6 @@ pub(crate) const MANIFOLD_VERSION: &str = "v3.5.1";
 /// faster, but every rebuild that hits the cache skips the C++ compile
 /// entirely. See issue #45.
 ///
-/// Whether `target_os` (from `CARGO_CFG_TARGET_OS`) is an Apple platform.
-fn is_apple(target_os: &str) -> bool {
-    matches!(target_os, "macos" | "ios" | "tvos" | "watchos" | "visionos")
-}
-
 /// We rerun-if-env-changed on the opt-out var and on `RUSTC_WRAPPER`
 /// (which often holds sccache for the Rust side) so users get consistent
 /// invalidation when they flip sccache on or off.
@@ -73,6 +68,16 @@ fn cmake_launcher_args() -> Vec<String> {
     .clone()
 }
 
+/// Whether the target is an Apple platform, which ships libc++ (not
+/// libstdc++) and uses the `.dylib` shared-library extension. Keyed on the
+/// target *vendor* (`CARGO_CFG_TARGET_VENDOR`), which is `apple` for every
+/// Apple triple - macOS, iOS, tvOS, watchOS, visionOS - and nothing else.
+/// Using the vendor covers current and future Apple targets without an
+/// OS allow-list to keep in sync.
+pub(crate) fn is_apple(target_vendor: &str) -> bool {
+    target_vendor == "apple"
+}
+
 /// Link against an externally-provided manifold install instead of
 /// cloning and compiling it. Driven by `MANIFOLD_CSG_LIB_DIR` (a
 /// directory containing `libmanifoldc` + `libmanifold`, e.g. a nixpkgs
@@ -94,7 +99,7 @@ fn cmake_launcher_args() -> Vec<String> {
 ///
 /// Caller must restrict this to host targets - the wasm/emscripten lanes
 /// have their own build paths and are bypassed before this is consulted.
-fn try_external_lib(target_env: &str, target_os: &str) -> bool {
+fn try_external_lib(target_env: &str, target_os: &str, target_vendor: &str) -> bool {
     // `env::var` returns Ok("") for a set-but-empty var, so a blank or
     // unset-via-expansion `MANIFOLD_CSG_LIB_DIR=$UNSET cargo build` would
     // otherwise hijack the build and emit an empty link-search. Treat
@@ -141,10 +146,10 @@ fn try_external_lib(target_env: &str, target_os: &str) -> bool {
     }
     for name in required {
         assert!(
-            external_lib_present(lib_path, name, &kind, target_env, target_os),
+            external_lib_present(lib_path, name, &kind, target_env, target_os, target_vendor),
             "MANIFOLD_CSG_LIB_DIR={lib_dir:?} has no {kind} '{name}' library (looked for \
              {names:?} directly in that dir); check the path and MANIFOLD_CSG_LIB_KIND",
-            names = external_lib_filenames(name, &kind, target_env, target_os),
+            names = external_lib_filenames(name, &kind, target_env, target_os, target_vendor),
         );
     }
 
@@ -161,10 +166,9 @@ fn try_external_lib(target_env: &str, target_os: &str) -> bool {
             // dir the linker actually searches (we emit a single
             // link-search=native above), so the name we pick is one that
             // links - keeping the probe consistent with the emit.
-            match ["tbb", "tbb12", "tbb12_static"]
-                .into_iter()
-                .find(|n| external_lib_present(lib_path, n, "static", target_env, target_os))
-            {
+            match ["tbb", "tbb12", "tbb12_static"].into_iter().find(|n| {
+                external_lib_present(lib_path, n, "static", target_env, target_os, target_vendor)
+            }) {
                 Some(tbb_name) => println!("cargo:rustc-link-lib=static={tbb_name}"),
                 None => {
                     // Don't hard-fail: a static manifold may fold TBB in or be
@@ -185,7 +189,7 @@ fn try_external_lib(target_env: &str, target_os: &str) -> bool {
     // C++ standard library, same logic as the from-source build. MSVC links
     // it automatically; Apple platforms use libc++; everything else libstdc++.
     if target_env != "msvc" {
-        if is_apple(target_os) {
+        if is_apple(target_vendor) {
             println!("cargo:rustc-link-lib=c++");
         } else {
             println!("cargo:rustc-link-lib=stdc++");
@@ -217,6 +221,7 @@ fn external_lib_filenames(
     kind: &str,
     target_env: &str,
     target_os: &str,
+    target_vendor: &str,
 ) -> Vec<String> {
     if kind == "static" {
         if target_env == "msvc" {
@@ -235,7 +240,7 @@ fn external_lib_filenames(
             format!("lib{name}.a"),
             format!("{name}.lib"),
         ]
-    } else if target_os == "macos" {
+    } else if is_apple(target_vendor) {
         vec![format!("lib{name}.dylib")]
     } else {
         vec![format!("lib{name}.so")]
@@ -251,8 +256,9 @@ fn external_lib_present(
     kind: &str,
     target_env: &str,
     target_os: &str,
+    target_vendor: &str,
 ) -> bool {
-    external_lib_filenames(name, kind, target_env, target_os)
+    external_lib_filenames(name, kind, target_env, target_os, target_vendor)
         .iter()
         .any(|f| dir.join(f).exists())
 }
@@ -292,6 +298,7 @@ fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap_or_default();
     let is_emscripten = target_os == "emscripten";
     // wasm32-unknown-unknown — bare wasm without WASI or Emscripten. Browser
     // target for wasm-bindgen consumers. Has its own dedicated build path
@@ -322,7 +329,7 @@ fn main() {
     // offline, no C++ compile. See docs/plans/offline-build.md and issue #49.
     println!("cargo:rerun-if-env-changed=MANIFOLD_CSG_LIB_DIR");
     println!("cargo:rerun-if-env-changed=MANIFOLD_CSG_LIB_KIND");
-    if !is_emscripten && try_external_lib(&target_env, &target_os) {
+    if !is_emscripten && try_external_lib(&target_env, &target_os, &target_vendor) {
         return;
     }
 
@@ -351,6 +358,6 @@ fn main() {
         &build_dir,
         &target,
         &target_env,
-        &target_os,
+        &target_vendor,
     )
 }

--- a/crates/manifold-csg-sys/build/build.rs
+++ b/crates/manifold-csg-sys/build/build.rs
@@ -23,7 +23,7 @@ pub fn build(
     build_dir: &Path,
     target: &str,
     target_env: &str,
-    target_os: &str,
+    target_vendor: &str,
 ) {
     // Configure with cmake.
     let mut parallel = env::var("CARGO_FEATURE_PARALLEL").is_ok();
@@ -159,7 +159,7 @@ pub fn build(
     // - Apple SDKs (macOS, iOS, tvOS, watchOS, visionOS) only ship libc++;
     //   there is no libstdc++ to link, so `stdc++` fails at link time.
     if !is_emscripten && target_env != "msvc" {
-        if is_apple(target_os) {
+        if is_apple(target_vendor) {
             println!("cargo:rustc-link-lib=c++");
         } else {
             println!("cargo:rustc-link-lib=stdc++");

--- a/crates/manifold-csg/CHANGELOG.md
+++ b/crates/manifold-csg/CHANGELOG.md
@@ -7,6 +7,15 @@ migration guides live at the repo root and are linked below.
 Watch especially for **behavioral** changes marked below: these compile cleanly
 but change output, so the compiler will not catch them for you.
 
+## 0.3.3
+
+- Build fix: link `libc++` (not `libstdc++`) on all Apple platforms, not just
+  macOS. iOS / tvOS / watchOS / visionOS builds previously failed to link
+  because Apple SDKs ship only libc++. Detection now keys on the target vendor
+  (`CARGO_CFG_TARGET_VENDOR == "apple"`) rather than an OS allow-list. Carried
+  by `manifold-csg-sys` 3.5.103; thanks to #52 for the original macOS-list fix.
+  No source or API changes.
+
 ## 0.3.2
 
 - Added `Manifold::slice_to_cross_section_with_fill_rule(height, fill_rule)`.

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -19,7 +19,7 @@ nalgebra = ["dep:nalgebra"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.5.102", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.5.103", default-features = false }
 thiserror = "2"
 log = "0.4"
 nalgebra = { version = "0.34", optional = true }

--- a/crates/manifold3d-sys/Cargo.toml
+++ b/crates/manifold3d-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "manifold3d-sys"
 description = "Raw FFI bindings to the manifold3d C API (facade crate — re-exports manifold-csg-sys)"
-version = "3.5.102"
+version = "3.5.103"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ parallel = ["manifold-csg-sys/parallel"]
 unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.5.102", default-features = false }
+manifold-csg-sys = { path = "../manifold-csg-sys", version = "=3.5.103", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["parallel"]

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -16,7 +16,7 @@ nalgebra = ["manifold-csg/nalgebra"]
 unstable-wasm-uu = ["manifold-csg/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg = { path = "../manifold-csg", version = "=0.3.2", default-features = false }
+manifold-csg = { path = "../manifold-csg", version = "=0.3.3", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]


### PR DESCRIPTION
Follow-up to #52 (thanks @uttarayan21 for the original macOS-list fix).

## Summary

- **Detect Apple platforms by target vendor, not an OS allow-list.** #52 special-cased the C++ stdlib link with `matches!(target_os, "macos" | "ios" | "tvos" | "watchos" | "visionos")`, which needs a new arm every time Apple ships a platform. This keys on `CARGO_CFG_TARGET_VENDOR == "apple"` instead - `apple` for every Apple triple and nothing else, so it covers current and future Apple targets and expresses the real intent (Apple ships libc++, not libstdc++).
- Threaded `CARGO_CFG_TARGET_VENDOR` through `try_external_lib` / `external_lib_filenames` / `external_lib_present` and the from-source `build()`.
- Also keyed `external_lib_filenames`' `.dylib`-vs-`.so` choice on the vendor, so the offline (`MANIFOLD_CSG_LIB_DIR`) existence check works on non-macOS Apple targets - iOS with a dylib previously looked for `lib*.so` and would wrongly fail.
- Dropped the now-unused `target_os` param from `build()`, and restored the `cmake_launcher_args` doc comment that #52's insertion had split.

## Release

The Apple link fix (both #52's and this) lives in `manifold-csg-sys`'s `build.rs`, and crates.io still has `3.5.102` without it - so a publish is required for it to reach users. This bumps `manifold-csg-sys` (and `manifold3d-sys` in lockstep) `3.5.102 -> 3.5.103`, and the workspace `0.3.2 -> 0.3.3` so the safe crate carries a `CHANGELOG.md` entry pointing at the fix.

## Test plan

- `cargo test --features nalgebra` -> 249 pass; `cargo clippy --all-targets --features nalgebra -- -D warnings` and `cargo fmt --all --check` clean.
- Host from-source build links `stdc++` (vendor `unknown`); offline path re-run against a prebuilt manifold still passes the existence check with the vendor threaded through.
- Apple targets can't be built in this CI, but the change is a pure predicate swap on a value CI can't exercise here; the linking logic is unchanged otherwise.
