### PR TITLE
Add a weekly upstream pin check that files an issue on drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       # but API_COVERAGE.md is never updated, which left the whole ray-casting
       # surface undocumented and the Summary reporting 208 against 290.
       - run: python3 scripts/check-api-coverage.py
+      # upstream-watch.yml only runs weekly, so without this a syntax error in
+      # its script would ship and first surface as a red job days later.
+      - run: python3 -m py_compile scripts/check-upstream.py
 
   msrv:
     name: MSRV (1.85)

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,226 @@
+name: Upstream watch
+
+# Checks weekly whether the pins this crate tracks have fallen behind, and
+# files (or updates, or reopens) a single issue when they have. GitHub emails
+# watchers on issue activity, so that is the notification path.
+#
+# NOTE: GitHub disables scheduled workflows in a public repo after 60 days
+# with no repository activity, which is the same quiet stretch this check is
+# meant to cover. GitHub emails the owner when it disables one, so it is not
+# silent, but re-enabling it is a manual step.
+
+on:
+  schedule:
+    # Mondays 13:00 UTC. GitHub cron is best-effort and can be delayed during
+    # busy periods, which is fine for a weekly hygiene check.
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+
+# Serializes runs so a dispatch does not interleave with the cron. Note this
+# narrows but does not fully close the duplicate-issue window: the lookup goes
+# through GitHub's search index, which is eventually consistent, so a run
+# starting seconds after another finishes can still miss a just-created issue.
+concurrency:
+  group: upstream-watch
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # The account that owns issues this workflow creates. Written as the real
+  # login rather than the `app/github-actions` search syntax: gh only routes
+  # to the search API when a --label filter is also present, so the search
+  # form silently returns nothing on the plain list path.
+  BOT: "github-actions[bot]"
+
+jobs:
+  check:
+    name: Check upstream pins
+    runs-on: ubuntu-latest
+    # A hung gh or socket would otherwise ride the 6h default, holding the
+    # concurrency group against a manual dispatch. 20 rather than 10 because
+    # the script's own retry budget (4 attempts, 30s socket timeout, and up to
+    # 60s of Retry-After per call) can legitimately reach ~15 minutes when
+    # GitHub is rate-limiting.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare pins against upstream
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # pipefail matters: without it `tee` swallows a crash in the script,
+          # `drift` never gets written, both later steps skip on the empty
+          # value, and the job goes green having checked nothing.
+          set -euo pipefail
+          python3 scripts/check-upstream.py | tee report.md
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Guard against an unusable result
+        # Covers two holes: the script produced no `drift` value, and the step
+        # failed *after* writing one (outputs survive a failed step, so the
+        # drift steps below would skip on their implicit success() guard while
+        # real drift went unreported).
+        if: >-
+          !cancelled() && (steps.check.outcome != 'success'
+          || steps.check.outputs.drift == '')
+        env:
+          OUTCOME: ${{ steps.check.outcome }}
+          DRIFT: ${{ steps.check.outputs.drift }}
+        run: |
+          echo "::error::check-upstream.py did not produce a usable result (outcome=${OUTCOME}, drift='${DRIFT}'). Treating as a failed run, not a clean one."
+          exit 1
+
+      - name: File, update or reopen the tracking issue
+        if: steps.check.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HASH: ${{ steps.check.outputs.hash }}
+          TITLE: ${{ steps.check.outputs.title }}
+          COMPLETE: ${{ steps.check.outputs.complete }}
+        run: |
+          set -euo pipefail
+          gh label create upstream-watch \
+            --description "Filed by the weekly upstream pin check" \
+            --color FBCA04 2>/dev/null || true
+
+          # Editing an issue body sends no notification, so the body alone
+          # cannot be the channel. The body carries a report hash; a *comment*
+          # is what gets posted when that hash changes, because comments do
+          # notify. An unchanged hash means the same stale pin as last week,
+          # so we stay quiet rather than emailing every Monday.
+          #
+          # The hash covers the findings only, not the error text. Exception
+          # strings vary between outages, so hashing them would rewrite the
+          # body, fire a spurious "situation changed" comment, and reopen an
+          # issue the maintainer had deliberately deferred -- over a blip.
+          {
+            echo "Filed automatically by [\`upstream-watch\`](https://github.com/${GITHUB_REPOSITORY}/blob/main/.github/workflows/upstream-watch.yml)."
+            echo
+            cat report.md
+            echo
+            echo "---"
+            echo
+            echo "Closes itself once the pins are current. Closing it by hand also works: it only reopens if the findings change, so closing is a way to say \"known, deferred\"."
+            echo "Run \`python3 scripts/check-upstream.py\` locally to re-check."
+            echo "<!-- report-hash: ${HASH} -->"
+          } > body.md
+
+          # --state all so a closed issue is reopened rather than duplicated,
+          # and --author so a human issue that happens to carry this label
+          # never has its body overwritten by the report.
+          num=$(gh issue list --label upstream-watch --state all --limit 1 \
+            --author "$BOT" --json number --jq '.[0].number // empty')
+
+          if [ -z "$num" ]; then
+            # Assigned so delivery does not depend on the watch setting being
+            # All Activity. Assumes a user-owned repo: an organization is not
+            # an assignable user, so if this repo is ever transferred, drop the
+            # --assignee (the job would fail loudly rather than misfile).
+            gh issue create --title "$TITLE" --label upstream-watch \
+              --assignee "${GITHUB_REPOSITORY_OWNER}" --body-file body.md
+            exit 0
+          fi
+
+          # An incomplete run (a transient lookup failure) does not know the
+          # true state, so it must not touch an existing issue. Its findings
+          # list is short by however many checks failed, which would otherwise
+          # read as "the findings changed": that would rewrite the body, post a
+          # spurious comment, and reopen an issue deliberately deferred -- all
+          # because GitHub had a blip. The issue above is still created when
+          # none exists, so a sustained outage is not invisible.
+          if [ "$COMPLETE" != "true" ]; then
+            # Failing is deliberate. Leaving the issue alone is right -- an
+            # incomplete run must not un-defer it or rewrite its findings --
+            # but exiting 0 would make an indefinite outage indistinguishable
+            # from a clean week: quiet, green, forever. A red job emails.
+            # Cost is one extra notification per genuine blip.
+            echo "::error::Run was incomplete (transient lookup failure), so #$num was left untouched and this week's findings were not delivered. Re-run once upstream is reachable."
+            exit 1
+          fi
+
+          # No `|| true` on these fetches: an API failure must fail the step,
+          # not yield an empty hash that reads as "changed" and fires a
+          # spurious notification.
+          prevbody=$(gh issue view "$num" --json body --jq .body)
+          state=$(gh issue view "$num" --json state --jq .state)
+          prev=$(printf '%s' "$prevbody" | grep -oP '(?<=<!-- report-hash: )[a-zA-Z0-9]+' || true)
+
+          if [ "$prev" = "$HASH" ] && [ "$state" = "CLOSED" ]; then
+            echo "#$num closed with identical findings; respecting the deferral"
+            exit 0
+          fi
+
+          # Notify FIRST, advance the stored hash LAST. If a reopen or comment
+          # fails midway, the body still holds the old hash, so next week
+          # retries the notification instead of concluding it already sent one.
+          # The failure direction is a duplicate comment, never a lost one.
+          if [ "$state" = "CLOSED" ]; then
+            gh issue reopen "$num"
+            { echo "Reopening: the upstream findings changed."; echo; cat report.md; } \
+              | gh issue comment "$num" --body-file -
+            echo "Reopened #$num with a comment"
+          elif [ "$prev" != "$HASH" ]; then
+            { echo "The upstream findings changed since the last check."; echo; cat report.md; } \
+              | gh issue comment "$num" --body-file -
+            echo "Commented on #$num (findings changed)"
+          else
+            echo "#$num already open with the same findings; refreshing body only"
+          fi
+
+          gh issue edit "$num" --title "$TITLE" --body-file body.md
+
+      - name: Close the tracking issue when pins are current
+        if: steps.check.outputs.drift == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.check.outputs.title }}
+        run: |
+          set -euo pipefail
+          num=$(gh issue list --label upstream-watch --state open --limit 1 \
+            --author "$BOT" --json number --jq '.[0].number // empty')
+          if [ -n "$num" ]; then
+            # Rewrite the body too, so a closed issue does not sit there
+            # asserting drift that no longer exists. No hash marker: the next
+            # drift run must treat this as changed and notify.
+            # Use the real report rather than a hardcoded all-clear: a run can
+            # reach drift=false having *skipped* checks (a SHA pin has no
+            # version to compare), and closing with "all current" would hide
+            # that the comparison never ran.
+            {
+              echo "Closing: the weekly check found nothing outstanding."
+              echo
+              cat report.md
+              echo
+              echo "Filed and closed automatically by \`upstream-watch\`."
+            } > body.md
+            # $TITLE, not a literal: a run can reach drift=false having skipped
+            # checks, and the title is the email subject and the issue-list row.
+            gh issue edit "$num" --title "$TITLE" --body-file body.md
+            # gh issue close takes --comment as a string only, no --comment-file.
+            gh issue close "$num" \
+              --comment "$(printf 'Closed by the weekly check:\n\n%s' "$(cat report.md)")"
+          else
+            # No open issue, but a hand-closed one may still carry a hash. That
+            # marker is load-bearing, not decoration: the drift step reads it to
+            # decide "closed with identical findings, deferral respected". Left
+            # in place after the drift is fixed, an identical recurrence later
+            # matches it and stays silent forever. Strip it here. Editing a body
+            # sends no notification, so this stays quiet as intended.
+            cnum=$(gh issue list --label upstream-watch --state closed --limit 1 \
+              --author "$BOT" --json number --jq '.[0].number // empty')
+            if [ -n "$cnum" ]; then
+              cbody=$(gh issue view "$cnum" --json body --jq .body)
+              case "$cbody" in
+                *'<!-- report-hash:'*)
+                  printf '%s\n' "$cbody" | grep -v '<!-- report-hash:' > body.md
+                  gh issue edit "$cnum" --body-file body.md
+                  echo "Cleared the stale report hash on closed #$cnum"
+                  ;;
+              esac
+            fi
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target
 Cargo.lock
 rust_out
