### PR TITLE
Move the optional nalgebra dependency to 0.35; release 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,10 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-${{ hashFiles('**/Cargo.lock', 'crates/manifold-csg-sys/build.rs', 'crates/manifold-csg-sys/build/**', 'crates/manifold-csg/build.rs') }}
           restore-keys: ${{ runner.os }}-cargo-msrv-${{ hashFiles('crates/manifold-csg-sys/cache-version') }}-
-      # nalgebra 0.34 (unconditional dev-dep) requires Rust 1.87+,
-      # so MSRV check verifies the library builds but skips tests.
+      # nalgebra 0.35 (unconditional dev-dep) requires Rust 1.89+, so the
+      # MSRV check verifies the library builds but skips tests. rust-version
+      # stays 1.85 because that is the floor for the crate itself; enabling
+      # the optional `nalgebra` feature inherits nalgebra's higher floor.
       - name: Build
         run: cargo build
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/zmerlynn/manifold-csg"

--- a/MIGRATION_0.3.4_TO_0.4.0.md
+++ b/MIGRATION_0.3.4_TO_0.4.0.md
@@ -19,10 +19,21 @@ pub fn to_vertices_and_faces(&self) -> (Vec<nalgebra::Point3<f64>>, Vec<[u32; 3]
 ```
 
 Cargo treats `nalgebra 0.34` and `nalgebra 0.35` as incompatible, so if your
-project still requires `0.34`, both end up in your dependency tree. Your
-`Vector3<f64>` is then a *different type* from the one these methods take, and
-the calls stop compiling with a "mismatched types" error naming what look like
-two identical types.
+project still requires `0.34`, both end up in your dependency tree and your
+`Vector3<f64>` is a *different type* from the one these methods take.
+
+The error is clear about it, so you should not have to guess:
+
+```
+error[E0308]: mismatched types
+  |     let _ = m.mirror_nalgebra(&n);
+  |               --------------- ^^ expected `Matrix<f64, Const<3>, Const<1>, ...>`,
+  |                                  found a different `Matrix<f64, Const<3>, Const<1>, ...>`
+note: there are multiple different versions of crate `nalgebra` in the dependency graph
+  --> .../nalgebra-0.35.0/src/base/matrix.rs:178:1     this is the expected type
+  --> .../nalgebra-0.34.2/src/base/matrix.rs:178:1     this is the found type
+  = help: you can use `cargo tree` to explore your dependency tree
+```
 
 ## Cargo.toml
 
@@ -72,7 +83,7 @@ If you would rather hand this to an assistant, the following is enough context:
 > `nalgebra` feature now requires nalgebra 0.35 instead of 0.34. Please update
 > my `Cargo.toml` so `manifold-csg` (or `manifold3d`) is `"0.4"` and my own
 > `nalgebra` dependency is `"0.35"`, then fix any compile errors that come from
-> nalgebra's own 0.34-to-0.35 changes. No manifold-csg API changed, so any
-> error mentioning two seemingly identical `Vector3<f64>` or `Point3<f64>`
-> types means a stale nalgebra version is still resolving somewhere; check with
-> `cargo tree -d`.
+> nalgebra's own 0.34-to-0.35 changes. No manifold-csg API changed, so an
+> E0308 saying "there are multiple different versions of crate `nalgebra` in
+> the dependency graph" means a stale nalgebra is still resolving somewhere;
+> find it with `cargo tree -d`.

--- a/MIGRATION_0.3.4_TO_0.4.0.md
+++ b/MIGRATION_0.3.4_TO_0.4.0.md
@@ -1,0 +1,78 @@
+# Migrating from manifold-csg 0.3.4 to 0.4.0
+
+**If you do not use the `nalgebra` feature, there is nothing to do.** Bump the
+version and you are done. No API changed in this release.
+
+If you do use it, the optional `nalgebra` dependency moved from `0.34` to
+`0.35`, and you need to move with it.
+
+## Why it matters
+
+`nalgebra::Vector3<f64>` and `nalgebra::Point3<f64>` appear directly in this
+crate's public signatures:
+
+```rust
+pub fn trim_by_plane_nalgebra(&self, normal: &nalgebra::Vector3<f64>, offset: f64) -> Self
+pub fn mirror_nalgebra(&self, normal: &nalgebra::Vector3<f64>) -> Self
+pub fn bounding_box_nalgebra(&self) -> Option<(nalgebra::Point3<f64>, nalgebra::Point3<f64>)>
+pub fn to_vertices_and_faces(&self) -> (Vec<nalgebra::Point3<f64>>, Vec<[u32; 3]>)
+```
+
+Cargo treats `nalgebra 0.34` and `nalgebra 0.35` as incompatible, so if your
+project still requires `0.34`, both end up in your dependency tree. Your
+`Vector3<f64>` is then a *different type* from the one these methods take, and
+the calls stop compiling with a "mismatched types" error naming what look like
+two identical types.
+
+## Cargo.toml
+
+```diff
+ [dependencies]
+-manifold-csg = { version = "0.3", features = ["nalgebra"] }
+-nalgebra = "0.34"
++manifold-csg = { version = "0.4", features = ["nalgebra"] }
++nalgebra = "0.35"
+```
+
+Using the `manifold3d` facade instead:
+
+```diff
+-manifold3d = { version = "0.3", features = ["nalgebra"] }
+-nalgebra = "0.34"
++manifold3d = { version = "0.4", features = ["nalgebra"] }
++nalgebra = "0.35"
+```
+
+## Code changes
+
+None on this crate's side. Any changes you need are nalgebra's own 0.34 to
+0.35 changes; see [nalgebra's
+changelog](https://github.com/dimforge/nalgebra/blob/main/CHANGELOG.md).
+
+## Rust version
+
+nalgebra 0.35 requires Rust 1.89, up from 0.34's 1.87. This crate's own
+`rust-version` stays `1.85`, which remains the floor when the `nalgebra`
+feature is off.
+
+## Checking
+
+If two nalgebra versions are still resolving, this shows it:
+
+```sh
+cargo tree -d | grep -A2 nalgebra
+```
+
+## AI prompt
+
+If you would rather hand this to an assistant, the following is enough context:
+
+> I am upgrading the Rust crate `manifold-csg` from 0.3.4 to 0.4.0 (or the
+> `manifold3d` facade, same versions). The only change is that its optional
+> `nalgebra` feature now requires nalgebra 0.35 instead of 0.34. Please update
+> my `Cargo.toml` so `manifold-csg` (or `manifold3d`) is `"0.4"` and my own
+> `nalgebra` dependency is `"0.35"`, then fix any compile errors that come from
+> nalgebra's own 0.34-to-0.35 changes. No manifold-csg API changed, so any
+> error mentioning two seemingly identical `Vector3<f64>` or `Point3<f64>`
+> types means a stale nalgebra version is still resolving somewhere; check with
+> `cargo tree -d`.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Notes:
   - [from 0.0.6](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_FROM_0.0.6.md) — original `manifold3d` crate line (pre-transfer to this project).
   - [0.1.8 → 0.2.0](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_0.1.8_TO_0.2.0.md) — `ExecutionContext` attachment API reshape.
   - [0.2.0 → 0.3.0](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_0.2.0_TO_0.3.0.md) — more idiomatic `Result` status/mesh APIs and upstream-aligned defaults.
+  - [0.3.4 → 0.4.0](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_0.3.4_TO_0.4.0.md) — optional `nalgebra` dependency moves to 0.35; no API change.
 
   These guides live at the repo root, so they are not part of the published crate tarball; the links above resolve on GitHub. A condensed [CHANGELOG.md](https://github.com/zmerlynn/manifold-csg/blob/main/crates/manifold-csg/CHANGELOG.md) ships inside the crate and flags behavioral (non-compile-breaking) changes.
 

--- a/crates/manifold-csg/CHANGELOG.md
+++ b/crates/manifold-csg/CHANGELOG.md
@@ -7,6 +7,22 @@ migration guides live at the repo root and are linked below.
 Watch especially for **behavioral** changes marked below: these compile cleanly
 but change output, so the compiler will not catch them for you.
 
+## 0.4.0
+
+Full guide: <https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_0.3.4_TO_0.4.0.md>
+
+- **Dependency (compile-breaking, only with the `nalgebra` feature):** the
+  optional `nalgebra` dependency moved from `0.34` to `0.35`. Nothing in this
+  crate's API changed, but `nalgebra::Vector3<f64>` and `Point3<f64>` appear in
+  the `Manifold::*_nalgebra` signatures, so the version has to agree with
+  yours. If your project is still on nalgebra 0.34, cargo resolves two copies
+  and your vectors become a different type from the ones these methods take.
+  The fix is to move your own dependency to `0.35`.
+- Enabling the `nalgebra` feature now requires Rust 1.89 (nalgebra 0.35's
+  floor, up from 0.34's 1.87). The crate's own `rust-version` stays `1.85`,
+  which is still the floor without that feature.
+- No change to the manifold3d pin, so `manifold-csg-sys` stays at 3.5.104.
+
 ## 0.3.4
 
 - Ships `LICENSE-APACHE` and `LICENSE-MIT` inside the crate. They lived only at

--- a/crates/manifold-csg/CHANGELOG.md
+++ b/crates/manifold-csg/CHANGELOG.md
@@ -9,19 +9,31 @@ but change output, so the compiler will not catch them for you.
 
 ## 0.4.0
 
+**If you do not enable the `nalgebra` feature, this release changes nothing
+for you.** No API changed, no behavior changed, and the manifold3d pin is the
+same as 0.3.4. It is a minor bump only because of the dependency change below.
+`nalgebra` is not a default feature, so unless you opted into it, upgrading is
+a version-number change and nothing else.
+
 Full guide: <https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_0.3.4_TO_0.4.0.md>
 
-- **Dependency (compile-breaking, only with the `nalgebra` feature):** the
-  optional `nalgebra` dependency moved from `0.34` to `0.35`. Nothing in this
-  crate's API changed, but `nalgebra::Vector3<f64>` and `Point3<f64>` appear in
-  the `Manifold::*_nalgebra` signatures, so the version has to agree with
-  yours. If your project is still on nalgebra 0.34, cargo resolves two copies
-  and your vectors become a different type from the ones these methods take.
-  The fix is to move your own dependency to `0.35`.
-- Enabling the `nalgebra` feature now requires Rust 1.89 (nalgebra 0.35's
-  floor, up from 0.34's 1.87). The crate's own `rust-version` stays `1.85`,
-  which is still the floor without that feature.
-- No change to the manifold3d pin, so `manifold-csg-sys` stays at 3.5.104.
+For users of the `nalgebra` feature:
+
+- **Dependency (compile-breaking):** the optional `nalgebra` dependency moved
+  from `0.34` to `0.35`, and your own `nalgebra` has to move with it.
+  `nalgebra::Vector3<f64>` and `Point3<f64>` appear in the
+  `Manifold::*_nalgebra` signatures, so cargo has to resolve one shared copy.
+  Stay on 0.34 and you get two, whereupon your vectors are a different type
+  from the ones these methods take. The error says so directly ("there are
+  multiple different versions of crate `nalgebra` in the dependency graph"),
+  so it should not cost you any debugging. The fix is `nalgebra = "0.35"` in
+  your own manifest.
+- Enabling the feature now requires Rust 1.89 (nalgebra 0.35's floor, up from
+  0.34's 1.87). The crate's own `rust-version` stays `1.85`, which remains the
+  floor without the feature.
+
+Unchanged for everyone: the manifold3d pin, so `manifold-csg-sys` stays at
+3.5.104.
 
 ## 0.3.4
 

--- a/crates/manifold-csg/Cargo.toml
+++ b/crates/manifold-csg/Cargo.toml
@@ -23,11 +23,11 @@ unstable-wasm-uu = ["manifold-csg-sys/unstable-wasm-uu"]
 manifold-csg-sys = { path = "../manifold-csg-sys", version = "3.5.104", default-features = false }
 thiserror = "2"
 log = "0.4"
-nalgebra = { version = "0.34", optional = true }
+nalgebra = { version = "0.35", optional = true }
 
 [dev-dependencies]
 approx = "0.5"
-nalgebra = "0.34"
+nalgebra = "0.35"
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]

--- a/crates/manifold3d/Cargo.toml
+++ b/crates/manifold3d/Cargo.toml
@@ -17,7 +17,7 @@ nalgebra = ["manifold-csg/nalgebra"]
 unstable-wasm-uu = ["manifold-csg/unstable-wasm-uu"]
 
 [dependencies]
-manifold-csg = { path = "../manifold-csg", version = "=0.3.4", default-features = false }
+manifold-csg = { path = "../manifold-csg", version = "=0.4.0", default-features = false }
 
 [package.metadata.docs.rs]
 features = ["nalgebra", "parallel"]


### PR DESCRIPTION
nalgebra 0.35.0 shipped 2026-05-24, and our `"0.34"` requirement excluded it: `^0.34` means `<0.35` for a 0.x crate.

## Why this is not a routine bump

nalgebra is in the public API. `Vector3<f64>` and `Point3<f64>` appear in the `Manifold::*_nalgebra` signatures:

```rust
pub fn trim_by_plane_nalgebra(&self, normal: &nalgebra::Vector3<f64>, offset: f64) -> Self
pub fn mirror_nalgebra(&self, normal: &nalgebra::Vector3<f64>) -> Self
pub fn bounding_box_nalgebra(&self) -> Option<(nalgebra::Point3<f64>, nalgebra::Point3<f64>)>
pub fn to_vertices_and_faces(&self) -> (Vec<nalgebra::Point3<f64>>, Vec<[u32; 3]>)
```

A consumer already on nalgebra 0.35 was resolving two copies of it, and their vectors were a *different type* from the ones these methods take. The feature quietly stopped being usable for them, with a "mismatched types" error naming two apparently identical types and nothing pointing at the cause.

Internal dependencies (`thiserror`, `log`, `cmake`) are deliberately not touched here. They are invisible to consumers, so they do not warrant a release on their own.

## Minor bump, not patch

Nothing in this crate's API changed, and `cargo-semver-checks` will not flag it. But a consumer pinned to nalgebra 0.34 cannot take this release without moving too, which is a compatibility break in the sense that matters to them. Pre-1.0, a minor bump is how that gets expressed.

Ships with [`MIGRATION_0.3.4_TO_0.4.0.md`](https://github.com/zmerlynn/manifold-csg/blob/main/MIGRATION_0.3.4_TO_0.4.0.md) per the convention in CLAUDE.md, linked from the README. The migration is short: bump your own nalgebra to 0.35.

The sys crates are untouched. No upstream manifold change here, so `manifold-csg-sys` stays at 3.5.104.

## Rust version

nalgebra 0.35 requires Rust 1.89, up from 0.34's 1.87. `rust-version` stays `1.85`, which is still the floor for the crate itself; enabling the optional feature inherits nalgebra's floor. Updated the MSRV lane's comment, since that is what explains why the lane builds without running tests.

## Test plan

- `cargo test --features nalgebra` -> 249 + 5 pass. `cargo tree` confirms nalgebra 0.35.0 is what resolves.
- `cargo clippy --all-targets --features nalgebra -- -D warnings` and `cargo fmt --all --check` clean.
- `cargo +1.85 build` still succeeds, confirming the declared MSRV holds with the feature off.
- Watch the Semver lane: it should pass, which is the point worth confirming rather than assuming, since the break here is one it cannot see.
