### PR TITLE
Ship the license files inside every published crate

### DIFF
--- a/crates/manifold-csg-sys/LICENSE-APACHE
+++ b/crates/manifold-csg-sys/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/manifold-csg-sys/LICENSE-MIT
+++ b/crates/manifold-csg-sys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/manifold-csg/CHANGELOG.md
+++ b/crates/manifold-csg/CHANGELOG.md
@@ -9,6 +9,9 @@ but change output, so the compiler will not catch them for you.
 
 ## 0.3.4
 
+- Ships `LICENSE-APACHE` and `LICENSE-MIT` inside the crate. They lived only at
+  the repo root, outside every crate directory, so no published version back to
+  0.1.x actually carried the license text the `license` field points at.
 - Renamed the `segments` parameter to `circular_segments` on
   `Manifold::cylinder`, `Manifold::sphere`, and `CrossSection::circle`, to
   match the C API and the sibling methods that already used that name. Rust

--- a/crates/manifold-csg/LICENSE-APACHE
+++ b/crates/manifold-csg/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/manifold-csg/LICENSE-MIT
+++ b/crates/manifold-csg/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/manifold3d-macros/LICENSE-APACHE
+++ b/crates/manifold3d-macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/manifold3d-macros/LICENSE-MIT
+++ b/crates/manifold3d-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/manifold3d-sys/LICENSE-APACHE
+++ b/crates/manifold3d-sys/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/manifold3d-sys/LICENSE-MIT
+++ b/crates/manifold3d-sys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/manifold3d/LICENSE-APACHE
+++ b/crates/manifold3d/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/manifold3d/LICENSE-MIT
+++ b/crates/manifold3d/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
`LICENSE-APACHE` and `LICENSE-MIT` live at the repo root, outside every crate directory, so cargo has never packaged them. The published 0.3.3 tarball contains neither, and neither does any release back to 0.1.x.

Nothing surfaced this: cargo does not warn, and the `license = "Apache-2.0 OR MIT"` field is set correctly, so crates.io displays the right thing. The `/publish` pre-flight check for license files is what caught it.

Worth fixing rather than waving through, since Apache-2.0 section 4(a) asks that recipients of the work receive a copy of the license, and the SPDX field alone does not deliver one.

## Approach

Symlinks from each crate directory to the root files, rather than copies, so the two texts cannot drift. Cargo dereferences them at package time. Verified against the built `manifold-csg-sys-3.5.104` tarball:

```
$ tar tzf manifold-csg-sys-3.5.104.crate | grep -i licen
manifold-csg-sys-3.5.104/LICENSE-APACHE
manifold-csg-sys-3.5.104/LICENSE-MIT

$ tar xzOf manifold-csg-sys-3.5.104.crate manifold-csg-sys-3.5.104/LICENSE-MIT | head -1
MIT License
```

Real content, not a dangling link.

Covers all five publishable crates: `manifold-csg`, `manifold-csg-sys`, `manifold3d`, `manifold3d-sys`, and `manifold3d-macros`. `manifold-csg-playground` is `publish = false` and does not need them.

## No version bump

0.3.4 is not published yet, so this rides along with it rather than needing 0.3.5. The CHANGELOG entry goes under the existing 0.3.4 heading.

## Test plan

- `cargo package --list` shows both files for all five crates.
- `cargo package -p manifold-csg-sys` produces a tarball carrying the real license text (21 files, up from 19).
- Nothing else changes: no source, no metadata, no versions.