+
+# Python bytecode from scripts/
+__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ A repo-root `flake.nix` exposes a devShell that links nixpkgs' prebuilt `manifol
 - When bumping the manifold3d pin in `build.rs`, the sys crate version must be updated to match (e.g., manifold3d v3.5.0 -> sys crate `3.5.100`).
 - When bumping `MANIFOLD_VERSION`, also run `nix flake update` and commit the new `flake.lock`: the `nix-offline` lane links nixpkgs' prebuilt `manifold`, which must resolve to the new pinned version or the lane links an ABI-mismatched library. The committed lock is what makes the "nixpkgs manifold matches our pin" guarantee reproducible.
 - **Before bumping `MANIFOLD_VERSION`, check that `wasm-cxx-shim` supports the new pin.** As of shim v0.5.0 the helper (`wasm_cxx_shim_add_manifold()`) ships **no** carry-patches for default-pin builds - it passes `MANIFOLD_GIT_TAG` straight to `FetchContent`, and patches arrive only via the caller's `EXTRA_MANIFOLD_PATCHES`, which we do not pass. So a pin past the shim's tested version has no patch that can fail to apply. What the shim does supply is the libc++/libc surface manifold compiles against, so the real risks are (a) a compile break if the new manifold reaches for something the shim lacks, and (b) wasm-uu link failures from FFI declarations for C API added in the gap. Both surface in the wasm-uu CI lane. Two paths if the shim hasn't caught up: (1) wait for a shim release that pins past your target SHA, or (2) cfg-gate the new FFI surface on `not(all(target_arch = "wasm32", target_os = "unknown"))` so the wasm-uu lane stays on the shim's tested pin. The "Pin / shim follow-ups" section below covers the post-bump cleanups for path (2).
