### PR TITLE
Add Dependabot for cargo manifests and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+# Two ecosystems, for two different reasons.
+#
+# cargo: this workspace does not commit a Cargo.lock, so consumers resolve
+# transitive dependencies themselves and a patch release upstream reaches them
+# with no action from us. What does need action is a dependency releasing
+# OUTSIDE our declared range -- and specifically one that appears in the public
+# API. `nalgebra` is the only such dependency: `Vector3<f64>` and `Point3<f64>`
+# show up in `Manifold::*_nalgebra` signatures, so if a consumer is on a
+# nalgebra we do not accept, their vectors are a different type from ours and
+# the whole feature quietly stops being usable for them. thiserror, log and
+# cmake are internal and observable by nobody.
+#
+# github-actions: pinned action majors drift apart silently. This repo already
+# has actions/checkout at both @v4 and @v5 across workflows, and cache the same.
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for the routine noise, so the only PRs that stand alone are the
+      # ones that need a judgement call (a new major, or a 0.x minor, which for
+      # a 0.x crate is the breaking one).
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering two ecosystems, for two different reasons.

## cargo

This workspace commits no `Cargo.lock`, so consumers resolve transitive dependencies themselves and an upstream patch release reaches them with no action from us. Cutting a release for those would be noise.

What does need action is a dependency releasing **outside our declared range**, and specifically one that is visible in the public API. `nalgebra` is the only one that qualifies: `Vector3<f64>` and `Point3<f64>` appear in the `Manifold::*_nalgebra` signatures, so a consumer on a nalgebra version we do not accept ends up with two copies in their dependency tree, and their vectors are a *different type* from ours. The feature quietly stops being usable, with no compiler error pointing at the cause. `thiserror`, `log` and `cmake` are internal and observable by nobody.

That case is live right now: nalgebra 0.35.0 is out and our `"0.34"` requirement excludes it (`^0.34` means `<0.35` for a 0.x crate). That bump is a separate PR, since it is a judgement call about dropping 0.34 rather than routine maintenance.

## github-actions

Pinned action majors drift apart quietly. This repo already runs `actions/checkout` at both `@v4` and `@v5`, and `actions/cache` the same, depending on which workflow you look at.

## Grouping

Minor and patch updates land as one grouped PR each week. The updates that stand alone are the ones that need a judgement call: a new major, or a 0.x minor, which for a 0.x crate is the breaking one. That is deliberate, so nalgebra-shaped changes never get lost inside a batch.

## Test plan

Config-only; nothing to build. `.github/dependabot.yml` parses as valid YAML with `version: 2` and both ecosystems resolving. GitHub validates it on push and will surface any schema error on the repo's Dependabot page.