-- The sys crate pins upstream to a specific commit SHA rather than a tag. This is necessary because upstream doesn't follow strict semver — minor releases can include breaking changes. Pinning to a commit gives us the same reproducibility as a tag, while allowing us to pick up post-release fixes and carry-patches between releases.
+- **Prefer a release tag for `MANIFOLD_VERSION`.** Upstream doesn't follow strict semver (minor releases can include breaking changes), so the pin is exact either way, but a tag keeps it legible against upstream's releases and lets `upstream-watch` tell you when a newer release lands. A commit SHA is a deliberate exception, for picking up a post-release fix or a carry-patch base between releases; `upstream-watch` skips a SHA pin rather than nagging, on the assumption it was chosen on purpose.
 - **Version bumps**: feature PRs may (and usually should) include their own version bump so the merge is ready to publish. The `/publish` skill will bump at publish time only if no PR has done so since the last release. Note that `cargo-semver-checks` CI requires a bump whenever the PR changes the public API in a way the current version doesn't allow (e.g., a breaking change requires a minor bump pre-1.0).
 - **Facade crates** (`manifold3d`, `manifold3d-sys`) always ship in lockstep with their canonical counterparts (`manifold-csg`, `manifold-csg-sys`) via `=` version pins. Bumping the canonical means bumping the facade.
 
@@ -57,6 +57,54 @@ A repo-root `flake.nix` exposes a devShell that links nixpkgs' prebuilt `manifol
 - `unsafe impl Send` requires documented justification on each type
 - `Sync` is implemented for `Manifold` and `CrossSection` (upstream synchronizes lazy evaluation with a mutex). `MeshGL`/`MeshGL64` are also `Sync` (pure data, no lazy state)
 - `manifold_meshgl_merge` / `manifold_meshgl64_merge` had an upstream ownership bug (returning the input pointer on failure, causing double-free). This was fixed upstream in #1632 (included in our pinned commit).
+
+## Upstream watch
+
+`.github/workflows/upstream-watch.yml` runs `scripts/check-upstream.py` weekly (Mondays 13:00 UTC, plus `workflow_dispatch`) and keeps a single reusable issue labelled `upstream-watch`. Run the script locally any time; it needs no arguments, and `GITHUB_TOKEN` only to avoid API rate limits.
+
+It checks three things: `MANIFOLD_VERSION` against the newest `elalish/manifold` release, `WASM_CXX_SHIM_TAG` against the newest `wasm-cxx-shim` release, and whether the nixpkgs revision in `flake.lock` still ships the manifold version we pin. The third is an invariant rather than drift - a mismatch means the `nix-offline` lane links a different manifold than we pin, which can pass CI while being wrong.
+
+**Release tags only, and only strictly newer ones.** A SHA, branch, or pre-release pin is skipped for the *drift* comparison rather than flagged: per the Versioning section above those are a deliberate exception and do not want a weekly reminder. "Newest release" is the highest semver among non-draft, non-pre-release releases, taken by version rather than by date, so a backport cut after a newer release cannot shadow it. The nixpkgs invariant still runs against a SHA pin - that is exactly when nixpkgs is most likely to disagree - and reports what it could not compare.
+
+The script sorts results into three classes, and the distinction is load-bearing:
+
+| Class | Meaning | Hashed? | Sets `complete=false`? |
+|---|---|---|---|
+| findings | wrong until someone acts: drift, a nixpkgs mismatch, or the check itself being structurally broken (a renamed const, an unreadable file, a non-rate-limit 4xx, a `flake.lock` that changed keys or shape) | yes | no |
+| errors | a transient lookup failure: timeout, DNS, 5xx, or a rate limit (403/429) surviving retries | no | yes |
+| skips | a check that did not apply, e.g. version comparison against a SHA pin | no | no |
+
+Structural breakage is a *finding*, not an error, because it never self-heals: as an error it would be unhashed, so a permanently broken check would sit silent behind an unchanged findings hash. The HTTP split is stated as a range (403/429/5xx transient, every other 4xx structural) rather than a list, because a list has to stay complete and anything it misses lands in the freezing category. A run that skipped anything never prints "All pinned release tags are current", so a reduced run cannot read as a clean bill of health.
+
+Notification is the point, so the issue handling is built around what GitHub actually emails on. **Editing an issue body sends nothing.** The body carries a `<!-- report-hash: ... -->` marker and a *comment* is what gets posted when that hash changes, because comments do notify.
+
+| State | Action | Notifies? |
+|---|---|---|
+| no issue yet | create | yes |
+| any existing issue, run incomplete | leave untouched, **fail the job** | yes, via the Actions failure email |
+| closed, findings changed | reopen + comment | yes |
+| open, findings changed | comment, then refresh body | yes |
+| open, same findings | refresh body only | no - a known-stale pin should not email every Monday |
+| closed, same findings | leave closed | no - closing by hand means "known, deferred" |
+| pins current again | rewrite body + close with comment | yes |
+
+Details that are load-bearing rather than incidental:
+
+- The hash covers **findings only**, and an incomplete run additionally **leaves an existing issue alone**. Both are needed for the same guarantee: a transient outage empties the findings list, so without the `complete` gate a blip would reopen a deferred issue and post two spurious "findings changed" comments. An outage still creates an issue when none exists, so a sustained one is not invisible.
+- The notification is sent **before** the body is rewritten. If a reopen or comment fails midway, the stored hash is still the old one, so the next run retries. The failure direction is a duplicate comment, never a lost one.
+- The lookup passes `--state all` so a closed issue is reopened rather than duplicated, and `--author 'github-actions[bot]'` so a human issue carrying the label never has its body overwritten. That is the real login; the `app/github-actions` search syntax only resolves on gh's search path and silently matches nothing without a `--label` filter.
+- An incomplete run leaves the existing issue alone *and fails the job*. Leaving it alone is required (it must not un-defer or rewrite findings it could not verify), but exiting 0 as well would make an indefinite outage indistinguishable from a clean week: quiet, green, forever. The red job is the escalation. One extra notification per genuine blip is the price.
+- Closing and reopening comments carry the full report, and the issue is assigned to the repo owner on create, so delivery does not depend on the watch setting.
+- When the pins come current and there is no open bot issue, the close step strips the `report-hash` marker from the hand-closed one. That marker is load-bearing rather than decoration: the drift step reads it to decide "closed with identical findings, deferral respected". Left in place after a fix, an identical recurrence later would match it and stay silent. Editing a body sends no notification, so the cleanup is quiet.
+- The report is echoed to `$GITHUB_STEP_SUMMARY`, so on the red/incomplete path the Actions failure email lands on a page that says what was found rather than only a raw log.
+- The issue title tracks the report too, including "(some checks skipped)". The title is the email subject and the issue-list row, so it cannot claim a clean bill of health the body withholds.
+- The issue is assigned to the repo owner on create. That assumes a user-owned repo; an organization is not an assignable user, so a transfer would need the `--assignee` dropped.
+- `ci.yml` byte-compiles `check-upstream.py` on every PR. The workflow itself only runs weekly, so otherwise a syntax error would first surface days later as a red scheduled job.
+- A guard step fails the job when the script produced no usable result, including when the step failed *after* writing an output - outputs survive a failed step, so otherwise real drift could be skipped by the implicit `success()` guard on the steps below.
+
+Upstream cuts release tags on a side branch that is never merged back to master, so git ancestry between a master commit and a release tag is always "diverged". That rules out inferring a version from a SHA pin, which is why the comparison is tag-only.
+
+GitHub disables scheduled workflows in a public repo after 60 days without repository activity, which is the same quiet stretch this check covers. Note that issue activity and workflow runs do not reset that timer, only repository activity does. GitHub emails the owner on disable, but re-enabling is manual.
 
 ## Pin / shim follow-ups
 

--- a/crates/manifold-csg-sys/build.rs
+++ b/crates/manifold-csg-sys/build.rs
@@ -13,8 +13,13 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 /// Pinned upstream manifold version. Accepts a tag (e.g., "v3.5.0"),
-/// branch, or commit SHA. Prefer SHAs for reproducibility (and
-/// post-release fixes), tags for tagged releases.
+/// branch, or commit SHA.
+///
+/// **Prefer a release tag.** A SHA is a deliberate exception, for picking up
+/// a post-release fix or a carry-patch base between releases. Tags keep the
+/// pin legible against upstream's releases, and the `upstream-watch` workflow
+/// only compares tags -- it skips a SHA pin on the assumption that one was
+/// chosen on purpose and needs no reminder.
 ///
 /// Used by both the host build (which clones this directly) and the
 /// wasm-uu build (which passes it through to the shim's

--- a/scripts/check-upstream.py
+++ b/scripts/check-upstream.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Report when the release tags this crate pins have fallen behind upstream.
+
+It looks at:
+
+  1. MANIFOLD_VERSION           vs the newest elalish/manifold release
+  2. WASM_CXX_SHIM_TAG          vs the newest wasm-cxx-shim release
+  3. nixpkgs' manifold, at the revision our flake.lock pins, vs MANIFOLD_VERSION
+
+Only release tags are compared for drift. A SHA or branch pin is skipped,
+not flagged: per CLAUDE.md those are a deliberate exception (a post-release
+fix, a carry-patch base) and do not want a weekly reminder. Skips are still
+*disclosed* in the report, so a run that checked less than usual can never
+read as a clean bill of health.
+
+Three result classes, deliberately distinct:
+
+  findings  something is wrong and will stay wrong until someone acts. Drift,
+            a nixpkgs mismatch, and structural breakage (a const that no
+            longer parses, a nixpkgs package that changed shape). Hashed, so
+            a change here is what earns a notification.
+  errors    a transient lookup failure. NOT hashed, and sets complete=false,
+            because an incomplete run must not rewrite the stored state or
+            reopen an issue that was deliberately deferred.
+  skips     a check that could not apply, e.g. the nixpkgs version comparison
+            against a SHA pin. Informational; never drift.
+
+Prints a markdown report on stdout. Writes `drift`, `complete`, `title` and
+`hash` to $GITHUB_OUTPUT. Exit status is 0 whenever a report was produced;
+non-zero is reserved for crashes, where the report would be untrustworthy.
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BUILD_RS = ROOT / "crates/manifold-csg-sys/build.rs"
+WASM_RS = ROOT / "crates/manifold-csg-sys/build/wasm.rs"
+FLAKE_LOCK = ROOT / "flake.lock"
+
+UA = "manifold-csg-upstream-watch (+https://github.com/zmerlynn/manifold-csg)"
+MANIFOLD = "elalish/manifold"
+SHIM = "zmerlynn/wasm-cxx-shim"
+
+# Plain release tags only: `v3.5.2` or `3.5.2`. Anything with a pre-release or
+# build suffix, and anything SHA-shaped, is deliberately not comparable here.
+RELEASE_TAG = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+class CheckError(Exception):
+    """A structural problem: a const that no longer parses, a nixpkgs package
+    that changed shape, a repo with no comparable releases.
+
+    Kept separate from transient network failures because the two need
+    opposite handling. A structural break never self-heals, so it has to be a
+    *finding* -- hashed, and therefore notified. A network blip does self-heal,
+    so it must not rewrite the stored hash or reopen a deferred issue."""
+
+
+def version(tag):
+    m = RELEASE_TAG.match(tag)
+    return tuple(int(g) for g in m.groups()) if m else None
+
+
+def api(path, raw=False, retries=4):
+    """GET api.github.com/{path}, retrying transient failures.
+
+    Without retries a single 5xx at 13:00 Monday costs a full week of
+    coverage, since the next scheduled run is seven days out. 403 is retried
+    too: GitHub uses it for secondary rate limits, not just for auth.
+    """
+    url = f"https://api.github.com/{path}"
+    headers = {"User-Agent": UA}
+    if tok := os.environ.get("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {tok}"
+    if raw:
+        headers["Accept"] = "application/vnd.github.raw"
+    last = None
+    for attempt in range(retries):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=30) as r:
+                body = r.read().decode()
+            return body if raw else json.loads(body)
+        except urllib.error.HTTPError as e:
+            last = e
+            if e.code in (403, 429) or 500 <= e.code < 600:
+                # Transient: rate limits (GitHub uses 403 for the secondary
+                # one) and server errors. Fall through to the retry below.
+                pass
+            elif 400 <= e.code < 500:
+                # Any other 4xx is permanent: a moved package path, a renamed
+                # repo, a revoked token, a repo taken down. Stated as a range
+                # rather than a list, because a list has to stay complete --
+                # and anything it misses becomes a transient error, which sets
+                # complete=false and freezes the issue untouched every week
+                # while real drift goes unreported.
+                raise CheckError(f"{e.code} for {path} ({e.reason})") from e
+            else:
+                raise
+            delay = e.headers.get("Retry-After") if e.headers else None
+            if delay and delay.isdigit() and attempt < retries - 1:
+                time.sleep(min(int(delay), 60))
+                continue
+        except Exception as e:  # noqa: BLE001 - timeouts, DNS, reset
+            last = e
+        if attempt < retries - 1:
+            time.sleep(2**attempt)
+    raise last
+
+
+def const(path, name):
+    """Read a `const NAME: &str = "..."`, anchored so a doc comment or a
+    commented-out line cannot be picked up instead."""
+    try:
+        text = path.read_text()
+    except OSError as e:
+        raise CheckError(f"cannot read {path.name} ({e})") from e
+    m = re.search(
+        rf'^\s*(?:pub(?:\([^)]*\))?\s+)?const {name}: &str = "([^"]+)";',
+        text,
+        re.M,
+    )
+    if not m:
+        raise CheckError(f"could not find `const {name}` in {path.name}")
+    return m.group(1)
+
+
+def newest_release(repo):
+    """Highest released version, by version number rather than by date.
+
+    `/releases/latest` is "most recent by date", so a backported patch cut
+    after a newer release would shadow it. Taking the max over the 100 most
+    recent releases avoids that, and lets us drop drafts and pre-releases
+    explicitly. The list is date-descending, so the highest version is always
+    on the first page for these repos; if a repo ever has no comparable tag in
+    that window, the caller raises rather than reporting "current".
+    """
+    best = None
+    for r in api(f"repos/{repo}/releases?per_page=100"):
+        if r["draft"] or r["prerelease"]:
+            continue
+        if (v := version(r["tag_name"])) and (best is None or v > best[0]):
+            best = (v, r["tag_name"])
+    return best[1] if best else None
+
+
+def check_pin(label, path, name, repo):
+    """(finding, skip) for one pinned tag."""
+    pinned = const(path, name)
+    pin_v = version(pinned)
+    if pin_v is None:
+        return None, (
+            f"- **{label}**: pinned `{pinned}`, which is not a release tag, so "
+            "no drift comparison was made (assumed deliberate)."
+        )
+    latest = newest_release(repo)
+    if latest is None:
+        raise CheckError(f"{repo} has no comparable release tags")
+    if version(latest) <= pin_v:
+        return None, None
+    return (
+        f"- **{label}**: pinned `{pinned}`, newest release is "
+        f"[`{latest}`](https://github.com/{repo}/releases/tag/{latest})"
+    ), None
+
+
+def check_nixpkgs():
+    """(finding, skip) for the nix-offline invariant.
+
+    Runs whatever form the pin takes. This is an invariant, not drift, so it
+    should not be gated on the pin being a comparable tag; against a SHA pin
+    it reports what it could not compare rather than returning nothing.
+    """
+    pin = const(BUILD_RS, "MANIFOLD_VERSION")
+    try:
+        rev = json.loads(FLAKE_LOCK.read_text())["nodes"]["nixpkgs"]["locked"]["rev"]
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        raise CheckError(
+            f"cannot read the nixpkgs revision from flake.lock ({e!r}); "
+            "the file moved or the input was restructured"
+        ) from e
+    pkg = api(
+        f"repos/NixOS/nixpkgs/contents/pkgs/by-name/ma/manifold/package.nix?ref={rev}",
+        raw=True,
+    )
+    m = re.search(r'^\s*version\s*=\s*"([^"]+)"', pkg, re.M)
+    if not m:
+        raise CheckError(
+            f"no `version = ...` in nixpkgs manifold/package.nix at {rev[:12]} "
+            "(package moved or changed shape?)"
+        )
+    nix_ver = m.group(1)
+    if version(pin) is None:
+        return None, (
+            f"- **nixpkgs**: our pin `{pin[:12]}` is not a release tag, so it "
+            f"cannot be compared to the `{nix_ver}` that the pinned nixpkgs "
+            "ships. Confirm the `nix-offline` lane by hand."
+        )
+    if version(nix_ver) == version(pin):
+        return None, None
+    return (
+        f"- **nixpkgs mismatch**: our pin is `{pin}` but the nixpkgs revision "
+        f"in `flake.lock` ships manifold `{nix_ver}`. The `nix-offline` lane "
+        "links that prebuilt library, so it tests against a different version "
+        "than we ship. Run `nix flake update`."
+    ), None
+
+
+def main():
+    findings, errors, skips = [], [], []
+
+    def run(label, fn):
+        try:
+            finding, skip = fn()
+            if finding:
+                findings.append(finding)
+            if skip:
+                skips.append(skip)
+        except CheckError as e:
+            # Structural: never self-heals, so it belongs with the findings
+            # where it is hashed and therefore notified.
+            findings.append(f"- **{label}**: check is broken and needs fixing ({e})")
+        except Exception as e:  # noqa: BLE001 - transient: network, DNS, 5xx
+            errors.append(f"- **{label}**: lookup failed, status unknown ({e})")
+
+    for label, path, name, repo in (
+        ("manifold3d", BUILD_RS, "MANIFOLD_VERSION", MANIFOLD),
+        ("wasm-cxx-shim", WASM_RS, "WASM_CXX_SHIM_TAG", SHIM),
+    ):
+        run(label, lambda p=path, n=name, r=repo, l=label: check_pin(l, p, n, r))
+    run("nixpkgs check", check_nixpkgs)
+
+    out = []
+    if findings:
+        out.append("Needs attention:\n")
+        out.append("\n".join(findings))
+        out.append(
+            "\nBefore bumping `MANIFOLD_VERSION`, check that `wasm-cxx-shim` "
+            "supports the new pin, and pair the bump with a `nix flake update` "
+            "so the `nix-offline` lane keeps matching. See the Versioning "
+            "section of CLAUDE.md."
+        )
+    if errors:
+        if out:
+            out.append("")
+        out.append("Checks that could not run. Treat these as unknown, not as clear:\n")
+        out.append("\n".join(errors))
+    if skips:
+        if out:
+            out.append("")
+        out.append("Checks that did not apply:\n")
+        out.append("\n".join(skips))
+    if not findings and not errors:
+        headline = "No outstanding drift." if skips else "All pinned release tags are current."
+        out = [headline, ""] + out if out else [headline]
+    print("\n".join(out))
+
+    # Hash the findings ONLY. Error text carries exception detail that varies
+    # between outages, and hashing it would rewrite the issue body, fire a
+    # spurious "findings changed" comment, and reopen an issue the maintainer
+    # had deliberately deferred -- over a blip. `complete` is the other half of
+    # that guarantee: an incomplete run must not advance the stored state.
+    digest = hashlib.sha256("\n".join(findings).encode()).hexdigest()[:12]
+
+    if findings:
+        title = "Upstream pins need attention"
+    elif errors:
+        title = "Upstream pin check could not run"
+    elif skips:
+        # The body already withholds "all current" when something was skipped;
+        # the title is the email subject and the issue-list row, so it has to
+        # do the same or it becomes the most visible overstatement.
+        title = "Upstream pins are current (some checks skipped)"
+    else:
+        title = "Upstream pins are current"
+
+    if gho := os.environ.get("GITHUB_OUTPUT"):
+        with open(gho, "a") as f:
+            f.write(f"drift={'true' if (findings or errors) else 'false'}\n")
+            f.write(f"complete={'false' if errors else 'true'}\n")
+            f.write(f"hash={digest}\n")
+            f.write(f"title={title}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a weekly check that files a GitHub issue when a pinned upstream version falls behind. GitHub emails on issue activity, so that is the notification path.

## What it checks

`scripts/check-upstream.py` compares three things:

- `MANIFOLD_VERSION` against the newest `elalish/manifold` release
- `WASM_CXX_SHIM_TAG` against the newest `wasm-cxx-shim` release
- whether the nixpkgs revision in `flake.lock` still ships the manifold version we pin

The third is an invariant rather than drift: the `nix-offline` lane links nixpkgs' prebuilt manifold, so a mismatch means it tests a different library than we ship, which can pass CI while being wrong.

Only release tags are compared, and only strictly newer semver. A SHA or branch pin is skipped rather than flagged, since those are chosen deliberately. Skips are disclosed, so a run that checked less than usual cannot read as a clean bill of health. Also updates CLAUDE.md and `build.rs` to prefer tags, with SHAs as the documented exception.

"Newest release" is the highest semver among non-draft, non-pre-release releases, taken by version rather than by date, so a backport cut after a newer release cannot shadow it.

## Notification behaviour

- Editing an issue body sends no notification, so the body carries a hash of the findings and a *comment* is what gets posted when that hash changes.
- The comment is sent before the body is rewritten, so a mid-sequence failure retries next run. The failure direction is a duplicate comment, never a lost one.
- Structural breakage (a renamed const, an unreadable file, a non-rate-limit 4xx, a `flake.lock` that changed keys or shape) is a finding, so it is hashed and notified. Unhashed, a permanently broken check would sit silent behind an unchanged hash.
- A transient failure sets `complete=false`: the run leaves an existing issue untouched and fails the job, so an outage cannot look like a clean week.
- Closing by hand means "known, deferred" and is respected. Once the pins are current the close step strips the stored hash, so a later identical recurrence still notifies.
- A guard step fails the job when the script produced no usable result, including when the step failed after writing an output.

One reusable issue rather than one per run, since a stale pin is a standing condition rather than an event.

| State | Action | Notifies? |
|---|---|---|
| no issue yet | create | yes |
| any existing issue, run incomplete | leave untouched, fail the job | yes, via the Actions failure email |
| closed, findings changed | reopen + comment | yes |
| open, findings changed | comment, then refresh body | yes |
| open, same findings | refresh body only | no |
| closed, same findings | leave closed | no |
| pins current again | rewrite body + close with comment | yes |

## Test plan

- `python3 scripts/check-upstream.py` reports all pins current against the real API.
- Drift detected for an older tag pin; nothing reported for a SHA pin, with the skip disclosed.
- Structural breaks verified as hashed findings: a renamed const, a 4xx, and three `flake.lock` shape changes (nodes as a list, nixpkgs as a follows-alias string, locked as a list).
- A simulated outage sets `complete=false`, leaves an existing issue untouched, and fails the job.
- All seven rows of the table above walked against the shell.
- `ci.yml` byte-compiles the script on every PR, since the workflow itself only runs weekly.

## Known limitation

GitHub disables scheduled workflows in a public repo after 60 days without repository activity, and issue activity and workflow runs do not reset that timer. GitHub emails the owner on disable, but re-enabling is manual.
